### PR TITLE
DW-198 Retry support for extract

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -79,6 +79,8 @@ def _build_config_map(settings):
     for section in {"object_store", "resources", "etl_events"}.intersection(settings):
         for name, value in _flatten_hier(section, settings[section]):
             mapping[name] = value
+    for top_level_scalar_key in {"extract_retries"}.intersection(settings):
+        mapping[top_level_scalar_key] = settings[top_level_scalar_key]
     return mapping
 
 

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -76,11 +76,9 @@ def _flatten_hier(prefix, props):
 
 def _build_config_map(settings):
     mapping = OrderedDict()
-    for section in {"object_store", "resources", "etl_events"}.intersection(settings):
+    for section in {"arthur_settings", "object_store", "resources", "etl_events"}.intersection(settings):
         for name, value in _flatten_hier(section, settings[section]):
             mapping[name] = value
-    for top_level_scalar_key in {"extract_retries"}.intersection(settings):
-        mapping[top_level_scalar_key] = settings[top_level_scalar_key]
     return mapping
 
 

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -1,4 +1,9 @@
 {
+    # General settings controlling how Arthur itself behaves
+    "arthur_settings": {
+        # If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries
+        "extract_retries": 1
+    },
     # Target (Redshift) cluster
     "data_warehouse": {
         # The environment variable must contain a full connection string for an admin user to create a database.
@@ -71,7 +76,5 @@
             # The bytea data type is probably not useful, but we'll try to pull it in base64 format.
             "bytea": ["varchar(65535)", "encode(%s, 'base64')", "string"]
         }
-    },
-    # If an extract from an upstream source fails due to some transient error, retry the extract at most this many times.
-    "extract_retries": 1
+    }
 }

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -72,6 +72,6 @@
             "bytea": ["varchar(65535)", "encode(%s, 'base64')", "string"]
         }
     },
-    # If an extract from an upstream source fails for any reason, retry the extract at most this many times.
+    # If an extract from an upstream source fails due to some transient error, retry the extract at most this many times.
     "extract_retries": 1
 }

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -71,5 +71,7 @@
             # The bytea data type is probably not useful, but we'll try to pull it in base64 format.
             "bytea": ["varchar(65535)", "encode(%s, 'base64')", "string"]
         }
-    }
+    },
+    # If an extract from an upstream source fails for any reason, retry the extract at most this many times.
+    "extract_retries": 1
 }

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -98,6 +98,17 @@
     },
     "type": "object",
     "properties": {
+        "arthur_settings": {
+            "type": "object",
+            "properties": {
+                "extract_retries": {
+                    "description": "If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries",
+                    "type": "integer",
+                    "minimum": 0
+                }
+            },
+            "additionalProperties": false
+        },
         "data_warehouse": {
             "type": "object",
             "properties": {
@@ -345,11 +356,6 @@
         "required_in_full_load": {
             "description": "DEPRECATED USE 'required_for_success' instead",
             "$ref": "#/definitions/glob_pattern_list"
-        },
-        "extract_retries": {
-            "description": "If an extract from an upstream source fails due to some transient error, retry the extract at most this many times.",
-            "type": "integer",
-            "minimum": 1
         }
     },
     "required": [ "data_warehouse", "sources", "type_maps" ],

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -347,6 +347,7 @@
             "$ref": "#/definitions/glob_pattern_list"
         },
         "extract_retries": {
+            "description": "If an extract from an upstream source fails due to some transient error, retry the extract at most this many times.",
             "type": "integer",
             "minimum": 1
         }

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -107,6 +107,7 @@
                     "minimum": 0
                 }
             },
+            "required": [ "extract_retries" ],
             "additionalProperties": false
         },
         "data_warehouse": {
@@ -358,6 +359,6 @@
             "$ref": "#/definitions/glob_pattern_list"
         }
     },
-    "required": [ "data_warehouse", "sources", "type_maps" ],
+    "required": [ "arthur_settings", "data_warehouse", "sources", "type_maps" ],
     "additionalProperties": false
 }

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -345,6 +345,10 @@
         "required_in_full_load": {
             "description": "DEPRECATED USE 'required_for_success' instead",
             "$ref": "#/definitions/glob_pattern_list"
+        },
+        "extract_retries": {
+            "type": "integer",
+            "minimum": 1
         }
     },
     "required": [ "data_warehouse", "sources", "type_maps" ],

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -4,6 +4,19 @@ class ETLError(Exception):
     """
 
 
+class PermanentETLError(ETLError):
+    """
+    Represents all types of errors that are known to be permanent failures due irrecoverable situations within the ETL
+    """
+
+
+class TransientETLError(ETLError):
+    """
+    Represents all types of errors that could potentially resolve themselves due to changes in the outside environment
+    or some kind of intervention, and are thus retryable.
+    """
+
+
 class ETLSystemError(ETLError):
     """
     Blunder in the ETL code -- you'll need to check the ETL code, sorry about that.
