### PR TITLE
Update pizza loader to use upgrade plus promote

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ If you find yourself using a one-off EC2 instance more often than an EMR cluster
 
 ### Using `develop` of `setup.py`
 
-Re-install the ETL code after pulling a new version. (Especially changes in scripts may not get picked up until you do.)
+When you pull a new version of Arthur, you should re-install the ETL code.
+This is especially important to pick up changes in the scripts!
 ```shell
 pip3 install -r requirements.txt
 python3 setup.py develop

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -310,7 +310,8 @@ def add_standard_arguments(parser, options):
                             action="store_true")
     if "continue-from" in options:
         parser.add_argument("--continue-from",
-                            help="skip forward in execution until the specified relation, then work forward from it")
+                            help="skip forward in execution until the specified relation, then work forward from it"
+                            " (the special token '*' is allowed to signify continuing from the first relation)")
     if "pattern" in options:
         parser.add_argument("pattern", help="glob pattern or identifier to select table(s) or view(s)",
                             nargs='*', action=StorePatternAsSelector)

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -987,7 +987,7 @@ def upgrade_data_warehouse(all_relations: List[RelationDescription], selector: T
         logger.warning("Found no relations matching: %s", selector)
         return
     if continue_from == '*':
-        logger.info("Continuing from first (selected) relation")
+        logger.info("Continuing from first (selected) relation since '*' was selected")
     elif continue_from is not None:
         logger.info("Trying to fast forward to '%s'", continue_from)
         selected_relations = list(dropwhile(lambda relation: relation.identifier != continue_from, selected_relations))

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -986,7 +986,9 @@ def upgrade_data_warehouse(all_relations: List[RelationDescription], selector: T
     if not selected_relations:
         logger.warning("Found no relations matching: %s", selector)
         return
-    if continue_from is not None:
+    if continue_from == '*':
+        logger.info("Continuing from first (selected) relation")
+    elif continue_from is not None:
         logger.info("Trying to fast forward to '%s'", continue_from)
         selected_relations = list(dropwhile(lambda relation: relation.identifier != continue_from, selected_relations))
         if not selected_relations:

--- a/python/etl/render_template/templates/pizza_load_pipeline.json
+++ b/python/etl/render_template/templates/pizza_load_pipeline.json
@@ -98,7 +98,7 @@
             "name": "Arthur Upgrade (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --with-staging-schemas --continue-from #{mySelection} --prolix --prefix #{myEtlEnvironment} --max-concurrency #{myMaxConcurrency} --wlm-query-slots #{myWlmQuerySlots}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --with-staging-schemas --continue-from '#{mySelection}' --prolix --prefix #{myEtlEnvironment} --max-concurrency #{myMaxConcurrency} --wlm-query-slots #{myWlmQuerySlots}",
             "dependsOn": { "ref": "Bootstrap" }
         },
         {

--- a/python/etl/render_template/templates/pizza_load_pipeline.json
+++ b/python/etl/render_template/templates/pizza_load_pipeline.json
@@ -94,12 +94,20 @@
             "dependsOn": { "ref": "CopyBootstrap" }
         },
         {
-            "id": "ArthurLoad",
-            "name": "Arthur Load (EC2)",
+            "id": "ArthurUpgrade",
+            "name": "Arthur Upgrade (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix #{myEtlEnvironment}  --max-concurrency #{myMaxConcurrency} --wlm-query-slots #{myWlmQuerySlots}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --with-staging-schemas --continue-from #{mySelection} --prolix --prefix #{myEtlEnvironment} --max-concurrency #{myMaxConcurrency} --wlm-query-slots #{myWlmQuerySlots}",
             "dependsOn": { "ref": "Bootstrap" }
+        },
+        {
+            "id": "ArthurPromote",
+            "name": "Arthur Promote (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ promote_schemas --from-position staging --prolix",
+            "dependsOn": { "ref": "ArthurUpgrade" }
         },
         {
             "id": "PublishAndBackup",
@@ -107,7 +115,7 @@
             "type": "ShellCommandActivity",
             "parent": {"ref": "ShellCommandParent"},
             "command": "bash /tmp/redshift_etl/bin/sync_env.sh -y #{myS3Bucket} #{myEtlEnvironment} #{myEtlEnvironment}/current",
-            "dependsOn": { "ref": "ArthurLoad" }
+            "dependsOn": { "ref": "ArthurPromote" }
         },
         {
             "id": "ArthurUnload",
@@ -115,7 +123,7 @@
             "type": "ShellCommandActivity",
             "parent": {"ref": "ArthurCommandParent"},
             "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ unload --prolix --keep-going --prefix #{myEtlEnvironment}",
-            "dependsOn": {"ref": "ArthurLoad"}
+            "dependsOn": {"ref": "ArthurPromote"}
         },
         {
             "id": "PingCronutAfterEtl",
@@ -158,12 +166,21 @@
             "description": "UTC ISO formatted string giving the datetime to start the pipeline",
             "watermark": "2525-01-01T00:00:00",
             "helpText": "When should the pipeline's daily cadence start?"
-        }
+        },
+        {
+            "id": "mySelection",
+            "type": "String",
+            "optional": "false",
+            "description": "Relation name to continue from (or *) (for ArthurUpgrade)",
+            "watermark": "*",
+            "helpText": "Which table should we continue from?"
+        },
     ],
     "values": {
         "myS3Bucket": "data_lake_bucket",
         "myEtlEnvironment": "development",
         "myStartDateTime": "2525-01-01T00:00:00",
+        "mySelection": "*",
         "myMaxConcurrency": "4",
         "myWlmQuerySlots": "3"
     }

--- a/python/etl/render_template/templates/refresh_pipeline.json
+++ b/python/etl/render_template/templates/refresh_pipeline.json
@@ -188,16 +188,16 @@
             "type": "String",
             "optional": "false",
             "description": "Space separated list of arthur pattern globs (for ArthurLoad)",
-            "watermark": "stuff",
-            "helpText": "stuff"
+            "watermark": "*",
+            "helpText": "Which tables should be refreshed?"
         },
         {
             "id": "myCommaSeparatedSelection",
             "type": "String",
             "optional": "false",
             "description": "Comma separated list of arthur pattern globs (for ArthurExtract)",
-            "watermark": "stuff",
-            "helpText": "stuff"
+            "watermark": "*",
+            "helpText": "Which tables should be refreshed?"
         }
     ],
     "values": {

--- a/python/scripts/install_pizza_load_pipeline.sh
+++ b/python/scripts/install_pizza_load_pipeline.sh
@@ -16,6 +16,12 @@ fi
 
 set -e -u
 
+# Verify that there is a local configuration directory
+if [[ ! -d ./config ]]; then
+    echo "Failed to find './config' directory. Make sure you are in the directory with your data warehouse setup."
+    exit 1
+fi
+
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
 PROJ_ENVIRONMENT="$1"
 WLM_SLOTS="$2"
@@ -41,11 +47,10 @@ fi
 AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
 
 PIPELINE_NAME="ETL Pizza Loader Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
-
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
-arthur.py render_template --prefix "$PROJ_ENVIRONMENT" pizza_load_pipeline > "$PIPELINE_DEFINITION_FILE"
-
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
+
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" pizza_load_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 aws datapipeline create-pipeline \
     --unique-id pizza-etl-pipeline \

--- a/python/scripts/install_rebuild_pipeline.sh
+++ b/python/scripts/install_rebuild_pipeline.sh
@@ -8,6 +8,12 @@ fi
 
 set -e -u
 
+# Verify that there is a local configuration directory
+if [[ ! -d ./config ]]; then
+    echo "Failed to find './config' directory. Make sure you are in the directory with your data warehouse setup."
+    exit 1
+fi
+
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
 PROJ_ENVIRONMENT="$1"
 
@@ -33,11 +39,10 @@ fi
 AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
 
 PIPELINE_NAME="ETL Rebuild Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
-
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
-arthur.py render_template --prefix "$PROJ_ENVIRONMENT" rebuild_pipeline > "$PIPELINE_DEFINITION_FILE"
-
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
+
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" rebuild_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 aws datapipeline create-pipeline \
     --unique-id rebuild-etl-pipeline \

--- a/python/scripts/install_refresh_pipeline.sh
+++ b/python/scripts/install_refresh_pipeline.sh
@@ -9,6 +9,12 @@ fi
 
 set -e -u
 
+# Verify that there is a local configuration directory
+if [[ ! -d ./config ]]; then
+    echo "Failed to find './config' directory. Make sure you are in the directory with your data warehouse setup."
+    exit 1
+fi
+
 function join_by { local IFS="$1"; shift; echo "$*"; }
 
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
@@ -39,11 +45,10 @@ fi
 AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
 
 PIPELINE_NAME="ETL Refresh Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
-
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
-arthur.py render_template --prefix "$PROJ_ENVIRONMENT" refresh_pipeline > "$PIPELINE_DEFINITION_FILE"
-
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
+
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" refresh_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 aws datapipeline create-pipeline \
     --unique-id refresh-etl-pipeline \

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -13,6 +13,12 @@ fi
 
 set -e -u
 
+# Verify that there is a local configuration directory
+if [[ ! -d ./config ]]; then
+    echo "Failed to find './config' directory. Make sure you are in the directory with your data warehouse setup."
+    exit 1
+fi
+
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
 PROJ_ENVIRONMENT="${1:-$DEFAULT_PREFIX}"
 
@@ -45,9 +51,9 @@ fi
 AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
 
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
-arthur.py render_template --prefix "$PROJ_ENVIRONMENT" validation_pipeline > "$PIPELINE_DEFINITION_FILE"
-
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
+
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" validation_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 aws datapipeline create-pipeline \
     --unique-id validation_pipeline \

--- a/python/scripts/launch_emr_cluster.sh
+++ b/python/scripts/launch_emr_cluster.sh
@@ -110,17 +110,21 @@ set +x +v
 say "Your cluster is now running. All functions appear normal." || echo "Your cluster is now running. All functions appear normal."
 
 cat <<EOF
-# If you need to proxy into the cluster, use:
+# If you want to proxy into the cluster to enjoy port forwarding, use:
 
   aws emr socks --cluster-id "$CLUSTER_ID" --key-pair-file "<location of your key file>"
 
-# If you want to submit steps, use:
+# If you need to login into the master node, use:
+
+  aws emr ssh --cluster-id "$CLUSTER_ID" --key-pair-file "<location of your key file>"
+
+# If you want to submit steps, use (and remember to always pass in the prefix):
 
   arthur.py --submit "$CLUSTER_ID" [command] --prolix --prefix "$PROJ_ENVIRONMENT" [options ...]
 
-# To easily reference this cluster, user:
+# To easily reference this cluster, set the environment variable in your shell:
 
   export CLUSTER_ID="$CLUSTER_ID"
 
-# * Do not forget to shutdown the cluster when you no longer need it. *
+# * Do not forget to shutdown the cluster as soon as you no longer need it. *
 EOF

--- a/python/scripts/submit_arthur.sh
+++ b/python/scripts/submit_arthur.sh
@@ -4,6 +4,7 @@ set -e -u
 
 # Submit to a local Spark cluster.  (Submitting to an EMR cluster is done using steps.)
 # This will grab all the JAR files in the local jars directory.
+# N.B. Arthur will automatically use this script for extracting with Spark.
 
 # CAVEAT If you make changes here, be sure to re-install the package to make sure changes
 # propagate to the copy of this script in your path.


### PR DESCRIPTION
User visible changes:
* It is now possible to specify a relation for the pizza loader from which the loader will continue. This is for the use case when load fails during the ELT but we find that we can fix the issue and would now like to continue loading from the originally-failed relation.
* The implementation of the pizza loader is changed to using a "upgrade" and "promote" step instead of just "load".
* The install scripts for pipelines should be invoked from the directory where your data warehouse code lives.  The scripts now test for the './config' directory. The scripts are on your path in the virtual environment so that working in the directory with your data warehouse code should be normal anyways.