### PR TITLE
Hotfix - add mypy to requirements to avoid failing import of typing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ jmespath~=0.9
 psycopg2~=2.6
 pep8>=1.7
 pgpasslib~=1.1
+mypy-lang~=0.4.6
+mypy~=0.501

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.3.0",
+    version="1.3.1",
     author="Harry's Data Engineering and Contributors",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
This happened after playing with too many Python versions.  Our production uses 3.4 which doesn't have `typing`.  Next version of ETL moves to Python 3.5 which does have `typing`