### PR TITLE
Create topic and subscription in SNS using script

### DIFF
--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:etl-status-#{myEtlEnvironment}"
+            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-status_#{myEtlEnvironment}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:etl-page-#{myEtlEnvironment}",
+            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-page_#{myEtlEnvironment}",
             "subject": "ETL Rebuild Failure: #{myEtlEnvironment} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:etl-status-#{myEtlEnvironment}"
+            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-status_#{myEtlEnvironment}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:etl-page-#{myEtlEnvironment}",
+            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-page_#{myEtlEnvironment}",
             "subject": "ETL Rebuild Failure: #{myEtlEnvironment} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:etl-status-#{myEtlEnvironment}"
+            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-status_#{myEtlEnvironment}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:etl-page-#{myEtlEnvironment}",
+            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-page_#{myEtlEnvironment}",
             "subject": "ETL Refresh Failure: #{myEtlEnvironment}/current at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:etl-validation-#{myEtlEnvironment}"
+            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-validation_#{myEtlEnvironment}"
         },
         {
             "id": "SuccessNotification",

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Create a topic (if necessary) and then subscribe the user
+
+DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
+
+set -e -u
+
+# === Command line args ===
+
+show_usage_and_exit() {
+    echo "Usage: `basename $0` [<environment>] <email_address>"
+    echo "The environment defaults to \"$DEFAULT_PREFIX\"."
+    exit ${1-0}
+}
+
+while getopts ":h" opt; do
+  case $opt in
+    h)
+      show_usage_and_exit
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ $# -eq 1 ]]; then
+    PROJ_ENVIRONMENT="$DEFAULT_PREFIX"
+    NOTIFICATION_ENDPOINT="$1"
+elif [[ $# -eq 2 ]]; then
+    PROJ_ENVIRONMENT="$1"
+    NOTIFICATION_ENDPOINT="$2"
+else
+    show_usage_and_exit 1
+fi
+
+set -x
+
+# === Configuration ===
+
+STATUS_NAME="redshift-etl-status_$PROJ_ENVIRONMENT"
+PAGE_NAME="redshift-etl-page_$PROJ_ENVIRONMENT"
+VALIDATION_NAME="redshift-etl-validation_$PROJ_ENVIRONMENT"
+
+# ===  Create topic and subscription ===
+
+TOPIC_ARN_FILE="/tmp/topic_arn_${USER}$$.json"
+
+for TOPIC in "$STATUS_NAME" "$PAGE_NAME" "$VALIDATION_NAME"; do
+    aws sns create-topic --name "$TOPIC" | tee "$TOPIC_ARN_FILE"
+    TOPIC_ARN=`jq --raw-output < "$TOPIC_ARN_FILE" '.TopicArn'`
+    if [[ -z "$TOPIC_ARN" ]]; then
+        set +x
+        echo "Failed to find topic arn in output. Check your settings, including VPN etc."
+        exit 1
+    fi
+    aws sns subscribe --topic-arn "$TOPIC_ARN" --protocol email --notification-endpoint "$NOTIFICATION_ENDPOINT"
+done
+
+aws sns list-topics | jq --raw-output '.Topics[].TopicArn' | grep 'redshift-etl-[^_]*_tom'

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "python/scripts/launch_ec2_instance.sh",
         "python/scripts/launch_emr_cluster.sh",
         "python/scripts/re_run_partial_pipeline.py",
+        "python/scripts/sns_subscribe.sh",
         "python/scripts/submit_arthur.sh"
     ],
     entry_points={


### PR DESCRIPTION
Make it easier for users to create the SNS topics (and subscribe their email)  when they want to install pipelines under a new prefix.
```
sns_subscribe.sh production etl-engineers@example.com
```