### PR TITLE
DW-227 Extract from older version of PostgreSQL (in particular Redshift)

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -57,7 +57,10 @@ cd "$PROJ_TEMP"
 
 # Download code to all nodes, this includes Python code and its requirements.txt
 aws s3 cp --only-show-errors --recursive "s3://$BUCKET_NAME/$ENVIRONMENT/jars/" ./jars/
-# TODO: copy sqoop-required jars to /usr/lib/sqoop/lib
+if [[ -d /usr/lib/sqoop/lib ]]; then
+    sudo cp ./jars/Redshift*.jar /usr/lib/sqoop/lib/
+    sudo chmod 644 /usr/lib/sqoop/lib/Redshift*.jar
+fi
 aws s3 cp --only-show-errors --exclude '*' --include ping_cronut.sh --include bootstrap.sh --include sync_env.sh \
     --recursive "s3://$BUCKET_NAME/$ENVIRONMENT/bin/" ./bin/
 chmod +x ./bin/*.sh

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -57,10 +57,6 @@ cd "$PROJ_TEMP"
 
 # Download code to all nodes, this includes Python code and its requirements.txt
 aws s3 cp --only-show-errors --recursive "s3://$BUCKET_NAME/$ENVIRONMENT/jars/" ./jars/
-if [[ -d /usr/lib/sqoop/lib ]]; then
-    sudo cp ./jars/Redshift*.jar /usr/lib/sqoop/lib/
-    sudo chmod 644 /usr/lib/sqoop/lib/Redshift*.jar
-fi
 aws s3 cp --only-show-errors --exclude '*' --include ping_cronut.sh --include bootstrap.sh --include sync_env.sh \
     --recursive "s3://$BUCKET_NAME/$ENVIRONMENT/bin/" ./bin/
 chmod +x ./bin/*.sh

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -57,6 +57,7 @@ cd "$PROJ_TEMP"
 
 # Download code to all nodes, this includes Python code and its requirements.txt
 aws s3 cp --only-show-errors --recursive "s3://$BUCKET_NAME/$ENVIRONMENT/jars/" ./jars/
+# TODO: copy sqoop-required jars to /usr/lib/sqoop/lib
 aws s3 cp --only-show-errors --exclude '*' --include ping_cronut.sh --include bootstrap.sh --include sync_env.sh \
     --recursive "s3://$BUCKET_NAME/$ENVIRONMENT/bin/" ./bin/
 chmod +x ./bin/*.sh

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -110,6 +110,7 @@ def extract_dsn(dsn_dict: Dict[str, str], read_only=False):
         "readOnly": "true" if read_only else "false",
         "driver": "org.postgresql.Driver"  # necessary, weirdly enough
     })
+    # TODO: Allow 'redshift://' in URL (and set driver accordingly?)
     if "port" in dsn_properties:
         jdbc_url = "jdbc:postgresql://{host}:{port}/{database}".format(**dsn_properties)
     else:

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -111,19 +111,15 @@ def extract_dsn(dsn_dict: Dict[str, str], read_only=False):
     be passed in separately.
     """
     dsn_properties = dict(dsn_dict)  # so as to not mutate the argument
-    if dsn_properties['subprotocol'] == 'redshift':
-        driver = "com.amazon.redshift.jdbc41.Driver"
-    else:
-        driver = "org.postgresql.Driver"
     dsn_properties.update({
         "ApplicationName": __name__,
         "readOnly": "true" if read_only else "false",
-        "driver": driver
+        "driver": "org.postgresql.Driver"
     })
     if "port" in dsn_properties:
-        jdbc_url = "jdbc:{subprotocol}://{host}:{port}/{database}".format(**dsn_properties)
+        jdbc_url = "jdbc:postgresql://{host}:{port}/{database}".format(**dsn_properties)
     else:
-        jdbc_url = "jdbc:{subprotocol}://{host}/{database}".format(**dsn_properties)
+        jdbc_url = "jdbc:postgresql://{host}/{database}".format(**dsn_properties)
     return jdbc_url, dsn_properties
 
 

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -45,7 +45,7 @@ def parse_connection_string(dsn: str) -> Dict[str, str]:
     """
     # Some people, when confronted with a problem, think "I know, I'll use regular expressions."
     # Now they have two problems.
-    dsn_re = re.compile(r"""(?:jdbc:)?(redshift|postgresql|postgres)://  # be nice and accept either connection type
+    dsn_re = re.compile(r"""(?:jdbc:)?(?P<subprotocol>redshift|postgresql|postgres)://  # be nice and accept either connection type
                             (?:(?P<user>\w[.\w]*)(?::(?P<password>[-\w]+))?@)?  # optional user with password
                             (?P<host>\w[-.\w]*)(:?:(?P<port>\d+))?/  # host and optional port information
                             (?P<database>\w+)  # database (and not dbname)
@@ -70,6 +70,12 @@ def unparse_connection(dsn: Dict[str, str]) -> str:
     return "host={host} port={port} dbname={database} user={user} password=***".format(**values)
 
 
+def _dsn_connection_values(dsn_dict: Dict[str, str], application_name: str):
+    dsn_values = dict(dsn_dict, application_name=application_name, cursor_factory=psycopg2.extras.DictCursor)
+    dsn_values.pop('subprotocol', None)
+    return dsn_values
+
+
 def connection(dsn_dict: Dict[str, str], application_name=psycopg2.__name__, autocommit=False, readonly=False):
     """
     Open a connection to the database described by dsn_string which looks something like
@@ -78,7 +84,7 @@ def connection(dsn_dict: Dict[str, str], application_name=psycopg2.__name__, aut
     Caveat Emptor: By default, this turns off autocommit on the connection. This means that you
     have to explicitly commit on the connection object or run your SQL within a transaction context!
     """
-    dsn_values = dict(dsn_dict, application_name=application_name, cursor_factory=psycopg2.extras.DictCursor)
+    dsn_values = _dsn_connection_values(dsn_dict, application_name)
     logger.info("Connecting to: %s", unparse_connection(dsn_values))
     cx = psycopg2.connect(**dsn_values)
     cx.set_session(autocommit=autocommit, readonly=readonly)
@@ -92,7 +98,7 @@ def connection_pool(max_conn, dsn_dict: Dict[str, str], application_name=psycopg
     Create a connection pool (with up to max_conn connections), where all connections will use the
     given connection string.
     """
-    dsn_values = dict(dsn_dict, application_name=application_name, cursor_factory=psycopg2.extras.DictCursor)
+    dsn_values = _dsn_connection_values(dsn_dict, application_name)
     return psycopg2.pool.ThreadedConnectionPool(1, max_conn, **dsn_values)
 
 
@@ -105,16 +111,19 @@ def extract_dsn(dsn_dict: Dict[str, str], read_only=False):
     be passed in separately.
     """
     dsn_properties = dict(dsn_dict)  # so as to not mutate the argument
+    if dsn_properties['subprotocol'] == 'redshift':
+        driver = "com.amazon.redshift.jdbc41.Driver"
+    else:
+        driver = "org.postgresql.Driver"
     dsn_properties.update({
         "ApplicationName": __name__,
         "readOnly": "true" if read_only else "false",
-        "driver": "org.postgresql.Driver"  # necessary, weirdly enough
+        "driver": driver
     })
-    # TODO: Allow 'redshift://' in URL (and set driver accordingly?)
     if "port" in dsn_properties:
-        jdbc_url = "jdbc:postgresql://{host}:{port}/{database}".format(**dsn_properties)
+        jdbc_url = "jdbc:{subprotocol}://{host}:{port}/{database}".format(**dsn_properties)
     else:
-        jdbc_url = "jdbc:postgresql://{host}/{database}".format(**dsn_properties)
+        jdbc_url = "jdbc:{subprotocol}://{host}/{database}".format(**dsn_properties)
     return jdbc_url, dsn_properties
 
 

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -71,6 +71,12 @@ def unparse_connection(dsn: Dict[str, str]) -> str:
 
 
 def _dsn_connection_values(dsn_dict: Dict[str, str], application_name: str):
+    """
+    Return a dictionary of parameters that can be used to open a db connection.
+
+    This includes popping "subprotocol" from our dictionary of paramters extracted
+    from the connection string, which is not expected by psycopg2.connect().
+    """
     dsn_values = dict(dsn_dict, application_name=application_name, cursor_factory=psycopg2.extras.DictCursor)
     dsn_values.pop('subprotocol', None)
     return dsn_values
@@ -109,6 +115,9 @@ def extract_dsn(dsn_dict: Dict[str, str], read_only=False):
     This is necessary since a JDBC URL may not contain all the properties needed
     to successfully connect, e.g. username, password.  These properties must
     be passed in separately.
+
+    Use the postgresql subprotocol and driver regardless of whether the connection
+    string's protocol was postgres or redshift.
     """
     dsn_properties = dict(dsn_dict)  # so as to not mutate the argument
     dsn_properties.update({

--- a/python/etl/extract/database_extractor.py
+++ b/python/etl/extract/database_extractor.py
@@ -114,7 +114,10 @@ class DatabaseExtractor(Extractor):
 
     def fetch_source_table_size(self, dsn_dict: Dict[str, str], relation: RelationDescription) -> int:
         """
-        Return size of source table for this relation in bytes
+        Return size or estimated size of source table for this relation in bytes.
+
+        For source tables in a postgres database, fetch the actual size from pg_catalog tables.
+        Otherwise, pessimistically estimate a large fixed size.
         """
         stmt = """
             SELECT pg_catalog.pg_table_size(%s) AS "bytes"

--- a/python/etl/extract/database_extractor.py
+++ b/python/etl/extract/database_extractor.py
@@ -3,7 +3,6 @@ DatabaseExtractors query upstream databases and save their data on S3 before wri
 """
 from typing import Dict, List, Optional
 
-import psycopg2
 from psycopg2.extensions import connection  # only for type annotation
 
 import etl.db
@@ -128,7 +127,7 @@ class DatabaseExtractor(Extractor):
                              relation.source_name, table.identifier, bytes_size, pretty_size)
         else:
             bytes_size, pretty_size = 671088640, '671 Mb'
-            self.logger.info("Pessimistic size estimate for pre-Postgres 9 table '%s.%s': %s (%s)",
+            self.logger.info("Pessimistic size estimate for non-postgres table '%s.%s': %s (%s)",
                              relation.source_name, table.identifier, bytes_size, pretty_size)
 
         return bytes_size

--- a/python/etl/extract/database_extractor.py
+++ b/python/etl/extract/database_extractor.py
@@ -3,6 +3,7 @@ DatabaseExtractors query upstream databases and save their data on S3 before wri
 """
 from typing import Dict, List, Optional
 
+import psycopg2
 from psycopg2.extensions import connection  # only for type annotation
 
 import etl.db
@@ -120,8 +121,14 @@ class DatabaseExtractor(Extractor):
                  , pg_catalog.pg_size_pretty(pg_catalog.pg_table_size(%s)) AS pretty_size
             """
         table = relation.source_table_name
-        rows = etl.db.query(conn, stmt, (str(table), str(table)))
-        bytes_size, pretty_size = rows[0]["bytes"], rows[0]["pretty_size"]
-        self.logger.info("Size of table '%s.%s': %s (%s)",
-                         relation.source_name, table.identifier, bytes_size, pretty_size)
+        try:
+            rows = etl.db.query(conn, stmt, (str(table), str(table)))
+            bytes_size, pretty_size = rows[0]["bytes"], rows[0]["pretty_size"]
+            self.logger.info("Size of table '%s.%s': %s (%s)",
+                             relation.source_name, table.identifier, bytes_size, pretty_size)
+        except psycopg2.ProgrammingError:
+            bytes_size, pretty_size = 671088640, '671 Mb'
+            self.logger.info("Pessimistic size estimate for pre-Postgres 9 table '%s.%s': %s (%s)",
+                             relation.source_name, table.identifier, bytes_size, pretty_size)
+
         return bytes_size

--- a/python/etl/extract/spark.py
+++ b/python/etl/extract/spark.py
@@ -79,7 +79,7 @@ class SparkExtractor(DatabaseExtractor):
         partition_key = relation.find_partition_key()
 
         with closing(etl.db.connection(source.dsn, readonly=True)) as conn:
-            table_size = self.fetch_source_table_size(conn, relation)
+            table_size = self.fetch_source_table_size(conn, source.dsn['subprotocol'], relation)
             num_partitions = self.maximize_partitions(table_size)
             if partition_key is None or num_partitions <= 1:
                 predicates = None

--- a/python/etl/extract/spark.py
+++ b/python/etl/extract/spark.py
@@ -78,9 +78,10 @@ class SparkExtractor(DatabaseExtractor):
         """
         partition_key = relation.find_partition_key()
 
+        table_size = self.fetch_source_table_size(source.dsn, relation)
+        num_partitions = self.maximize_partitions(table_size)
+
         with closing(etl.db.connection(source.dsn, readonly=True)) as conn:
-            table_size = self.fetch_source_table_size(conn, source.dsn['subprotocol'], relation)
-            num_partitions = self.maximize_partitions(table_size)
             if partition_key is None or num_partitions <= 1:
                 predicates = None
             else:

--- a/python/etl/extract/spark.py
+++ b/python/etl/extract/spark.py
@@ -81,10 +81,10 @@ class SparkExtractor(DatabaseExtractor):
         table_size = self.fetch_source_table_size(source.dsn, relation)
         num_partitions = self.maximize_partitions(table_size)
 
-        with closing(etl.db.connection(source.dsn, readonly=True)) as conn:
-            if partition_key is None or num_partitions <= 1:
-                predicates = None
-            else:
+        if partition_key is None or num_partitions <= 1:
+            predicates = None
+        else:
+            with closing(etl.db.connection(source.dsn, readonly=True)) as conn:
                 predicates = self.determine_partitioning(conn, relation, partition_key, num_partitions)
 
         if self.use_sampling_with_table(table_size):

--- a/python/etl/extract/sqoop.py
+++ b/python/etl/extract/sqoop.py
@@ -107,7 +107,7 @@ class SqoopExtractor(DatabaseExtractor):
 
         args = ["import",
                 "--connect", q(jdbc_url),
-                "--driver", q("org.postgresql.Driver"),
+                "--driver", q("org.postgresql.Driver"),  # TODO: use com.amazon.redshift.jdbc41.Driver
                 "--connection-param-file", q(connection_param_file_path),
                 "--username", q(dsn_properties["user"]),
                 "--password-file", '"file://{}"'.format(password_file_path),

--- a/python/etl/extract/sqoop.py
+++ b/python/etl/extract/sqoop.py
@@ -40,8 +40,7 @@ class SqoopExtractor(DatabaseExtractor):
         """
         Run Sqoop for one table; creates the sub-process and all the pretty args for Sqoop.
         """
-        with closing(etl.db.connection(source.dsn, readonly=True)) as conn:
-            table_size = self.fetch_source_table_size(conn, source.dsn['subprotocol'], relation)
+        table_size = self.fetch_source_table_size(source.dsn, relation)
 
         connection_params_file_path = self.write_connection_params()
         password_file_path = self.write_password_file(source.dsn["password"])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.2.0",
+    version="1.2.1",
     author="Harry's Data Engineering and Contributors",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
Relatively shallow integration of Redshift as an upstream data source.

User-facing changes:
* Arthur now supports any data source that can be extracted using the postgresql JDBC driver, in particular Redshift
* For non-postgres sources, tables are pessimistically assumed to be size 671 mb for the purposes of efficiently partitioning during extract.