### PR TITLE
Update to Python 3.5

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,8 +82,8 @@ of the virtual environment.
 mkdir venv
 virtualenv --python=python3 venv
 source venv/bin/activate
-pip3 install --requirement ./requirements.txt --disable-pip-version-check
-pip3 install --requirement ./requirements-dev.txt --disable-pip-version-check
+pip3 install --requirement ./requirements.txt
+pip3 install --requirement ./requirements-dev.txt
 python3 setup.py develop
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,3 @@ jmespath~=0.9
 psycopg2~=2.6
 pep8>=1.7
 pgpasslib~=1.1
-mypy-lang~=0.4.6
-mypy~=0.501


### PR DESCRIPTION
User visible changes
* We now use Python 3.5 on the EC2 instances, including EMR.
* Note that a version of 3.5 or higher is required so that the `typing` library is available without having to install the `mypy` package.  So this version also drops `mypy` from requirements.
* The version of the PostgreSQL driver used to communicate with upstream databases was bumped to 9.5.