@@ -136,6 +149,11 @@ class SqoopExecutionError(DataExtractError):
     pass
 
 
+class TransientSqoopExecutionError(TransientETLError):
+    # TODO: Refactor exception hierarchy to properly tag all transient errors
+    pass
+
+
 class MissingCsvFilesError(DataExtractError):
     pass
 
@@ -195,4 +213,13 @@ class RequiredRelationLoadError(ETLRuntimeError):
 class DataUnloadError(ETLRuntimeError):
     """
     Exception when the unload operation fails
+    """
+
+
+class RetriesExhaustedError(PermanentETLError):
+    """
+    Raised when all retry attempts have been exhausted.
+
+    The causing exception should be passed to this one to complete the chain of failure accountability. For example:
+    >>> raise RetriesExhaustedError from ETLRuntimeError("Boom!")
     """

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -225,7 +225,7 @@ class RetriesExhaustedError(PermanentETLError):
     """
 
 
-def retry(max_attempts: int, callback: callable, logger=None):
+def retry(max_retries: int, callback: callable, logger):
     """
     Retry a function a maximum number of times and return its results.
 
@@ -235,15 +235,15 @@ def retry(max_attempts: int, callback: callable, logger=None):
     failure_reason = None
     successful_result = None
 
-    for attempt in range(max_attempts + 1):
+    for attempt in range(max_retries + 1):
         try:
             successful_result = callback(attempt)
         except TransientETLError as e:
             # Only retry transient errors
             failure_reason = e
-            if logger and max_attempts - attempt:
+            if max_retries - attempt:
                 logger.warning("Encountered the following error (retrying %s more times): %s",
-                               max_attempts - attempt, str(e))
+                               max_retries - attempt, str(e))
             continue
         except:
             # We consider all other errors permanent and immediately re-raise without retrying

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -9,19 +9,6 @@ class ETLError(Exception):
     """
 
 
-class PermanentETLError(ETLError):
-    """
-    Represents all types of errors that are known to be permanent failures due irrecoverable situations within the ETL
-    """
-
-
-class TransientETLError(ETLError):
-    """
-    Represents all types of errors that could potentially resolve themselves due to changes in the outside environment,
-    etc., and are thus retryable.
-    """
-
-
 class ETLSystemError(ETLError):
     """
     Blunder in the ETL code -- you'll need to check the ETL code, sorry about that.
@@ -43,6 +30,13 @@ class ETLRuntimeError(ETLError):
     Error found at runtime -- you might be able to just try again or need to fix something upstream.
 
     This exception should be raised when the show-stopper lies outside of code or configuration.
+    """
+
+
+class TransientETLError(ETLRuntimeError):
+    """
+    Represents all types of runtime errors that should be retryable due to the cause being something in the external
+    environment that might change over time.
     """
 
 
@@ -140,7 +134,7 @@ class UpstreamValidationError(ETLRuntimeError):
     """
 
 
-class DataExtractError(ETLRuntimeError):
+class DataExtractError(TransientETLError):
     """
     Exception when extracting from an upstream source fails
     """
@@ -151,11 +145,6 @@ class UnknownTableSizeError(DataExtractError):
 
 
 class SqoopExecutionError(DataExtractError):
-    pass
-
-
-class TransientSqoopExecutionError(TransientETLError):
-    # TODO: Refactor exception hierarchy to properly tag all transient errors
     pass
 
 
@@ -221,7 +210,7 @@ class DataUnloadError(ETLRuntimeError):
     """
 
 
-class RetriesExhaustedError(PermanentETLError):
+class RetriesExhaustedError(ETLRuntimeError):
     """
     Raised when all retry attempts have been exhausted.
 

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -248,6 +248,6 @@ def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
         else:
             break
     else:
