### PR TITLE
Release candidate for v1.1.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,193 @@
+This file describes the steps necessary to run ETLs using this codebase.
+
+# Getting ready to run ETLs
+
+What all you need in order to use this ETL tool depends on where you'd like run it and whether you anticipate
+making changes to the ETL code.
+
+## Pre-requisites for "end users"
+
+Let's go through your setup steps in order to run the CLI, `arthur.py`, assuming that you will not work on the code base.
+
+### Clone this project
+
+Should be obvious ... but you need to `git clone` this repo using the handy link in Github.
+
+### AWS CLI
+
+We are using some shell scripts that use the AWS CLI and so this must be installed. We strongly suggest
+that you use a packaging tool, like [Homebrew](https://brew.sh/) on macOS.
+```shell
+brew install awscli
+aws --version
+# Should be better than 1.10
+```
+
+In order to interact with the S3 bucket with ETL data, a.k.a. your object store, you will need
+to set up AWS credentials.
+```shell
+aws configure
+```
+* If you have to work with multiple access keys, check out the support of profiles in the CLI.
+* It is important to setup a **default region** since the start scripts do not specify one.
+* Leave the `output` alone or set it to `json`.
+* To test, try to list the contents of your company's object store:
+```shell
+aws s3 ls 's3://<your s3 bucket>'
+```
+
+### Other commands
+
+We also use a tool called [jq](https://stedolan.github.io/jq/manual/v1.5/) to help parse responses
+from AWS CLI commands.
+```shell
+brew install jq
+```
+
+### Python and virtual environment
+
+Our ETL code is using [Python3](https://docs.python.org/3/) so you may have to install that first.
+On a Mac, simply use [Homebrew](http://brew.sh/) for an easy installation.
+We strongly suggest that you always work within a virtual environment.
+```shell
+brew install python3
+# Using the newly installed pip3
+pip3 install virtualenv
+```
+
+For new versions of pip, make sure to run this **outside** the virtual environment:
+```
+pip3 install pip --upgrade --disable-pip-version-check
+```
+
+To run code locally, you'll need to create a virtual environment with additional packages.
+These packages are listed (with their expected versions) in the `requirements.txt` file.
+The most prominent packages are:
+* [Psycopg2](http://initd.org/psycopg/docs/) to connect to PostgreSQL and Redshift easily
+* [boto3](https://boto3.readthedocs.org/en/latest/) to interact with AWS
+* [PyYAML](http://pyyaml.org/wiki/PyYAML) for configuration files
+* [simplejson](https://pypi.python.org/pypi/simplejson/) for dealing with YAML files that are really just JSON
+* [jsonschema](https://github.com/Julian/jsonschema) for validating configurations and table design files
+* [mypy](http://mypy-lang.org/) for static type checking
+
+For running the ETL remotely in EC2, the `bin/bootstrap.sh` script will take care of the creation
+of the virtual environment.
+
+#### Using vanilla virtualenv
+
+**Note** this assumes you are in the **top-level** directory of the Redshift ETL.
+
+```shell
+mkdir venv
+virtualenv --python=python3 venv
+source venv/bin/activate
+pip3 install --requirement ./requirements.txt --disable-pip-version-check
+python3 setup.py develop
+```
+
+_Hint_: Don't worry if you get assertion violations while building a wheel for PyYAML.
+
+#### Using virtualenv wrapper
+
+Feel free to use [`virtualenv-wrapper`](https://virtualenvwrapper.readthedocs.io/en/latest/) to make
+your life switching in and out of virtual environments easier.
+
+Assuming you already have setup your environment to take advantage of the virtualenv wrapper tool
+by
+* setting the environment variable `WORKON_HOME`
+* setting the environment variable `VIRTUALENVWRAPPER_PYTHON` to `/usr/local/bin/python3`
+* making sure that `/usr/local/bin/virtualenvwrapper.sh` is _source_d in your shell profile.
+
+**Creating virtual env if you don't plan on changing the ETL code**
+
+First, change into the directory where your data warehouse setup will live, then:
+```shell
+mkvirtualenv --python=python3 -a `pwd` dw
+```
+The option `-a` will send you into this directory everytime you run:
+```
+workon dw
+```
+
+**Creating virtual env as an ETL developer**
+
+Use the same name for the virtual env that is the name of the repo:
+```shell
+mkvirtualenv --python=python3 arthur-redshift-etl
+```
+This will make it easier later when you're in the directory to say:
+```
+workon .
+```
+
+**Updating the environment (under either scenario)**
+```
+pip3 install --requirement ./requirements.txt
+python3 setup.py develop
+
+# Make sure to check the path below
+echo "source `\cd ../arthur-redshift-etl/etc && \pwd`/arthur_completion.sh" >> $VIRTUAL_ENV/bin/postactivate
+```
+
+Jumping ahead bit, if you want to use a default environment other than your login name, use something like this:
+```
+echo "export ARTHUR_DEFAULT_PREFIX=experimental" >> $VIRTUAL_ENV/bin/postactivate
+```
+
+(This is different from something you will set for the `AWS_PROFILE`.)
+
+## Additional pre-requisites for developers
+
+Ok, so even if you want to work on the ETL code, you should *first* follow the steps above to get to a running setup.
+This section describes what *else* you should do when you want to develop here.
+
+### Spark
+
+Install Spark if you'd like to be able to test jobs on your local machine.
+On a Mac, simply use `brew install apache-spark`.
+
+Our ETL code base includes everything to run the ETL in a Spark cluster on AWS
+using [Amazon EMR](https://aws.amazon.com/elasticmapreduce/) so that local testing may be less important to you.
+Running it locally offers shorter development cycles while running it in AWS means less network activity (going in
+and out of your VPC).
+
+### JAR files
+
+Download the JAR files for the following software before deployment into an AWS Spark Cluster in order
+to be able to connect to PostgreSQL databases and write CSV files for a Dataframe:
+
+| Software | Version | JAR file  |
+|---|---|---|
+| [PostgreSQL JDBC](https://jdbc.postgresql.org/) driver | 9.4 | [postgresql-9.4.1208.jar](https://jdbc.postgresql.org/download/postgresql-9.4.1208.jar) |
+| [Redshift JDBC](http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html#download-jdbc-driver) | 1.2.1 | [RedshiftJDBC41-1.2.1.1001.jar](https://s3.amazonaws.com/redshift-downloads/drivers/RedshiftJDBC41-1.2.1.1001.jar) |
+
+Additionally, you'll need the following JAR files when running Spark jobs **locally** and want to push files into S3:
+
+| Software (local) | Version | JAR file  |
+|---|---|---|
+| [Hadoop AWS](https://hadoop.apache.org/docs/r2.7.1/api/org/apache/hadoop/fs/s3native/NativeS3FileSystem.html) | 2.7.1 | [hadoop-aws-2.7.1.jar](http://central.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.1/hadoop-aws-2.7.1.jar) |
+| [AWS Java SDK](https://aws.amazon.com/sdk-for-java/) | 1.7.4 | [aws-java-sdk-1.7.4.2.jar](http://central.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4.2/aws-java-sdk-1.7.4.2.jar) |
+
+Do not upload these last two into EMR because EMR comes with all the correct versions out of the box.
+
+The JAR files should be stored into the `jars` directory locally and in the `jars` folder of your selected
+environment (see below).  A bootstrap action will copy them from S3 to the EMR cluster.
+
+_Hint_: There is a download script in `bin/download_jars.sh` to pull the versions with which the ETL was tested.
+
+The EMR releases 4.5 and later include python3 so there's no need to install Python 3 using a bootstrap action.
+
+#### Adding PySpark to your IDE
+
+The easiest way to add PySpark so that code completion and type checking works while working on ETL code
+might be to just add a pointer in the virtual environment.
+
+First, activate your Python virtual environment so that the `VIRTUAL_ENV` environment variable is set.
+
+Then, with Spark 2.1.1, try this for example:
+```shell
+cat > $VIRTUAL_ENV/lib/python3.5/site-packages/_spark_python.pth <<EOF
+/usr/local/Cellar/apache-spark/2.1.1/libexec/python
+/usr/local/Cellar/apache-spark/2.1.1/libexec/python/lib/py4j-0.10.4-src.zip
+EOF
+```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
  /_/    \_\_|   \__|_| |_|\__,_|_|    |_|  \_\___|\__,_|___/_| |_|_|_|  \__| |______|  |_|  |______|
 ```
 
+Arthur is an ETL tool for managing a data warehouse in the AWS ecosystem. Arthur is designed to manage a warehouse in full-rebuild mode where the entire warehouse is rebuilt, from scratch, every night. Arthur is *not* designed to support streaming or micro-batch ETL. Arthur is best suited for organizations whose data are managed in a stateful transactional database and have lots of complicated business logic for their data transformations that they want to be able to manage effectively.
+
+If you’re interested in this approach or are in a similar situation, then we’d like to talk to you.  Please reach out and let’s have a data & analytics meetup.
+
 This README outlines how to get started with the ETL.
 This includes information about setting up _Arthur_ which is the driver for ETL activities.
 
@@ -16,196 +20,12 @@ You are probably (also) looking for the [Wiki](https://github.com/harrystech/art
 which include a lot more information about the ETL and what it does (and why it does what it does).
 And if something appears amiss, check out the [issues page](https://github.com/harrystech/arthur-redshift-etl/issues).
 
-# Getting ready to run ETLs
+# Installing the code
 
-What all you need in order to use this ETL tool depends on where you'd like run it and whether you anticipate
-making changes to the ETL code.
+See the separate [INSTALL.md](./INSTALL.md) file.
 
-## Pre-requisites for "end users"
 
-Let's go through your setup steps in order to run the CLI, `arthur.py`, assuming that you will not work on the code base.
-
-### Clone this project
-
-Should be obvious ... but you need to `git clone` this repo using the handy link in Github.
-
-### AWS CLI
-
-We are using some shell scripts that use the AWS CLI and so this must be installed. We strongly suggest
-that you use a packaging tool, like [Homebrew](https://brew.sh/) on macOS.
-```shell
-brew install awscli
-aws --version
-# Should be better than 1.10
-```
-
-In order to interact with the S3 bucket with ETL data, a.k.a. your data lake, you will need
-to set up credentials.
-```shell
-aws configure
-```
-* If you have to work with multiple access keys, check out the support of profiles in the CLI.
-* It is important to setup a **default region** since the start scripts do not specify one.
-* To test, try to list the contents of your company's data lake:
-```shell
-aws s3 ls 's3://<your s3 bucket>'
-```
-
-### Other commands
-
-We also use a tool called [jq](https://stedolan.github.io/jq/manual/v1.5/) to help parse responses
-from AWS CLI commands.
-```shell
-brew install jq
-```
-
-### Python and virtual environment
-
-Our ETL code is using [Python3](https://docs.python.org/3/) so you may have to install that first.
-On a Mac, simply use [Homebrew](http://brew.sh/) for an easy installation.
-We strongly suggest that you always work within a virtual environment.
-```shell
-brew install python3
-# Using the newly installed pip3
-pip3 install virtualenv
-```
-
-For new versions of pip, make sure to run this **outside** the virtual environment:
-```
-pip3 install pip --upgrade --disable-pip-version-check
-```
-
-To run code locally, you'll need to create a virtual environment with additional packages.
-These packages are listed (with their expected versions) in the `requirements.txt` file.
-The most prominent packages are:
-* [Psycopg2](http://initd.org/psycopg/docs/) to connect to PostgreSQL and Redshift easily
-* [boto3](https://boto3.readthedocs.org/en/latest/) to interact with AWS
-* [PyYAML](http://pyyaml.org/wiki/PyYAML) for configuration files
-* [simplejson](https://pypi.python.org/pypi/simplejson/) for dealing with YAML files that are really just JSON
-* [jsonschema](https://github.com/Julian/jsonschema) for validating configurations and table design files
-* [mypy](http://mypy-lang.org/) for static type checking
-
-For running the ETL remotely in EC2, the `bin/bootstrap.sh` script will take care of the creation
-of the virtual environment.
-
-#### Using vanilla virtualenv
-
-**Note** this assumes you are in the **top-level** directory of the Redshift ETL.
-
-```shell
-mkdir venv
-virtualenv --python=python3 venv
-source venv/bin/activate
-pip3 install --requirement ./requirements.txt --disable-pip-version-check
-python3 setup.py develop
-```
-
-_Hint_: Don't worry if you get assertion violations while building a wheel for PyYAML.
-
-#### Using virtualenv wrapper
-
-Feel free to use [`virtualenv-wrapper`](https://virtualenvwrapper.readthedocs.io/en/latest/) to make
-your life switching in and out of virtual environments easier.
-
-Assuming you already have setup your environment to take advantage of the virtualenv wrapper tool
-by
-* setting the environment variable `WORKON_HOME`
-* setting the environment variable `VIRTUALENVWRAPPER_PYTHON` to `/usr/local/bin/python3`
-* making sure that `/usr/local/bin/virtualenvwrapper.sh` is _source_d in your shell profile.
-
-**Creating virtual env if you don't plan on changing the ETL code**
-
-First, change into the directory where your data warehouse setup will live, then:
-```shell
-mkvirtualenv --python=python3 -a `pwd` dw
-```
-The option `-a` will send you into this directory everytime you run:
-```
-workon dw
-```
-
-**Creating virtual env as an ETL developer**
-
-Use the same name for the virtual env that is the name of the repo:
-```shell
-mkvirtualenv --python=python3 arthur-redshift-etl
-```
-This will make it easier later when you're in the directory to say:
-```
-workon .
-```
-
-**Updating the environment (under either scenario)**
-```
-pip3 install --requirement ./requirements.txt
-python3 setup.py develop
-
-# Make sure to check the path below
-echo "source `\cd ../arthur-redshift-etl/etc && \pwd`/arthur_completion.sh" >> $VIRTUAL_ENV/bin/postactivate
-```
-
-Jumping ahead bit, if you want to use a default environment other than your login name, use something like this:
-```
-echo "export ARTHUR_DEFAULT_PREFIX=experimental" >> $VIRTUAL_ENV/bin/postactivate
-```
-
-## Additional pre-requisites for developers
-
-Ok, so even if you want to work on the ETL code, you should *first* follow the steps above to get to a running setup.
-This section describes what *else* you should do when you want to develop here.
-
-### Spark
-
-Install Spark if you'd like to be able to test jobs on your local machine.
-On a Mac, simply use `brew install apache-spark`.
-
-Our ETL code base includes everything to run the ETL in a Spark cluster on AWS
-using [Amazon EMR](https://aws.amazon.com/elasticmapreduce/) so that local testing may be less important to you.
-Running it locally offers shorter development cycles while running it in AWS means less network activity (going in
-and out of your VPC).
-
-### JAR files
-
-Download the JAR files for the following software before deployment into an AWS Spark Cluster in order
-to be able to connect to PostgreSQL databases and write CSV files for a Dataframe:
-
-| Software | Version | JAR file  |
-|---|---|---|
-| [PostgreSQL JDBC](https://jdbc.postgresql.org/) driver | 9.4 | [postgresql-9.4.1208.jar](https://jdbc.postgresql.org/download/postgresql-9.4.1208.jar) |
-| [Redshift JDBC](http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html#download-jdbc-driver) | 1.2.1 | [RedshiftJDBC41-1.2.1.1001.jar](https://s3.amazonaws.com/redshift-downloads/drivers/RedshiftJDBC41-1.2.1.1001.jar) |
-
-Additionally, you'll need the following JAR files when running Spark jobs **locally** and want to push files into S3:
-
-| Software (local) | Version | JAR file  |
-|---|---|---|
-| [Hadoop AWS](https://hadoop.apache.org/docs/r2.7.1/api/org/apache/hadoop/fs/s3native/NativeS3FileSystem.html) | 2.7.1 | [hadoop-aws-2.7.1.jar](http://central.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.1/hadoop-aws-2.7.1.jar) |
-| [AWS Java SDK](https://aws.amazon.com/sdk-for-java/) | 1.7.4 | [aws-java-sdk-1.7.4.2.jar](http://central.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4.2/aws-java-sdk-1.7.4.2.jar) |
-
-Do not upload these last two into EMR because EMR comes with all the correct versions out of the box.
-
-The JAR files should be stored into the `jars` directory locally and in the `jars` folder of your selected
-environment (see below).  A bootstrap action will copy them from S3 to the EMR cluster.
-
-_Hint_: There is a download script in `bin/download_jars.sh` to pull the versions with which the ETL was tested.
-
-The EMR releases 4.5 and later include python3 so there's no need to install Python 3 using a bootstrap action.
-
-#### Adding PySpark to your IDE
-
-The easiest way to add PySpark so that code completion and type checking works while working on ETL code
-might be to just add a pointer in the virtual environment.
-
-First, activate your Python virtual environment so that the `VIRTUAL_ENV` environment variable is set.
-
-Then, with Spark 2.1.1, try this for example:
-```shell
-cat > $VIRTUAL_ENV/lib/python3.5/site-packages/_spark_python.pth <<EOF
-/usr/local/Cellar/apache-spark/2.1.1/libexec/python
-/usr/local/Cellar/apache-spark/2.1.1/libexec/python/lib/py4j-0.10.4-src.zip
-EOF
-```
-
-## Configuring the ETL (and upstream sources)
+# Configuring the ETL (and upstream sources)
 
 The best approach is to have a separate repo for your data warehouse that contains the configuration files
 and all the table design files and transformations.  The documentation will in many places assume
@@ -213,7 +33,7 @@ that you have a "*sibling*" repo so that when within the repo for your local dat
 configuration, credentials, and table designs), you can simply use `../arthur-redshift-etl/` to find
 your way back to this ETL code.
 
-### Redshift cluster and users
+## Redshift cluster and users
 
 Although the Redshift cluster can be administered using the AWS console and `psql`, some
 helper scripts will make setting up the cluster consistently much easier.
@@ -224,14 +44,14 @@ to your settings file so that Redshift has the needed permissions to access the
 folder in S3.
 (And don't forget to add the role to the list of known IAM roles in Redshift.)
 
-### Sources
+## Sources
 
 See the [Wiki](https://github.com/harrystech/arthur-redshift-etl/wiki) pages about
 a description of configurations.
 
-## Running the ETL (`arthur.py`)
+# Running the ETL (`arthur.py`)
 
-### General notes about the CLI
+## General notes about the CLI
 
 * Commands expect a config file and will start by picking up all files in a local `./config` directory.
 * Commands accept `--dry-run` command line flag to test without modifying the environment.
@@ -244,9 +64,9 @@ a description of configurations.
 * You could copy data manually, but you probably shouldn't and let `arthur.py sync` manage files.
 * You can use environment variables to pass in credentials for database access, but you should probably use a file for that.
 
-### Prerequisites for running the ETL in a cluster
+## Prerequisites for running the ETL in a cluster
 
-#### Creating a credentials file
+### Creating a credentials file
 
 All credentials can be picked up from environment variables by the ETL. Instead of setting these
 variables before starting the ETL, you can also add a file with credentials to the `config` directory
@@ -265,7 +85,7 @@ to execute in Redshift.  Make sure this file exists in your data warehouse repo 
 DATA_WAREHOUSE_ETL=postgres://etl:<password>@<host>:<port>/<dbname>?sslmode=require
 ```
 
-#### Copying code into the S3 bucket
+### Copying code into the S3 bucket
 
 Copy the ETL code (including bootstrap scripts and configuration):
 ```shell
@@ -274,7 +94,7 @@ export DATA_WAREHOUSE_CONFIG="<path to directory with config files and credentia
 bin/upload_env.sh "<your S3 bucket>" $USER
 ```
 
-#### Starting a cluster and submitting commands
+### Starting a cluster and submitting commands
 
 Start a cluster:
 ```shell
@@ -292,7 +112,7 @@ Note that the `--submit` option must be between `arthur.py` and the sub-command 
 arthur.py --submit "<cluster ID>" load --prolix --prefix $USER
 ```
 
-### Initializing the Redshift cluster
+## Initializing the Redshift cluster
 
 | Sub-command   | Goal |
 | ---- | ---- |
@@ -305,7 +125,7 @@ arthur.py initialize  # NOP but errors out
 arthur.py initialize development --with-user-creation  # Must create users and groups on first call
 ```
 
-### Starting with design files (and managing them)
+## Starting with design files (and managing them)
 
 | Sub-command   | Goal |
 | ---- | ---- |
@@ -320,7 +140,7 @@ arthur.py sync "<schema>"  # This will upload local files related to one schema 
 arthur.py sync "<schema>.<table>"  # This will upload local files for just one table
 ```
 
-### Loading and updating data
+## Loading and updating data
 
 | Sub-command   | Goal |
 | ---- | ---- |
@@ -340,7 +160,7 @@ the load after fixing any query errors or input data, using:
 arthur.py upgrade --with-staging-schemas --continue-from failed_relation.in_load_step
 ```
 
-### Dealing with schemas (create, restore)
+## Dealing with schemas (create, restore)
 
 | Sub-command   | Goal |
 | ---- | ---- |
@@ -354,7 +174,7 @@ arthur.py create_schemas --with-staging schema_name
 arthur.py promote_schemas --from staging schema_name
 ```
 
-### Working with subsets of tables
+## Working with subsets of tables
 
 | Sub-command   | Goal |
 | ---- | ---- |
@@ -365,7 +185,7 @@ The patterns used by commands like `extract` or `load` may be provided using fil
 Together with `show_downstream_dependents` and `show_upstream_dependencies`, this opens up
 opportunities to work on a "sub-tree" of the data warehouse.
 
-#### Working with just the source schemas or transformation schemas
+### Working with just the source schemas or transformation schemas
 
 At the beginning it might be worthwhile to focus just on tables in source schemas -- those
 tables that get loaded using CSV files after `extract`.
@@ -387,7 +207,7 @@ arthur.py sync @transformations.txt
 arthur.py upgrade --only @transformations.txt
 ```
 
-#### Working with a table and everything feeding it
+### Working with a table and everything feeding it
 
 While working on transformations or constraints, it might be useful to focus on just a
 set of of tables that feed data into it.
@@ -400,7 +220,7 @@ arthur.py sync www.users
 arthur.py upgrade --only @www_users.txt
 ```
 
-### Using configuration values to fill in templates
+## Using configuration values to fill in templates
 
 AWS service templates can be filled out based on configuration in the ETL.
 
@@ -419,7 +239,7 @@ arthur.py show_value object_store.s3.bucket_name
 arthur.py show_vars object_store.s3.*
 ```
 
-## Working with a staging environment
+# Working with a staging environment
 
 A staging environment can help with deploying data that you'll be confident to release into production.
 

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -123,7 +123,7 @@ groups are used by EMR and will be automatically updated when clusters are runni
 #### Access from our office IP addresses
 
 * Name prefix: `dw-sg-office`
-* Access using SSH from our offices
+* Access using SSH from whitelisted IP address ranges
 
 #### Access to data warehouse
 
@@ -137,6 +137,7 @@ This references all the prior security groups
     * Security group for "lambda (Tallboy)"
     * Security group for EC2 instances
     * IP addresses from our office
+    * IP addresses from other applications
     
 ### Roles and instance profiles (for EMR)
 
@@ -163,6 +164,8 @@ Uses all defaults except:
 
 # Installation
 
+The commands below assume that your role has the necessary privileges for CloudFormation.
+
 ## Creating the VPC using CloudFormation
 
 ### Creating the stack
@@ -173,7 +176,7 @@ cloudformation/create_dw_vpc.sh dev your-object-store-dev
 
 If you want to specify a specific IP address:
 ```bash
-cloudformation/create_dw_vpc.sh dev your-object-store-dev ParameterKey=OfficeCIDR,ParameterValue=192.168.1.1/32
+cloudformation/create_dw_vpc.sh dev your-object-store-dev ParameterKey=WhitelistCIDR1,ParameterValue=192.168.1.1/32
 ```
 
 ### Updating the stack

--- a/cloudformation/cluster.yaml
+++ b/cloudformation/cluster.yaml
@@ -31,6 +31,25 @@ Parameters:
             - ds2.xlarge
             - ds2.8xlarge
 
+    NumberOfNodes:
+        Description: The number of compute nodes in the cluster
+        Type: Number
+        Default: 2
+
+    SnapshotIdentifier:
+        Description: The identifier of an existing snapshot (leave empty to skip)
+        Type: String
+        Default: ""
+
+
+Conditions:
+
+    IsSingleNodeCluster:
+        !Equals [ !Ref "NumberOfNodes", 1 ]
+
+    HasSnapshotIdentifier:
+        !Not [ !Equals [ !Ref "SnapshotIdentifier", "" ] ]
+
 
 Resources:
 
@@ -66,8 +85,6 @@ Resources:
                 !Ref RedshiftClusterParameterGroup
             ClusterSubnetGroupName:
                 !Ref RedshiftClusterSubnetGroup
-            ClusterType:
-                "multi-node"
             DBName:
                 "dev"
             ElasticIp:
@@ -82,12 +99,17 @@ Resources:
                 !Ref MasterUserPassword
             NodeType:
                 !Ref NodeType
+            ClusterType:
+                !If [ "IsSingleNodeCluster", "single-node", "multi-node" ]
             NumberOfNodes:
-                2
+                !If [ "IsSingleNodeCluster", !Ref "AWS::NoValue", !Ref NumberOfNodes ]
             PubliclyAccessible:
                 true
             VpcSecurityGroupIds:
                 - Fn::ImportValue: !Sub "${VpcStackName}::redshift-public-sg"
+            SnapshotIdentifier:
+                !If [ "HasSnapshotIdentifier", !Ref "SnapshotIdentifier", !Ref "AWS::NoValue" ]
+
     # Note that an option to set enhanced VPC routing is missing in cloudformation, so this must be done using the CLI
     # aws redshift modify-cluster --cluster-identifier dw-cluster-dev-redshiftcluster-[your ident] --enhanced-vpc-routing
 

--- a/cloudformation/vpc.yaml
+++ b/cloudformation/vpc.yaml
@@ -52,7 +52,7 @@ Parameters:
         AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
         ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
 
-    OfficeCIDR1:
+    WhitelistCIDR1:
         Description: Please enter the first IP address range that can be used to SSH to EC2 instances
         Type: String
         Default: 0.0.0.0/0
@@ -61,8 +61,26 @@ Parameters:
         AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
         ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
 
-    OfficeCIDR2:
+    WhitelistCIDR2:
         Description: Please enter the second IP address range that can be used to SSH to EC2 instances
+        Type: String
+        Default: 0.0.0.0/0
+        MinLength: 9
+        MaxLength: 18
+        AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
+        ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
+
+    WhitelistCIDR3:
+        Description: Please enter the third IP address range that can be used to SSH to EC2 instances
+        Type: String
+        Default: 0.0.0.0/0
+        MinLength: 9
+        MaxLength: 18
+        AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
+        ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
+
+    WhitelistCIDR4:
+        Description: Please enter the fourth IP address range that can be used to SSH to EC2 instances
         Type: String
         Default: 0.0.0.0/0
         MinLength: 9
@@ -73,11 +91,17 @@ Parameters:
 
 Conditions:
 
-    ValidNotAnythingOfficeCIDR1:
-        !Not [ !Equals [ !Ref OfficeCIDR1, "0.0.0.0/0" ] ]
+    ValidNotAnythingWhitelistCIDR1:
+        !Not [ !Equals [ !Ref WhitelistCIDR1, "0.0.0.0/0" ] ]
 
-    ValidNotAnythingOfficeCIDR2:
-        !Not [ !Equals [ !Ref OfficeCIDR2, "0.0.0.0/0" ] ]
+    ValidNotAnythingWhitelistCIDR2:
+        !Not [ !Equals [ !Ref WhitelistCIDR2, "0.0.0.0/0" ] ]
+
+    ValidNotAnythingWhitelistCIDR3:
+        !Not [ !Equals [ !Ref WhitelistCIDR3, "0.0.0.0/0" ] ]
+
+    ValidNotAnythingWhitelistCIDR4:
+        !Not [ !Equals [ !Ref WhitelistCIDR4, "0.0.0.0/0" ] ]
 
 
 Resources:
@@ -230,20 +254,28 @@ Resources:
               - !Ref PrivateRouteTable
             ServiceName: !Join [ ".", [ "com.amazonaws", !Ref "AWS::Region", "s3" ] ]
 
-    OfficeAccessSecurityGroup:
+    WhitelistAccessSecurityGroup:
         Type: "AWS::EC2::SecurityGroup"
         Properties:
-            GroupDescription: Enable SSH access via port 22 from an office IP (but never the whole internet)
+            GroupDescription: Enable SSH access via port 22 from an office IP or known applications
             VpcId: !Ref VPC
             SecurityGroupIngress:
                 - IpProtocol: "tcp"
                   FromPort: "22"
                   ToPort: "22"
-                  CidrIp: !If [ ValidNotAnythingOfficeCIDR1, !Ref "OfficeCIDR1", !Ref "AWS::NoValue" ]
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR1, !Ref "WhitelistCIDR1", !Ref "AWS::NoValue" ]
                 - IpProtocol: "tcp"
                   FromPort: "22"
                   ToPort: "22"
-                  CidrIp: !If [ ValidNotAnythingOfficeCIDR2, !Ref "OfficeCIDR2", !Ref "AWS::NoValue" ]
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR2, !Ref "WhitelistCIDR2", !Ref "AWS::NoValue" ]
+                - IpProtocol: "tcp"
+                  FromPort: "22"
+                  ToPort: "22"
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR3, !Ref "WhitelistCIDR3", !Ref "AWS::NoValue" ]
+                - IpProtocol: "tcp"
+                  FromPort: "22"
+                  ToPort: "22"
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR4, !Ref "WhitelistCIDR4", !Ref "AWS::NoValue" ]
             Tags:
                 - Key: Name
                   Value: !Join [ "-", [ !Ref "AWS::StackName", "office" ] ]
@@ -434,11 +466,19 @@ Resources:
                 - IpProtocol: "tcp"
                   FromPort: "5439"
                   ToPort: "5439"
-                  CidrIp: !If [ ValidNotAnythingOfficeCIDR1, !Ref "OfficeCIDR1", !Ref "AWS::NoValue" ]
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR1, !Ref "WhitelistCIDR1", !Ref "AWS::NoValue" ]
                 - IpProtocol: "tcp"
                   FromPort: "5439"
                   ToPort: "5439"
-                  CidrIp: !If [ ValidNotAnythingOfficeCIDR2, !Ref "OfficeCIDR2", !Ref "AWS::NoValue" ]
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR2, !Ref "WhitelistCIDR2", !Ref "AWS::NoValue" ]
+                - IpProtocol: "tcp"
+                  FromPort: "5439"
+                  ToPort: "5439"
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR3, !Ref "WhitelistCIDR3", !Ref "AWS::NoValue" ]
+                - IpProtocol: "tcp"
+                  FromPort: "5439"
+                  ToPort: "5439"
+                  CidrIp: !If [ ValidNotAnythingWhitelistCIDR4, !Ref "WhitelistCIDR4", !Ref "AWS::NoValue" ]
                 # Heap
                 - IpProtocol: "tcp"
                   FromPort: "5439"
@@ -675,7 +715,7 @@ Outputs:
 
     AdditionalSecurityGroups:
         Description: A list of addtional security groups for EMR setup
-        Value: !Join [ ",", [ !Ref OfficeAccessSecurityGroup, !Ref RedshiftEC2SecurityGroup ] ]
+        Value: !Join [ ",", [ !Ref WhitelistAccessSecurityGroup, !Ref RedshiftEC2SecurityGroup ] ]
         Export:
             Name: !Sub "${AWS::StackName}::additional-sg"
 

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -46,11 +46,9 @@ def get_dw_config():
     return _dw_config
 
 
-def get_config_value(name: str) -> Optional[str]:
-    if _mapped_config is None:
-        return None
-    else:
-        return _mapped_config.get(name)
+def get_config_value(name: str, default: Optional[str]=None) -> Optional[str]:
+    assert _mapped_config is not None, "attempted to get config value before reading config map"
+    return _mapped_config.get(name, default)
 
 
 def set_config_value(name: str, value: str) -> None:

--- a/python/etl/config/logging.json
+++ b/python/etl/config/logging.json
@@ -33,11 +33,11 @@
             "backupCount": 5,
             "filters": [ "insert_trace_key" ]
         },
-        "monitor_http": {
+        "arthur_http": {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "console",
             "level": "DEBUG",
-            "filename": "monitor_http.log",
+            "filename": "arthur_http.log",
             "mode": "a",
             "maxBytes": 10000,
             "backupCount": 1,
@@ -74,9 +74,9 @@
             "level": "WARNING",
             "propagate": 0
         },
-        "monitor_http": {
-            "qualname": "monitor_http",
-            "handlers": ["monitor_http"],
+        "arthur_http": {
+            "qualname": "arthur_http",
+            "handlers": [ "arthur_http" ],
             "level": "INFO",
             "propagate": 0
         },

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -239,7 +239,7 @@
                         "region": { "type": "string" },
                         "account": { "type": "string" }
                     },
-                    "required": [ "id", "public_subnet", "whitelist_security_group", "region" ],
+                    "required": [ "account", "public_subnet", "whitelist_security_group", "region" ],
                     "additionalProperties": false
                 },
                 "EC2": {
@@ -279,6 +279,20 @@
                                 "topicArn": { "$ref": "#/definitions/aws_arn" }
                             },
                             "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "RedshiftCluster": {
+                    "type": "object",
+                    "properties": {
+                        "max_concurrency": {
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "wlm_query_slots": {
+                            "type": "integer",
+                            "minimum": 1
                         }
                     },
                     "additionalProperties": false

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -350,9 +350,7 @@ def copy_data(conn: connection, relation: LoadableRelation, dry_run=False):
     Load data into table in the data warehouse using the COPY command.
     A manifest for the CSV files must be provided -- it is an error if the manifest is missing.
     """
-    aws_iam_role = etl.config.get_config_value("object_store.iam_role")
-    assert aws_iam_role is not None, "Forgot to set the object_store.iam_role"
-
+    aws_iam_role = str(etl.config.get_config_value("object_store.iam_role"))
     s3_uri = "s3://{}/{}".format(relation.bucket_name, relation.manifest_file_name)
 
     if not relation.has_manifest:

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -465,7 +465,7 @@ class MemoryStorage(PayloadDispatcher):
         Factory method to create a handler that serves our storage content.
         """
         storage = self
-        http_logger = logging.getLogger("monitor_http")
+        http_logger = logging.getLogger("arthur_http")
 
         class MonitorHTTPHandler(http.server.BaseHTTPRequestHandler):
 

--- a/python/etl/render_template/__init__.py
+++ b/python/etl/render_template/__init__.py
@@ -81,14 +81,14 @@ def render(template_name: str, compact=False) -> None:
         print(rendered, end='')
 
 
-def show_value(name: str) -> None:
+def show_value(name: str, default: Optional[str]) -> None:
     """
-    Show value of a specific variable.
+    Show value of a specific variable. This fails if the variable is not set and no default is provided.
     """
-    try:
-        print(etl.config.get_config_value(name))
-    except KeyError as exc:
-        raise InvalidArgumentError() from exc
+    value = etl.config.get_config_value(name, default)
+    if value is None:
+        raise InvalidArgumentError("setting '{}' has no value".format(name))
+    print(value)
 
 
 def show_vars(name: Optional[str]) -> None:

--- a/python/etl/unload.py
+++ b/python/etl/unload.py
@@ -98,8 +98,7 @@ def unload_relation(conn: connection, relation: RelationDescription, schema: Dat
     schema_table_name = "{0.schema}-{0.table}".format(relation.target_table_name)
     s3_key_prefix = os.path.join(rendered_prefix, "data", schema.name, schema_table_name, "csv")
     unload_path = "s3://{}/{}/".format(schema.s3_bucket, s3_key_prefix)
-    # FIXME Should we fail in `get_config_value`?
-    aws_iam_role = etl.config.get_config_value("object_store.iam_role") or "missing_iam_role"
+    aws_iam_role = str(etl.config.get_config_value("object_store.iam_role"))
 
     with etl.monitor.Monitor(relation.identifier,
                              "unload",

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -72,7 +72,7 @@ def validate_semantics(relations: List[RelationDescription], keep_going=False) -
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
         result = executor.map(lambda relation: validate_relation_description(relation, keep_going), relations)
     # Drop all relations from the result which returned None (meaning they failed validation).
-    return list(filter(None, result))
+    return list(filter(None, result))  # type: ignore
 
 
 def compare_query_to_design(from_query: Iterable, from_design: Iterable) -> Optional[str]:

--- a/python/scripts/install_pizza_load_pipeline.sh
+++ b/python/scripts/install_pizza_load_pipeline.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
-if [[ $# -ne 5 || "$1" = "-h" ]]; then
-    echo "Usage: `basename $0` <bucket_name> <environment> <startdatetime> <occurrences> <wlm-slots>"
-    echo "      Start time should take the ISO8601 format like: `date -u +"%Y-%m-%dT%H:%M:%S"`"
+if [[ $# -ne 2 || "$1" = "-h" ]]; then
+    echo "Pizza delivery! Right on time or it's free! Runs once, starting now."
+    echo "Expects prefix to already have all necessary manifests for source data."
+    echo "Usage: `basename $0` <environment> <wlm-slots>"
     exit 0
 fi
 
 set -e -u
 
-PROJ_BUCKET="$1"
-PROJ_ENVIRONMENT="$2"
+PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_ENVIRONMENT="$1"
+WLM_SLOTS="$2"
 
-START_DATE_TIME="$3"
-OCCURRENCES="$4"
-WLM_SLOTS="$5"
+START_DATE_TIME=`date -u +"%Y-%m-%dT%H:%M:%S"`
 
 # Verify that this bucket/environment pair is set up on s3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
@@ -32,17 +32,17 @@ fi
 # Note: key/value are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
 
-PIPELINE_NAME="ETL Rebuild Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+PIPELINE_NAME="ETL Pizza Loader Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
-arthur.py render_template --prefix "$PROJ_ENVIRONMENT" rebuild_pipeline > "$PIPELINE_DEFINITION_FILE"
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" pizza_load_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
 
 aws datapipeline create-pipeline \
-    --unique-id rebuild-etl-pipeline \
+    --unique-id pizza-etl-pipeline \
     --name "$PIPELINE_NAME" \
-    --tags "$AWS_TAGS" \
+    --tags $AWS_TAGS \
     | tee "$PIPELINE_ID_FILE"
 
 PIPELINE_ID=`jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId'`
@@ -59,8 +59,6 @@ aws datapipeline put-pipeline-definition \
         myS3Bucket="$PROJ_BUCKET" \
         myEtlEnvironment="$PROJ_ENVIRONMENT" \
         myStartDateTime="$START_DATE_TIME" \
-        myOccurrences="$OCCURRENCES" \
-        myMaxPartitions="16" \
         myMaxConcurrency="4" \
         myWlmQuerySlots="$WLM_SLOTS" \
     --pipeline-id "$PIPELINE_ID"

--- a/python/scripts/install_rebuild_pipeline.sh
+++ b/python/scripts/install_rebuild_pipeline.sh
@@ -1,28 +1,22 @@
 #!/usr/bin/env bash
 
-if [[ $# -lt 5 || "$1" = "-h" ]]; then
-    echo "Usage: `basename $0` <bucket_name> <environment> <startdatetime> <occurrences> <source table selection> [<source table selection> ...]"
+if [[ $# -ne 4 || "$1" = "-h" ]]; then
+    echo "Usage: `basename $0` <environment> <startdatetime> <occurrences> <wlm-slots>"
     echo "      Start time should take the ISO8601 format like: `date -u +"%Y-%m-%dT%H:%M:%S"`"
-    echo "      Specify source tables using space-delimited arthur pattern globs."
     exit 0
 fi
 
 set -e -u
 
-function join_by { local IFS="$1"; shift; echo "$*"; }
+PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_ENVIRONMENT="$1"
 
-PROJ_BUCKET="$1"
-PROJ_ENVIRONMENT="$2"
-
-START_DATE_TIME="$3"
-OCCURRENCES="$4"
-
-shift 4
-SELECTION="$@"
-C_S_SELECTION="$(join_by ',' $SELECTION)"
+START_DATE_TIME="$2"
+OCCURRENCES="$3"
+WLM_SLOTS="$4"
 
 # Verify that this bucket/environment pair is set up on s3
-BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/current/bin/bootstrap.sh"
+BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
     echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
     exit 1
@@ -38,17 +32,17 @@ fi
 # Note: key/value are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
 
-PIPELINE_NAME="ETL Refresh Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+PIPELINE_NAME="ETL Rebuild Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
-arthur.py render_template --prefix "$PROJ_ENVIRONMENT" refresh_pipeline > "$PIPELINE_DEFINITION_FILE"
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" rebuild_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
 
 aws datapipeline create-pipeline \
-    --unique-id refresh-etl-pipeline \
+    --unique-id rebuild-etl-pipeline \
     --name "$PIPELINE_NAME" \
-    --tags "$AWS_TAGS" \
+    --tags $AWS_TAGS \
     | tee "$PIPELINE_ID_FILE"
 
 PIPELINE_ID=`jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId'`
@@ -66,11 +60,9 @@ aws datapipeline put-pipeline-definition \
         myEtlEnvironment="$PROJ_ENVIRONMENT" \
         myStartDateTime="$START_DATE_TIME" \
         myOccurrences="$OCCURRENCES" \
-        mySelection="$SELECTION" \
-        myCommaSeparatedSelection="$C_S_SELECTION" \
         myMaxPartitions="16" \
         myMaxConcurrency="4" \
-        myWlmQuerySlots="3" \
+        myWlmQuerySlots="$WLM_SLOTS" \
     --pipeline-id "$PIPELINE_ID"
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"

--- a/python/scripts/install_refresh_pipeline.sh
+++ b/python/scripts/install_refresh_pipeline.sh
@@ -1,22 +1,28 @@
 #!/usr/bin/env bash
 
-if [[ $# -ne 3 || "$1" = "-h" ]]; then
-    echo "Pizza delivery! Right on time or it's free! Runs once, starting now."
-    echo "Expects prefix to already have all necessary manifests for source data."
-    echo "Usage: `basename $0` <bucket_name> <environment> <wlm-slots>"
+if [[ $# -lt 4 || "$1" = "-h" ]]; then
+    echo "Usage: `basename $0` <environment> <startdatetime> <occurrences> <source table selection> [<source table selection> ...]"
+    echo "      Start time should take the ISO8601 format like: `date -u +"%Y-%m-%dT%H:%M:%S"`"
+    echo "      Specify source tables using space-delimited arthur pattern globs."
     exit 0
 fi
 
 set -e -u
 
-PROJ_BUCKET="$1"
-PROJ_ENVIRONMENT="$2"
-WLM_SLOTS="$3"
+function join_by { local IFS="$1"; shift; echo "$*"; }
 
-START_DATE_TIME=`date -u +"%Y-%m-%dT%H:%M:%S"`
+PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_ENVIRONMENT="$1"
+
+START_DATE_TIME="$2"
+OCCURRENCES="$3"
+
+shift 3
+SELECTION="$@"
+C_S_SELECTION="$(join_by ',' $SELECTION)"
 
 # Verify that this bucket/environment pair is set up on s3
-BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
+BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/current/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
     echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
     exit 1
@@ -32,17 +38,17 @@ fi
 # Note: key/value are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
 
-PIPELINE_NAME="ETL Pizza Loader Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
+PIPELINE_NAME="ETL Refresh Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
-arthur.py render_template --prefix "$PROJ_ENVIRONMENT" pizza_load_pipeline > "$PIPELINE_DEFINITION_FILE"
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" refresh_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
 
 aws datapipeline create-pipeline \
-    --unique-id pizza-etl-pipeline \
+    --unique-id refresh-etl-pipeline \
     --name "$PIPELINE_NAME" \
-    --tags "$AWS_TAGS" \
+    --tags $AWS_TAGS \
     | tee "$PIPELINE_ID_FILE"
 
 PIPELINE_ID=`jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId'`
@@ -59,8 +65,12 @@ aws datapipeline put-pipeline-definition \
         myS3Bucket="$PROJ_BUCKET" \
         myEtlEnvironment="$PROJ_ENVIRONMENT" \
         myStartDateTime="$START_DATE_TIME" \
+        myOccurrences="$OCCURRENCES" \
+        mySelection="$SELECTION" \
+        myCommaSeparatedSelection="$C_S_SELECTION" \
+        myMaxPartitions="16" \
         myMaxConcurrency="4" \
-        myWlmQuerySlots="$WLM_SLOTS" \
+        myWlmQuerySlots="3" \
     --pipeline-id "$PIPELINE_ID"
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -3,8 +3,8 @@
 START_NOW=`date -u +"%Y-%m-%dT%H:%M:%S"`
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
-if [[ $# -lt 1 || $# -gt 4 || "$1" = "-h" ]]; then
-    echo "Usage: `basename $0` <bucket_name> [<environment> [<startdatetime> [<occurrences>]]]"
+if [[ $# -gt 3 || "$1" = "-h" ]]; then
+    echo "Usage: `basename $0` [<environment> [<startdatetime> [<occurrences>]]]"
     echo "      The environment defaults to \"$DEFAULT_PREFIX\"."
     echo "      Start time should take the ISO8601 format, defaults to \"$START_NOW\" (now)."
     echo "      The number of occurrences defaults to 1."
@@ -13,11 +13,11 @@ fi
 
 set -e -u
 
-PROJ_BUCKET="$1"
-PROJ_ENVIRONMENT="${2:-$DEFAULT_PREFIX}"
+PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_ENVIRONMENT="${1:-$DEFAULT_PREFIX}"
 
-START_DATE_TIME="${3:-$START_NOW}"
-OCCURRENCES="${4:-1}"
+START_DATE_TIME="${2:-$START_NOW}"
+OCCURRENCES="${3:-1}"
 
 # Verify that this bucket/environment pair is set up on s3 with credentials
 VALIDATION_CREDENTIALS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/validation/config/credentials_validation.sh"
@@ -52,7 +52,7 @@ PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
 aws datapipeline create-pipeline \
     --unique-id validation_pipeline \
     --name "$PIPELINE_NAME" \
-    --tags "$AWS_TAGS" \
+    --tags $AWS_TAGS \
     | tee "$PIPELINE_ID_FILE"
 
 PIPELINE_ID=`jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId'`

--- a/python/scripts/launch_ec2_instance.sh
+++ b/python/scripts/launch_ec2_instance.sh
@@ -59,8 +59,8 @@ fi
 
 # === Fill in config templates ===
 
-CLI_INPUT_JSON=$( arthur.py render_template --prefix "${2-$DEFAULT_PREFIX}" --compact ec2_instance )
-USER_DATA_JSON=$( arthur.py render_template --prefix "${2-$DEFAULT_PREFIX}" --compact cloud_init )
+CLI_INPUT_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compact ec2_instance )
+USER_DATA_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compact cloud_init )
 
 # ===  Start instance ===
 

--- a/python/scripts/launch_emr_cluster.sh
+++ b/python/scripts/launch_emr_cluster.sh
@@ -116,7 +116,7 @@ cat <<EOF
 
 # If you want to submit steps, use:
 
-  arthur.py --submit "$CLUSTER_ID" [command] --prolix --prefix $DEFAULT_PREFIX [options ...]
+  arthur.py --submit "$CLUSTER_ID" [command] --prolix --prefix "$PROJ_ENVIRONMENT" [options ...]
 
 # To easily reference this cluster, user:
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setup(
         ]
     },
     scripts=[
+        "python/scripts/install_pizza_load_pipeline.sh",
+        "python/scripts/install_rebuild_pipeline.sh",
+        "python/scripts/install_refresh_pipeline.sh",
+        "python/scripts/install_validation_pipeline.sh",
         "python/scripts/launch_ec2_instance.sh",
         "python/scripts/launch_emr_cluster.sh",
         "python/scripts/re_run_partial_pipeline.py",

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.0.1",
+    version="1.1.0",
     author="Harry's Data Engineering and Contributors",
-    description="ETL code to ferry data from PostgreSQL databases (or S3 files) to Redshift cluster",
+    description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",
     keywords="redshift postgresql ETL ELT extract transform load",
     url="https://github.com/harrystech/arthur-redshift-etl",


### PR DESCRIPTION
User visible changes
* Add high-level summary of the Arthur project in the `README.md`
* Split installation instructions off into its own file, `INSTALL.md`
* Increase number of IP ranges that can be specified to be whitelisted in the VPC when starting VPC using cloudformation
* Allow to pass in the identifier of a snapshot when starting a cluster (so that we can start from a backup)
* Move the install scripts for data pipelines into the scripts directory (which ends up on a user's path once installed in the virtual environment)
* Remove the bucket name as a parameter since it's now coming from the configuration file
* Log files from HTTP requests to the monitor pages are now logged in `arthur_http.log` files.

Not addressed
* Scripts should really accept a directory with configuration files now and pass it on to `arthur.py`
