### PR TITLE
DW-235: Enable max_partitions for extract (in EMR settings)

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -22,9 +22,9 @@ import simplejson as json
 import yaml
 
 import etl.config.dw
-from etl.config.dw import DataWarehouseConfig
-from etl.errors import SchemaInvalidError, SchemaValidationError
 import etl.monitor
+from etl.config.dw import DataWarehouseConfig
+from etl.errors import InvalidArgumentError, SchemaInvalidError, SchemaValidationError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -47,11 +47,32 @@ def get_dw_config():
 
 
 def get_config_value(name: str, default: Optional[str]=None) -> Optional[str]:
+    """
+    Lookup configuration value in known and flattened settings -- pass in a fully-qualified name
+    """
     assert _mapped_config is not None, "attempted to get config value before reading config map"
     return _mapped_config.get(name, default)
 
 
+def get_config_int(name: str, default: Optional[int]=None) -> int:
+    """
+    Lookup a configuration value that is an integer.
+    It is an error if the value (even when using the default) is None.
+    """
+    if default is None:
+        value = get_config_value(name)
+    else:
+        value = get_config_value(name, str(default))
+    if value is None:
+        raise InvalidArgumentError("missing config for {}".format(name))
+    else:
+        return int(value)
+
+
 def set_config_value(name: str, value: str) -> None:
+    """
+    Set configuration value to given string.
+    """
     if _mapped_config is not None:
         _mapped_config.setdefault(name, value)
 

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -270,7 +270,12 @@
                     "properties": {
                         "release_label": { "type": "string" },
                         "master": { "$ref": "#/definitions/cluster_group" },
-                        "core": { "$ref": "#/definitions/cluster_group" }
+                        "core": { "$ref": "#/definitions/cluster_group" },
+                        "max_partitions": {
+                            "description": "Maximum number of partitions during extract, limits num_partitions for each table",
+                            "type": "integer",
+                            "minimum": 1
+                        }
                     },
                     "required": [ "release_label", "master", "core" ],
                     "additionalProperties": false

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Set
 import etl.monitor
 import etl.s3
 import etl.db
-from etl.config import get_config_value
+from etl.config import get_config_int
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import (
     DataExtractError,
@@ -90,7 +90,7 @@ class Extractor:
                                                  attempt_num=attempt_num + 1):
                                 self.extract_table(source, relation)
 
-                    retries = int(get_config_value("arthur_settings.extract_retries"))  # type: ignore
+                    retries = get_config_int("arthur_settings.extract_retries")
                     retry(retries, _monitored_table_extract, self.logger)
 
                 except ETLRuntimeError:
@@ -167,13 +167,13 @@ class Extractor:
 
         if self.dry_run:
             if not remote_files:
-                self.logger.warning("Dry-run: Found no CSV files")
+                self.logger.warning("Dry-run: Found no CSV files to add to manifest")
             else:
                 self.logger.info("Dry-run: Skipping writing manifest file 's3://%s/%s' for %d CSV file(s)",
                                  relation.bucket_name, relation.manifest_file_name, len(csv_files))
         else:
             if not remote_files:
-                raise MissingCsvFilesError("Found no CSV files")
+                raise MissingCsvFilesError("found no CSV files to add to manifest")
 
             self.logger.info("Writing manifest file to 's3://%s/%s' for %d CSV file(s)",
                              relation.bucket_name, relation.manifest_file_name, len(csv_files))


### PR DESCRIPTION
Part of cleanup to make data pipelines in new account(s) easier -- the number of partitions should be in the system configuration and not the pipeline definition.  This is step 1.

User-visible changes:
* You can now specify `max_partitions` for the EMR resource in a settings `.yaml` file.