### PR TITLE
DW-175 Support snapshot in CloudFormation

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -123,7 +123,7 @@ groups are used by EMR and will be automatically updated when clusters are runni
 #### Access from our office IP addresses
 
 * Name prefix: `dw-sg-office`
-* Access using SSH from our offices
+* Access using SSH from whitelisted IP address ranges
 
 #### Access to data warehouse
 
@@ -137,6 +137,7 @@ This references all the prior security groups
     * Security group for "lambda (Tallboy)"
     * Security group for EC2 instances
     * IP addresses from our office
+    * IP addresses from other applications
     
 ### Roles and instance profiles (for EMR)
 
@@ -163,6 +164,8 @@ Uses all defaults except:
 
 # Installation
 
+The commands below assume that your role has the necessary privileges for CloudFormation.
+
 ## Creating the VPC using CloudFormation
 
 ### Creating the stack
@@ -173,7 +176,7 @@ cloudformation/create_dw_vpc.sh dev your-object-store-dev
 
 If you want to specify a specific IP address:
 ```bash
-cloudformation/create_dw_vpc.sh dev your-object-store-dev ParameterKey=OfficeCIDR,ParameterValue=192.168.1.1/32
+cloudformation/create_dw_vpc.sh dev your-object-store-dev ParameterKey=WhitelistCIDR1,ParameterValue=192.168.1.1/32
 ```
 
 ### Updating the stack

--- a/cloudformation/cluster.yaml
+++ b/cloudformation/cluster.yaml
@@ -31,6 +31,25 @@ Parameters:
             - ds2.xlarge
             - ds2.8xlarge
 
+    NumberOfNodes:
+        Description: The number of compute nodes in the cluster
+        Type: Number
+        Default: 2
+
+    SnapshotIdentifier:
+        Description: The identifier of an existing snapshot (leave empty to skip)
+        Type: String
+        Default: ""
+
+
+Conditions:
+
+    IsSingleNodeCluster:
+        !Equals [ !Ref "NumberOfNodes", 1 ]
+
+    HasSnapshotIdentifier:
+        !Not [ !Equals [ !Ref "SnapshotIdentifier", "" ] ]
+
 
 Resources:
 
@@ -66,8 +85,6 @@ Resources:
                 !Ref RedshiftClusterParameterGroup
             ClusterSubnetGroupName:
                 !Ref RedshiftClusterSubnetGroup
-            ClusterType:
-                "multi-node"
             DBName:
                 "dev"
             ElasticIp:
@@ -82,12 +99,17 @@ Resources:
                 !Ref MasterUserPassword
             NodeType:
                 !Ref NodeType
+            ClusterType:
+                !If [ "IsSingleNodeCluster", "single-node", "multi-node" ]
             NumberOfNodes:
-                2
+                !If [ "IsSingleNodeCluster", !Ref "AWS::NoValue", !Ref NumberOfNodes ]
             PubliclyAccessible:
                 true
             VpcSecurityGroupIds:
                 - Fn::ImportValue: !Sub "${VpcStackName}::redshift-public-sg"
+            SnapshotIdentifier:
+                !If [ "HasSnapshotIdentifier", !Ref "SnapshotIdentifier", !Ref "AWS::NoValue" ]
+
     # Note that an option to set enhanced VPC routing is missing in cloudformation, so this must be done using the CLI
     # aws redshift modify-cluster --cluster-identifier dw-cluster-dev-redshiftcluster-[your ident] --enhanced-vpc-routing
 

--- a/cloudformation/vpc.yaml
+++ b/cloudformation/vpc.yaml
@@ -52,7 +52,7 @@ Parameters:
         AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
         ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
 
-    OfficeCIDR1:
+    WhitelistCIDR1:
         Description: Please enter the first IP address range that can be used to SSH to EC2 instances
         Type: String
         Default: 0.0.0.0/0
@@ -61,8 +61,26 @@ Parameters:
         AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
         ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
 
-    OfficeCIDR2:
+    WhitelistCIDR2:
         Description: Please enter the second IP address range that can be used to SSH to EC2 instances
+        Type: String
+        Default: 0.0.0.0/0
+        MinLength: 9
+        MaxLength: 18
+        AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
+        ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
+
+    WhitelistCIDR3:
+        Description: Please enter the third IP address range that can be used to SSH to EC2 instances
+        Type: String
+        Default: 0.0.0.0/0
+        MinLength: 9
+        MaxLength: 18
+        AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
+        ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
+
+    WhitelistCIDR4:
+        Description: Please enter the fourth IP address range that can be used to SSH to EC2 instances
         Type: String
         Default: 0.0.0.0/0
         MinLength: 9
@@ -73,11 +91,17 @@ Parameters:
 
 Conditions:
 
