### PR TITLE
Support easily multiple network ranges for VPC

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -93,7 +93,7 @@ Example:
 
 The data warehouse and EMR cluster will be in the "public" subnet.
 
-Region: `us-east-1b`
+Region: `us-east-1`
 IPv4 CIDR: `10.10.0.0/22`
 Routing Table:
 * local: `10.10.0.0/16`
@@ -106,7 +106,7 @@ Routing Table:
 
 Any Lambda instances will be running in the "private" subnet.
 
-Region: `us-east-1b`
+Region: `us-east-1`
 IPv4 CIDR: `10.10.8.0/22`
 Routing Table:
 * local: `10.10.0.0/16`

--- a/cloudformation/dw_vpc.yaml
+++ b/cloudformation/dw_vpc.yaml
@@ -17,14 +17,12 @@ Parameters:
         Description: (required) A bucket name where data is stored, likely using 'unload' for other applications
         Type: String
 
-    VpcCIDR:
-        Description: (optional) IP range in CIDR notation for this VPC
-        Type: String
-        Default: 10.10.0.0/16
-        MinLength: 9
-        MaxLength: 18
-        AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
-        ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
+    VpcNetworkSelection:
+        Description: (required) Second octect of the IP range (final IP range is 10.(selection).0.0/16),
+            e.g. 20 for production and 30 for development
+        Type: Number
+        MinValue: 0
+        MaxValue: 255
 
     PrimaryAvailabilityZone:
         Description: (optional) Availability zone for the subnets
@@ -32,24 +30,6 @@ Parameters:
         Default: us-east-1d
         # Choices are limited by the possible locations for the Redshift cluster.
         AllowedValues: ["us-east-1a", "us-east-1c", "us-east-1d"]
-
-    PublicSubnetCIDR:
-        Description: (optional) IP range in CIDR notation for the public subnet
-        Type: String
-        Default: 10.10.0.0/22
-        MinLength: 9
-        MaxLength: 18
-        AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
-        ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
-
-    PrivateSubnetCIDR:
-        Description: (optional) IP range in CIDR notation for the private subnet
-        Type: String
-        Default: 10.10.8.0/22
-        MinLength: 9
-        MaxLength: 18
-        AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
-        ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
 
     WhitelistCIDR1:
         Description: (recommended) First IP range in CIDR notation that can be used to SSH to EC2 instances
@@ -108,7 +88,7 @@ Resources:
     VPC:
         Type: "AWS::EC2::VPC"
         Properties:
-            CidrBlock: !Ref VpcCIDR
+            CidrBlock: !Sub "10.${VpcNetworkSelection}.0.0/16"
             EnableDnsSupport: true
             EnableDnsHostnames: true
             Tags:
@@ -133,7 +113,7 @@ Resources:
         Properties:
             VpcId: !Ref VPC
             AvailabilityZone: !Ref PrimaryAvailabilityZone
-            CidrBlock: !Ref PublicSubnetCIDR
+            CidrBlock: !Sub "10.${VpcNetworkSelection}.0.0/22"
             MapPublicIpOnLaunch: true
             Tags:
                 - Key: Name
@@ -144,7 +124,7 @@ Resources:
         Properties:
             VpcId: !Ref VPC
             AvailabilityZone: us-east-1b
-            CidrBlock: !Ref PrivateSubnetCIDR
+            CidrBlock: !Sub "10.${VpcNetworkSelection}.8.0/22"
             MapPublicIpOnLaunch: false
             Tags:
                 - Key: Name
@@ -676,22 +656,25 @@ Resources:
                     Version: "2012-10-17"
                     Statement:
                       -
-                        Sid: "ReadAccess"
+                        Sid: "ReadAccessBuckets"
                         Effect: "Allow"
                         Action:
-                          - "s3:GetBucket*"
                           - "s3:ListBucket*"
                         Resource:
-                          - !Sub "arn:aws:s3:::${ObjectStore}"
-                          - !Sub "arn:aws:s3:::${DataLake}"
+                          - !Sub "arn:aws:s3:::*"
+                      -
+                        Sid: "ReadAccessObjects"
+                        Effect: "Allow"
+                        Action:
+                          - "s3:GetObject"
+                        Resource:
+                          - !Sub "arn:aws:s3:::*/*"
                       -
                         Sid: "WriteAccess"
                         Effect: "Allow"
                         Action:
-                          - "s3:DeleteObject*"
-                          - "s3:GetObject*"
-                          - "s3:ListObject*"
-                          - "s3:PutObject*"
+                          - "s3:DeleteObject"
+                          - "s3:PutObject"
                         Resource:
                           - !Sub "arn:aws:s3:::${ObjectStore}/*"
                           - !Sub "arn:aws:s3:::${DataLake}/*"
@@ -725,7 +708,7 @@ Outputs:
             Name: !Sub "${AWS::StackName}::public-subnet-id"
 
     PrivateSubnet:
-        Description: A reference to the private subnet
+        Description: (VPC.private_subnet) A reference to the private subnet
         Value: !Ref PrivateSubnet
         Export:
             Name: !Sub "${AWS::StackName}::private-subnet-id"

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -247,6 +247,7 @@
                     "properties": {
                         "id": { "type": "string" },
                         "public_subnet": { "type": "string" },
+                        "private_subnet": { "type": "string" },
                         "whitelist_security_group": { "type": "string" },
                         "region": { "type": "string" },
                         "account": { "type": "string" }


### PR DESCRIPTION
Instead of specifying IP ranges in CIDR notation, simply pick a number between 0 and 255 and the CloudFormation template will figure out the rest.