-        raise RetriesExhaustedError from failure_reason
+        raise RetriesExhaustedError("reached max number of retries (={:d})".format(max_retries)) from failure_reason
 
     return successful_result

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -1,3 +1,8 @@
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
 class ETLError(Exception):
     """
     Parent to all ETL-oriented exceptions which allows to write effective except statements
@@ -12,8 +17,8 @@ class PermanentETLError(ETLError):
 
 class TransientETLError(ETLError):
     """
-    Represents all types of errors that could potentially resolve themselves due to changes in the outside environment
-    or some kind of intervention, and are thus retryable.
+    Represents all types of errors that could potentially resolve themselves due to changes in the outside environment,
+    etc., and are thus retryable.
     """
 
 
@@ -222,10 +227,13 @@ class RetriesExhaustedError(PermanentETLError):
 
     The causing exception should be passed to this one to complete the chain of failure accountability. For example:
     >>> raise RetriesExhaustedError from ETLRuntimeError("Boom!")
+    Traceback (most recent call last):
+        ...
+    etl.errors.RetriesExhaustedError
     """
 
 
-def retry(max_retries: int, callback: callable, logger):
+def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
     """
     Retry a function a maximum number of times and return its results.
 

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -226,6 +226,12 @@ class RetriesExhaustedError(PermanentETLError):
 
 
 def retry(max_attempts: int, callback: callable, logger=None):
+    """
+    Retry a function a maximum number of times and return its results.
+
+    The given callback function is only retried if it throws a TransientETLError. Any other error is considered
+    permanent, and therefore no retry attempt is made.
+    """
     failure_reason = None
     successful_result = None
 

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -90,7 +90,8 @@ class Extractor:
                                                  attempt_num=attempt_num + 1):
                                 self.extract_table(source, relation)
 
-                    retry(get_config_value("arthur_settings.extract_retries"), _monitored_table_extract, self.logger)
+                    retries = int(get_config_value("arthur_settings.extract_retries"))  # type: ignore
+                    retry(retries, _monitored_table_extract, self.logger)
 
                 except ETLRuntimeError:
                     self.failed_sources.add(source.name)

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -14,7 +14,12 @@ import etl.s3
 import etl.db
 from etl.config import get_config_value
 from etl.config.dw import DataWarehouseSchema
-from etl.errors import DataExtractError, ETLRuntimeError, MissingCsvFilesError, TransientETLError, RetriesExhaustedError
+from etl.errors import (
+    DataExtractError,
+    ETLRuntimeError,
+    MissingCsvFilesError,
+    retry
+)
 from etl.names import join_with_quotes
 from etl.relation import RelationDescription
 from etl.timer import Timer
@@ -72,35 +77,20 @@ class Extractor:
         with Timer() as timer:
             for i, relation in enumerate(relations):
                 try:
-                    retries = get_config_value("extract_retries")
-                    failure_reason = None
-                    for attempt in range(retries + 1):
-                        try:
-                            with etl.monitor.Monitor(relation.identifier,
-                                                     "extract",
-                                                     options=self.options_info(),
-                                                     source=self.source_info(source, relation),
-                                                     destination={'bucket_name': relation.bucket_name,
-                                                                  'object_key': relation.manifest_file_name},
-                                                     index={"current": i + 1, "final":
-                                                            len(relations), "name": source.name},
-                                                     dry_run=self.dry_run,
-                                                     attempt_num=attempt):
+                    def _monitored_table_extract(attempt_num):
+                        with etl.monitor.Monitor(relation.identifier,
+                                                 "extract",
+                                                 options=self.options_info(),
+                                                 source=self.source_info(source, relation),
+                                                 destination={'bucket_name': relation.bucket_name,
+                                                              'object_key': relation.manifest_file_name},
+                                                 index={"current": i + 1, "final":
+                                                        len(relations), "name": source.name},
+                                                 dry_run=self.dry_run,
+                                                 attempt_num=attempt_num):
                                 self.extract_table(source, relation)
-                        except TransientETLError as e:
-                            # Only retry transient errors
-                            failure_reason = e
-                            if retries - attempt:
-                                self.logger.warning("Encountered the following error; retrying %s more times: %s",
-                                                    retries - attempt, str(e))
-                            continue
-                        except:
-                            # We consider all other errors permanent and immediately re-raise without retry
-                            raise
-                        else:
-                            break
-                    else:
-                        raise RetriesExhaustedError from failure_reason
+
+                    retry(get_config_value("extract_retries"), _monitored_table_extract, self.logger)
 
                 except ETLRuntimeError:
                     self.failed_sources.add(source.name)

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -87,7 +87,7 @@ class Extractor:
                                                  index={"current": i + 1, "final":
                                                         len(relations), "name": source.name},
                                                  dry_run=self.dry_run,
-                                                 attempt_num=attempt_num):
+                                                 attempt_num=attempt_num + 1):
                                 self.extract_table(source, relation)
 
                     retry(get_config_value("extract_retries"), _monitored_table_extract, self.logger)

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -90,7 +90,7 @@ class Extractor:
                                                  attempt_num=attempt_num + 1):
                                 self.extract_table(source, relation)
 
-                    retry(get_config_value("extract_retries"), _monitored_table_extract, self.logger)
+                    retry(get_config_value("arthur_settings.extract_retries"), _monitored_table_extract, self.logger)
 
                 except ETLRuntimeError:
                     self.failed_sources.add(source.name)

--- a/python/etl/extract/sqoop.py
+++ b/python/etl/extract/sqoop.py
@@ -11,7 +11,7 @@ import etl.monitor
 import etl.db
 import etl.s3
 from etl.config.dw import DataWarehouseSchema
-from etl.errors import SqoopExecutionError
+from etl.errors import TransientSqoopExecutionError
 from etl.extract.database_extractor import DatabaseExtractor
 from etl.relation import RelationDescription
 
@@ -213,7 +213,9 @@ class SqoopExtractor(DatabaseExtractor):
             self.logger.debug("Sqoop stdout:%s", nice_out)
             self.logger.debug("Sqoop stderr:%s", nice_err)
             if sqoop.returncode != 0:
-                raise SqoopExecutionError("Sqoop failed with return code %s" % sqoop.returncode)
+                # TODO: Parse Sqoop output and write logic to decide if error is permanent or transient. In the mean
+                # time, we're being optimistic and considering all failures transient, since we limit retry attempts.
+                raise TransientSqoopExecutionError("Sqoop failed with return code %s" % sqoop.returncode)
 
 
 class FakeSqoopExtractor(SqoopExtractor):

--- a/python/etl/extract/sqoop.py
+++ b/python/etl/extract/sqoop.py
@@ -11,7 +11,7 @@ import etl.monitor
 import etl.db
 import etl.s3
 from etl.config.dw import DataWarehouseSchema
-from etl.errors import TransientSqoopExecutionError
+from etl.errors import SqoopExecutionError
 from etl.extract.database_extractor import DatabaseExtractor
 from etl.relation import RelationDescription
 
@@ -213,9 +213,9 @@ class SqoopExtractor(DatabaseExtractor):
             self.logger.debug("Sqoop stdout:%s", nice_out)
             self.logger.debug("Sqoop stderr:%s", nice_err)
             if sqoop.returncode != 0:
-                # TODO: Parse Sqoop output and write logic to decide if error is permanent or transient. In the mean
-                # time, we're being optimistic and considering all failures transient, since we limit retry attempts.
-                raise TransientSqoopExecutionError("Sqoop failed with return code %s" % sqoop.returncode)
+                # TODO: Be more intelligent about detecting whether certain Sqoop errors are retryable, instead of
+                # assuming they all are.
+                raise SqoopExecutionError("Sqoop failed with return code %s" % sqoop.returncode)
 
 
 class FakeSqoopExtractor(SqoopExtractor):


### PR DESCRIPTION
This add support for extract to retry on a per-table basis. The number of retry attempts it uses is controlled by a new configuration setting, and has a default value of 1 retry.

This was tested out using the `FakeSqoopExtractor`; so it does work in the case where Sqoop returns a non-zero exit code. 

Open questions/issues for feedback:
* Are there any known failure cases today where Sqoop returns a non-zero error code and we do *not* want to retry? The current implementation is a very blunt instrument, and just always retries Sqoop.
* The Static and ManifestOnly extractors both simply interact with S3 via Boto. Boto internally handles retries for various transient errors, so it didn't seem necessary to add explicit retries in user code on top of that. Thoughts?
* The Spark extractor seems to be broken, based on the comments in `spark.py` on lines 156 and 157. Because of that, the complexity involved in creating a test environment I could use to test retry code for Spark errors, and not finding some readily available documentation on the exceptions/errorrs thrown by Spark, I didn't test this out on Spark. Should Spark be out of scope for this?