-    ValidNotAnythingOfficeCIDR1:
-        !Not [ !Equals [ !Ref OfficeCIDR1, "0.0.0.0/0" ] ]
+    ValidNotAnythingWhitelistCIDR1:
+        !Not [ !Equals [ !Ref WhitelistCIDR1, "0.0.0.0/0" ] ]
 
-    ValidNotAnythingOfficeCIDR2:
-        !Not [ !Equals [ !Ref OfficeCIDR2, "0.0.0.0/0" ] ]
+    ValidNotAnythingWhitelistCIDR2:
+        !Not [ !Equals [ !Ref WhitelistCIDR2, "0.0.0.0/0" ] ]
+
+    ValidNotAnythingWhitelistCIDR3:
+        !Not [ !Equals [ !Ref WhitelistCIDR3, "0.0.0.0/0" ] ]
+
+    ValidNotAnythingWhitelistCIDR4:
+        !Not [ !Equals [ !Ref WhitelistCIDR4, "0.0.0.0/0" ] ]
 
 
 Resources:
@@ -230,20 +254,28 @@ Resources:
               - !Ref PrivateRouteTable
             ServiceName: !Join [ ".", [ "com.amazonaws", !Ref "AWS::Region", "s3" ] ]
 
-    OfficeAccessSecurityGroup:
+    WhitelistAccessSecurityGroup:
         Type: "AWS::EC2::SecurityGroup"
         Properties:
-            GroupDescription: Enable SSH access via port 22 from an office IP (but never the whole internet)
+            GroupDescription: Enable SSH access via port 22 from an office IP or known applications
             VpcId: !Ref VPC
             SecurityGroupIngress:
                 - IpProtocol: "tcp"
                   FromPort: "22"
                   ToPort: "22"
-                  CidrIp: !If [ ValidNotAnythingOfficeCIDR1, !Ref "OfficeCIDR1", !Ref "AWS::NoValue" ]
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR1, !Ref "WhitelistCIDR1", !Ref "AWS::NoValue" ]
                 - IpProtocol: "tcp"
                   FromPort: "22"
                   ToPort: "22"
-                  CidrIp: !If [ ValidNotAnythingOfficeCIDR2, !Ref "OfficeCIDR2", !Ref "AWS::NoValue" ]
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR2, !Ref "WhitelistCIDR2", !Ref "AWS::NoValue" ]
+                - IpProtocol: "tcp"
+                  FromPort: "22"
+                  ToPort: "22"
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR3, !Ref "WhitelistCIDR3", !Ref "AWS::NoValue" ]
+                - IpProtocol: "tcp"
+                  FromPort: "22"
+                  ToPort: "22"
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR4, !Ref "WhitelistCIDR4", !Ref "AWS::NoValue" ]
             Tags:
                 - Key: Name
                   Value: !Join [ "-", [ !Ref "AWS::StackName", "office" ] ]
@@ -434,11 +466,19 @@ Resources:
                 - IpProtocol: "tcp"
                   FromPort: "5439"
                   ToPort: "5439"
-                  CidrIp: !If [ ValidNotAnythingOfficeCIDR1, !Ref "OfficeCIDR1", !Ref "AWS::NoValue" ]
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR1, !Ref "WhitelistCIDR1", !Ref "AWS::NoValue" ]
                 - IpProtocol: "tcp"
                   FromPort: "5439"
                   ToPort: "5439"
-                  CidrIp: !If [ ValidNotAnythingOfficeCIDR2, !Ref "OfficeCIDR2", !Ref "AWS::NoValue" ]
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR2, !Ref "WhitelistCIDR2", !Ref "AWS::NoValue" ]
+                - IpProtocol: "tcp"
+                  FromPort: "5439"
+                  ToPort: "5439"
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR3, !Ref "WhitelistCIDR3", !Ref "AWS::NoValue" ]
+                - IpProtocol: "tcp"
+                  FromPort: "5439"
+                  ToPort: "5439"
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR4, !Ref "WhitelistCIDR4", !Ref "AWS::NoValue" ]
                 # Heap
                 - IpProtocol: "tcp"
                   FromPort: "5439"
@@ -675,7 +715,7 @@ Outputs:
 
     AdditionalSecurityGroups:
         Description: A list of addtional security groups for EMR setup
-        Value: !Join [ ",", [ !Ref OfficeAccessSecurityGroup, !Ref RedshiftEC2SecurityGroup ] ]
+        Value: !Join [ ",", [ !Ref WhitelistAccessSecurityGroup, !Ref RedshiftEC2SecurityGroup ] ]
         Export:
             Name: !Sub "${AWS::StackName}::additional-sg"
 


### PR DESCRIPTION
User visible changes
* Increase number of IP ranges that can be specified to be whitelisted in the VPC
* Allow to pass in the identifier of a snapshot when starting a cluster (so that we can start from a backup)