### PR TITLE
Cleanup scripts for pipelines and deploys

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -93,12 +93,12 @@ Example:
 
 The data warehouse and EMR cluster will be in the "public" subnet.
 
-Region: `us-east-1`
-IPv4 CIDR: `10.10.0.0/22`
-Routing Table:
-* local: `10.10.0.0/16`
-* all: internet gateway
-* service endpoint for S3
+* Region: `us-east-1`
+* IPv4 CIDR: `10.10.0.0/22`
+* Routing Table:
+    * local: `10.10.0.0/16`
+    * all: internet gateway
+    * service endpoint for S3
 
 (The EMR cluster is "public" to make it easy to login from the office and debug if that's ever necessary.)
 
@@ -106,12 +106,12 @@ Routing Table:
 
 Any Lambda instances will be running in the "private" subnet.
 
-Region: `us-east-1`
-IPv4 CIDR: `10.10.8.0/22`
-Routing Table:
-* local: `10.10.0.0/16`
-* all: NAT
-* service endpoint for S3
+* Region: `us-east-1` (should always match public subnet)
+* IPv4 CIDR: `10.10.8.0/22`
+* Routing Table:
+    * local: `10.10.0.0/16`
+    * all: NAT
+    * service endpoint for S3
 
 ### Security groups
 

--- a/cloudformation/dw_vpc.yaml
+++ b/cloudformation/dw_vpc.yaml
@@ -123,7 +123,7 @@ Resources:
         Type: "AWS::EC2::Subnet"
         Properties:
             VpcId: !Ref VPC
-            AvailabilityZone: us-east-1b
+            AvailabilityZone: !Ref PrimaryAvailabilityZone
             CidrBlock: !Sub "10.${VpcNetworkSelection}.8.0/22"
             MapPublicIpOnLaunch: false
             Tags:
@@ -141,9 +141,6 @@ Resources:
         Properties:
             AllocationId: !GetAtt NatGatewayEIP.AllocationId
             SubnetId: !Ref PublicSubnet
-#            Tags:
-#                - Key: Name
-#                  Value: !Join [ "-", [ !Ref "AWS::StackName", "nat" ] ]
 
     PublicRouteTable:
         Type: AWS::EC2::RouteTable
@@ -695,6 +692,10 @@ Outputs:
         Export:
             Name: !Sub "${AWS::StackName}::vpc-id"
 
+    VpcRegion:
+        Description: (VPC.region) Name of the region
+        Value: !Ref "AWS::Region"
+
     DefaultAvailabilityZone:
         Description: A reference to the primary availability zone (used as default elsewhere)
         Value: !Ref PrimaryAvailabilityZone
@@ -752,6 +753,12 @@ Outputs:
         Value: !Ref ObjectStore
         Export:
             Name: !Sub "${AWS::StackName}::object-store"
+
+    DataLake:
+        Description: (data_lake.s3.bucket_name) Name of the bucket for the data lake
+        Value: !Ref DataLake
+        Export:
+            Name: !Sub "${AWS::StackName}::data-lake"
 
     RedshiftCopyCole:
         Description: (object_store.iam_role) ARN for the role created for Redshift to read from the object store

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -8,8 +8,8 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "DataPipelineDefaultResourceRole",
             "role": "DataPipelineDefaultRole",
-            "pipelineLogUri": "s3://#{myS3Bucket}/#{myEtlEnvironment}/logs/",
-            "region": "us-east-1",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/logs/",
+            "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },
         {
@@ -22,27 +22,27 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-status_#{myEtlEnvironment}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.s3.prefix}"
         },
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
             "parent": {"ref": "SNSParent"},
-            "subject": "ETL Rebuild Success: #{myEtlEnvironment} at #{node.@scheduledStartTime}",
+            "subject": "ETL Rebuild Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": {"ref": "SNSParent"},
-            "subject": "ETL Rebuild Failure: #{myEtlEnvironment} at #{node.@scheduledStartTime}",
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-page_#{myEtlEnvironment}",
-            "subject": "ETL Rebuild Failure: #{myEtlEnvironment} at #{node.@scheduledStartTime}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${object_store.s3.prefix}",
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
@@ -83,14 +83,14 @@
             "name": "Copy Bootstrap (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://#{myS3Bucket}/#{myEtlEnvironment}/bin/bootstrap.sh /tmp/bootstrap.sh"
+            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh /tmp/bootstrap.sh"
         },
         {
             "id": "Bootstrap",
             "name": "Bootstrap (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "bash /tmp/bootstrap.sh #{myS3Bucket} #{myEtlEnvironment}",
+            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}",
             "dependsOn": { "ref": "CopyBootstrap" }
         },
         {
@@ -98,7 +98,7 @@
             "name": "Arthur Upgrade (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --with-staging-schemas --continue-from '#{mySelection}' --prolix --prefix #{myEtlEnvironment}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --with-staging-schemas --continue-from '#{mySelection}' --prolix --prefix ${object_store.s3.prefix}",
             "dependsOn": { "ref": "Bootstrap" }
         },
         {
@@ -114,7 +114,7 @@
             "name": "Publish and Backup (EC2)",
             "type": "ShellCommandActivity",
             "parent": {"ref": "ShellCommandParent"},
-            "command": "bash /tmp/redshift_etl/bin/sync_env.sh -y #{myS3Bucket} #{myEtlEnvironment} #{myEtlEnvironment}/current",
+            "command": "bash /tmp/redshift_etl/bin/sync_env.sh -y ${object_store.s3.bucket_name} ${object_store.s3.prefix} ${object_store.s3.prefix}/current",
             "dependsOn": { "ref": "ArthurPromote" }
         },
         {
@@ -122,14 +122,14 @@
             "name": "Arthur Unload (EC2)",
             "type": "ShellCommandActivity",
             "parent": {"ref": "ArthurCommandParent"},
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ unload --prolix --keep-going --prefix #{myEtlEnvironment}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ unload --keep-going --prolix --prefix ${object_store.s3.prefix}",
             "dependsOn": {"ref": "ArthurPromote"}
         },
         {
             "id": "PingCronutAfterEtl",
             "name": "Ping Cronut After ETL (EC2)",
             "type": "ShellCommandActivity",
-            "parent": { "ref":"ShellCommandParent" },
+            "parent": { "ref": "ShellCommandParent" },
             "command": "bash /tmp/redshift_etl/bin/ping_cronut.sh PING_AFTER_ETL",
             "dependsOn": [
                 { "ref": "PublishAndBackup" },
@@ -143,22 +143,6 @@
         }
     ],
     "parameters": [
-        {
-            "id": "myS3Bucket",
-            "type": "String",
-            "optional": "false",
-            "description": "Name of S3 bucket",
-            "watermark": "data_lake_bucket",
-            "helpText": "Pick the name of the data lake."
-        },
-        {
-            "id": "myEtlEnvironment",
-            "type": "String",
-            "optional": "false",
-            "description": "Name of ETL environment",
-            "watermark": "production",
-            "helpText": "Pick the name such as 'production', 'development' or your user name."
-        },
         {
             "id": "myStartDateTime",
             "type": "String",
@@ -174,11 +158,9 @@
             "description": "Relation name to continue from (or *) (for ArthurUpgrade)",
             "watermark": "*",
             "helpText": "Which table should we continue from?"
-        },
+        }
     ],
     "values": {
-        "myS3Bucket": "data_lake_bucket",
-        "myEtlEnvironment": "development",
         "myStartDateTime": "2525-01-01T00:00:00",
         "mySelection": "*"
     }

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -8,8 +8,8 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "DataPipelineDefaultResourceRole",
             "role": "DataPipelineDefaultRole",
-            "pipelineLogUri": "s3://#{myS3Bucket}/#{myEtlEnvironment}/logs/",
-            "region": "us-east-1",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/logs/",
+            "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },
         {
@@ -22,34 +22,34 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-status_#{myEtlEnvironment}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.s3.prefix}"
         },
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
             "parent": {"ref": "SNSParent"},
-            "subject": "ETL Rebuild Success: #{myEtlEnvironment} at #{node.@scheduledStartTime}",
+            "subject": "ETL Rebuild Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": {"ref": "SNSParent"},
-            "subject": "ETL Rebuild Failure: #{myEtlEnvironment} at #{node.@scheduledStartTime}",
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-page_#{myEtlEnvironment}",
-            "subject": "ETL Rebuild Failure: #{myEtlEnvironment} at #{node.@scheduledStartTime}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${object_store.s3.prefix}",
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
-            "terminateAfter": "8 Hours"
+            "terminateAfter": "6 Hours"
         },
         {
             "id": "ETLCluster",
@@ -63,7 +63,7 @@
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [ "${resources.VPC.whitelist_security_group}" ],
-            "bootstrapAction": "s3://#{myS3Bucket}/#{myEtlEnvironment}/bin/bootstrap.sh,#{myS3Bucket},#{myEtlEnvironment}",
+            "bootstrapAction": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh,${object_store.s3.bucket_name},${object_store.s3.prefix}",
             "applications": [ "Spark", "Ganglia", "Zeppelin", "Sqoop" ],
             "configuration": []
         },
@@ -98,7 +98,7 @@
             "id": "EmrActivityUpstreamExtract",
             "name": "Arthur Extract (EMR Activity)",
             "type": "EmrActivity",
-            "step": "/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar,/tmp/redshift_etl/venv/bin/arthur.py,--config,/tmp/redshift_etl/config/,extract,--prolix,--prefix,#{myEtlEnvironment}",
+            "step": "/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar,/tmp/redshift_etl/venv/bin/arthur.py,--config,/tmp/redshift_etl/config/,extract,--prolix,--prefix,${object_store.s3.prefix}",
             "runsOn": { "ref": "ETLCluster" },
             "maximumRetries": "0"
         },
@@ -107,21 +107,21 @@
             "name": "Copy Bootstrap (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://#{myS3Bucket}/#{myEtlEnvironment}/bin/bootstrap.sh /tmp/bootstrap.sh"
+            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh /tmp/bootstrap.sh"
         },
         {
             "id": "Bootstrap",
             "name": "Bootstrap (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "bash /tmp/bootstrap.sh #{myS3Bucket} #{myEtlEnvironment}",
+            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}",
             "dependsOn": { "ref": "CopyBootstrap" }
         },
         {
             "id": "PingCronutAfterBootstrap",
             "name": "Ping Cronut After Bootstrap (EC2)",
             "type": "ShellCommandActivity",
-            "parent": { "ref":"ShellCommandParent" },
+            "parent": { "ref": "ShellCommandParent" },
             "command": "bash /tmp/redshift_etl/bin/ping_cronut.sh PING_AFTER_BOOTSTRAP",
             "dependsOn": { "ref": "Bootstrap" }
         },
@@ -130,17 +130,15 @@
             "name": "Arthur Load (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix #{myEtlEnvironment} --concurrent-extract",
-            "dependsOn": [
-                { "ref": "Bootstrap" }
-            ]
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix ${object_store.s3.prefix} --concurrent-extract",
+            "dependsOn": { "ref": "Bootstrap" }
         },
         {
             "id": "PublishAndBackup",
             "name": "Publish and Backup (EC2)",
             "type": "ShellCommandActivity",
             "parent": {"ref": "ShellCommandParent"},
-            "command": "bash /tmp/redshift_etl/bin/sync_env.sh -y #{myS3Bucket} #{myEtlEnvironment} #{myEtlEnvironment}/current",
+            "command": "bash /tmp/redshift_etl/bin/sync_env.sh -y ${object_store.s3.bucket_name} ${object_store.s3.prefix} ${object_store.s3.prefix}/current",
             "dependsOn": { "ref": "ArthurLoad" }
         },
         {
@@ -148,14 +146,14 @@
             "name": "Arthur Unload (EC2)",
             "type": "ShellCommandActivity",
             "parent": {"ref": "ArthurCommandParent"},
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ unload --prolix --keep-going --prefix #{myEtlEnvironment}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ unload --keep-going --prolix --prefix ${object_store.s3.prefix}",
             "dependsOn": {"ref": "ArthurLoad"}
         },
         {
             "id": "PingCronutAfterEtl",
             "name": "Ping Cronut After ETL (EC2)",
             "type": "ShellCommandActivity",
-            "parent": { "ref":"ShellCommandParent" },
+            "parent": { "ref": "ShellCommandParent" },
             "command": "bash /tmp/redshift_etl/bin/ping_cronut.sh PING_AFTER_ETL",
             "dependsOn": [
                 { "ref": "PublishAndBackup" },
@@ -169,22 +167,6 @@
         }
     ],
     "parameters": [
-        {
-            "id": "myS3Bucket",
-            "type": "String",
-            "optional": "false",
-            "description": "Name of S3 bucket",
-            "watermark": "data_lake_bucket",
-            "helpText": "Pick the name of the data lake."
-        },
-        {
-            "id": "myEtlEnvironment",
-            "type": "String",
-            "optional": "false",
-            "description": "Name of ETL environment",
-            "watermark": "production",
-            "helpText": "Pick the name such as 'production', 'development' or your user name."
-        },
         {
             "id": "myStartDateTime",
             "type": "String",
@@ -203,8 +185,6 @@
         }
     ],
     "values": {
-        "myS3Bucket": "data_lake_bucket",
-        "myEtlEnvironment": "development",
         "myStartDateTime": "2525-01-01T00:00:00",
         "myOccurrences": "1000"
     }

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -62,7 +62,10 @@
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
-            "additionalMasterSecurityGroupIds": [ "${resources.VPC.whitelist_security_group}" ],
+            "additionalMasterSecurityGroupIds": [
+                "${resources.EC2.public_security_group}",
+                "${resources.VPC.whitelist_security_group}"
+            ],
             "bootstrapAction": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh,${object_store.s3.bucket_name},${object_store.s3.prefix}",
             "applications": [ "Spark", "Ganglia", "Zeppelin", "Sqoop" ],
             "configuration": []

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -62,7 +62,10 @@
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
-            "additionalMasterSecurityGroupIds": [ "${resources.VPC.whitelist_security_group}" ],
+            "additionalMasterSecurityGroupIds": [
+                "${resources.EC2.public_security_group}",
+                "${resources.VPC.whitelist_security_group}"
+            ],
             "bootstrapAction": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/current/bin/bootstrap.sh,${object_store.s3.bucket_name},${object_store.s3.prefix}/current",
             "applications": [ "Spark", "Ganglia", "Zeppelin", "Sqoop" ],
             "configuration": []

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -8,8 +8,8 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "DataPipelineDefaultResourceRole",
             "role": "DataPipelineDefaultRole",
-            "pipelineLogUri": "s3://#{myS3Bucket}/#{myEtlEnvironment}/current/logs/",
-            "region": "us-east-1",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/current/logs/",
+            "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },
         {
@@ -22,27 +22,27 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-status_#{myEtlEnvironment}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.s3.prefix}"
         },
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
             "parent": {"ref": "SNSParent"},
-            "subject": "ETL Refresh Success: #{myEtlEnvironment}/current at #{node.@scheduledStartTime}",
+            "subject": "ETL Refresh Success: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": {"ref": "SNSParent"},
-            "subject": "ETL Refresh Failure: #{myEtlEnvironment}/current at #{node.@scheduledStartTime}",
+            "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-page_#{myEtlEnvironment}",
-            "subject": "ETL Refresh Failure: #{myEtlEnvironment}/current at #{node.@scheduledStartTime}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${object_store.s3.prefix}",
+            "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
@@ -63,7 +63,7 @@
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [ "${resources.VPC.whitelist_security_group}" ],
-            "bootstrapAction": "s3://#{myS3Bucket}/#{myEtlEnvironment}/current/bin/bootstrap.sh,#{myS3Bucket},#{myEtlEnvironment}/current",
+            "bootstrapAction": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/current/bin/bootstrap.sh,${object_store.s3.bucket_name},${object_store.s3.prefix}/current",
             "applications": [ "Spark", "Ganglia", "Zeppelin", "Sqoop" ],
             "configuration": []
         },
@@ -98,7 +98,7 @@
             "id": "EmrActivityUpstreamExtract",
             "name": "Arthur Extract (EMR Activity)",
             "type": "EmrActivity",
-            "step": "/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar,/tmp/redshift_etl/venv/bin/arthur.py,--config,/tmp/redshift_etl/config/,extract,--prolix,--prefix,#{myEtlEnvironment}/current,#{myCommaSeparatedSelection}",
+            "step": "/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar,/tmp/redshift_etl/venv/bin/arthur.py,--config,/tmp/redshift_etl/config/,extract,--prolix,--prefix,${object_store.s3.prefix}/current,#{myCommaSeparatedSelection}",
             "runsOn": { "ref": "ETLCluster" },
             "maximumRetries": "0"
         },
@@ -107,30 +107,30 @@
             "name": "Copy Bootstrap (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://#{myS3Bucket}/#{myEtlEnvironment}/current/bin/bootstrap.sh /tmp/bootstrap.sh"
+            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/current/bin/bootstrap.sh /tmp/bootstrap.sh"
         },
         {
             "id": "Bootstrap",
             "name": "Bootstrap (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "bash /tmp/bootstrap.sh #{myS3Bucket} #{myEtlEnvironment}/current",
+            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}/current",
             "dependsOn": { "ref": "CopyBootstrap" }
         },
         {
             "id": "PingCronutAfterBootstrap",
             "name": "Ping Cronut After Bootstrap (EC2)",
             "type": "ShellCommandActivity",
-            "parent": { "ref":"ShellCommandParent" },
+            "parent": { "ref": "ShellCommandParent" },
             "command": "bash /tmp/redshift_etl/bin/ping_cronut.sh PING_AFTER_BOOTSTRAP",
             "dependsOn": { "ref": "Bootstrap" }
         },
         {
-            "id": "ArthurLoad",
+            "id": "ArthurUpdate",
             "name": "Arthur Update (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ update --prolix --prefix #{myEtlEnvironment}/current #{mySelection}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ update --prolix --prefix ${object_store.s3.prefix}/current #{mySelection}",
             "dependsOn": [
                 { "ref": "Bootstrap" },
                 { "ref": "EmrActivityUpstreamExtract" }
@@ -140,9 +140,9 @@
             "id": "PingCronutAfterEtl",
             "name": "Ping Cronut After ETL (EC2)",
             "type": "ShellCommandActivity",
-            "parent": { "ref":"ShellCommandParent" },
+            "parent": { "ref": "ShellCommandParent" },
             "command": "bash /tmp/redshift_etl/bin/ping_cronut.sh PING_AFTER_ETL",
-            "dependsOn": { "ref": "ArthurLoad" },
+            "dependsOn": { "ref": "ArthurUpdate" },
             "onSuccess": { "ref": "SuccessNotification" },
             "onFail": [
                 { "ref": "FailureNotification" },
@@ -151,22 +151,6 @@
         }
     ],
     "parameters": [
-        {
-            "id": "myS3Bucket",
-            "type": "String",
-            "optional": "false",
-            "description": "Name of S3 bucket",
-            "watermark": "data_lake_bucket",
-            "helpText": "Pick the name of the data lake."
-        },
-        {
-            "id": "myEtlEnvironment",
-            "type": "String",
-            "optional": "false",
-            "description": "Name of ETL environment",
-            "watermark": "production",
-            "helpText": "Pick the name such as 'production', 'development' or your user name."
-        },
         {
             "id": "myStartDateTime",
             "type": "String",
@@ -187,7 +171,7 @@
             "id": "mySelection",
             "type": "String",
             "optional": "false",
-            "description": "Space separated list of arthur pattern globs (for ArthurLoad)",
+            "description": "Space separated list of arthur pattern globs (for ArthurUpdate)",
             "watermark": "*",
             "helpText": "Which tables should be refreshed?"
         },
@@ -201,8 +185,6 @@
         }
     ],
     "values": {
-        "myS3Bucket": "data_lake_bucket",
-        "myEtlEnvironment": "development",
         "myStartDateTime": "2525-01-01T00:00:00",
         "myOccurrences": "1000",
         "mySelection": "",

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -8,8 +8,8 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "DataPipelineDefaultResourceRole",
             "role": "DataPipelineDefaultRole",
-            "pipelineLogUri": "s3://#{myS3Bucket}/#{myEtlEnvironment}/logs/",
-            "region": "us-east-1",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/logs/",
+            "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },
         {
@@ -22,20 +22,20 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:us-east-1:${resources.VPC.account}:redshift-etl-validation_#{myEtlEnvironment}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-validation_${object_store.s3.prefix}"
         },
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
             "parent": {"ref": "SNSParent"},
-            "subject": "ETL Validation Success: #{myEtlEnvironment}/validation at #{node.@scheduledStartTime}",
+            "subject": "ETL Validation Success: ${object_store.s3.prefix}/validation at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": {"ref": "SNSParent"},
-            "subject": "ETL Validation Failure: #{myEtlEnvironment}/validation at #{node.@scheduledStartTime}",
+            "subject": "ETL Validation Failure: ${object_store.s3.prefix}/validation at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
@@ -65,87 +65,71 @@
         },
         {
             "id": "ShellCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"}
+            "parent": { "ref": "Ec2CommandGrandParent" }
         },
         {
             "id": "ArthurCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"},
+            "parent": { "ref": "Ec2CommandGrandParent" },
             "maximumRetries": "0"
         },
         {
             "id": "CopyStartupScripts",
             "name": "Copy Startup Scripts (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ShellCommandParent"},
-            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp --recursive --exclude '*' --include 'bootstrap.sh' --include 'sync_env.sh' s3://#{myS3Bucket}/#{myEtlEnvironment}/bin /tmp"
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp --recursive --exclude '*' --include 'bootstrap.sh' --include 'sync_env.sh' s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin /tmp"
         },
         {
             "id": "SyncEnvironment",
             "name": "Sync environments (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ShellCommandParent"},
-            "command": "bash /tmp/sync_env.sh -y #{myS3Bucket} #{myEtlEnvironment} #{myEtlEnvironment}/validation",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "bash /tmp/sync_env.sh -y ${object_store.s3.bucket_name} ${object_store.s3.prefix} ${object_store.s3.prefix}/validation",
             "dependsOn": { "ref": "CopyStartupScripts" }
         },
         {
             "id": "Bootstrap",
             "name": "Bootstrap (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ShellCommandParent"},
-            "command": "bash /tmp/bootstrap.sh #{myS3Bucket} #{myEtlEnvironment}/validation",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}/validation",
             "dependsOn": { "ref": "SyncEnvironment" }
         },
         {
             "id": "ArthurValidateUpstream",
             "name": "Validate Upstream (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ArthurCommandParent"},
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ validate --prolix --remote-files --prefix #{myEtlEnvironment}/validation --keep-going --skip-dependencies-check",
-            "dependsOn": {"ref": "Bootstrap"}
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ validate --prolix --remote-files --prefix ${object_store.s3.prefix}/validation --keep-going --skip-dependencies-check",
+            "dependsOn": { "ref": "Bootstrap" }
         },
         {
             "id": "ArthurInitialize",
             "name": "Initialize (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ArthurCommandParent"},
+            "parent": { "ref": "ArthurCommandParent" },
             "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ initialize --prolix",
-            "dependsOn": {"ref": "ArthurValidateUpstream"}
+            "dependsOn": { "ref": "ArthurValidateUpstream" }
         },
         {
             "id": "ArthurLoad",
             "name": "Load with skip copy (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ArthurCommandParent"},
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix #{myEtlEnvironment}/validation --skip-copy",
-            "dependsOn": {"ref": "ArthurInitialize"}
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix ${object_store.s3.prefix}/validation --skip-copy",
+            "dependsOn": { "ref": "ArthurInitialize" }
         },
         {
             "id": "ArthurValidateDependencies",
             "name": "Validate Dependencies (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ArthurCommandParent"},
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ validate --prolix --remote-files --prefix #{myEtlEnvironment}/validation --keep-going --skip-sources-check",
-            "dependsOn": {"ref": "ArthurLoad"},
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ validate --prolix --remote-files --prefix ${object_store.s3.prefix}/validation --keep-going --skip-sources-check",
+            "dependsOn": { "ref": "ArthurLoad" },
             "onSuccess": {"ref": "SuccessNotification"}
         }
     ],
     "parameters": [
-        {
-            "id": "myS3Bucket",
-            "type": "String",
-            "optional": "false",
-            "description": "Name of S3 bucket",
-            "watermark": "data_lake_bucket",
-            "helpText": "Pick the name of the data lake."
-        },
-        {
-            "id": "myEtlEnvironment",
-            "type": "String",
-            "optional": "false",
-            "description": "Name of ETL environment",
-            "watermark": "production",
-            "helpText": "Pick the name such as 'production', 'development' or your user name."
-        },
         {
             "id": "myStartDateTime",
             "type": "String",
@@ -164,8 +148,6 @@
         }
     ],
     "values": {
-        "myS3Bucket": "data_lake_bucket",
-        "myEtlEnvironment": "development",
         "myStartDateTime": "2525-01-01T00:00:00",
         "myOccurrences": "1000"
     }

--- a/python/scripts/install_refresh_pipeline.sh
+++ b/python/scripts/install_refresh_pipeline.sh
@@ -2,7 +2,7 @@
 
 if [[ $# -lt 4 || "$1" = "-h" ]]; then
     echo "Usage: `basename $0` <environment> <startdatetime> <occurrences> <source table selection> [<source table selection> ...]"
-    echo "      Start time should take the ISO8601 format like: `date -u +"%Y-%m-%dT%H:%M:%S"`"
+    echo "      Start time should be 'now' or take the ISO8601 format like: `date -u +"%Y-%m-%dT%H:%M:%S"`"
     echo "      Specify source tables using space-delimited arthur pattern globs."
     exit 0
 fi
@@ -10,8 +10,10 @@ fi
 set -e -u
 
 # Verify that there is a local configuration directory
-if [[ ! -d ./config ]]; then
-    echo "Failed to find './config' directory. Make sure you are in the directory with your data warehouse setup."
+DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
+if [[ ! -d "$DEFAULT_CONFIG" ]]; then
+    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
+    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
     exit 1
 fi
 
@@ -20,7 +22,11 @@ function join_by { local IFS="$1"; shift; echo "$*"; }
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
 PROJ_ENVIRONMENT="$1"
 
-START_DATE_TIME="$2"
+if [[ "$2" == "now" ]]; then
+    START_DATE_TIME="`date -u +'%Y-%m-%dT%H:%M:%S'`"
+else
+    START_DATE_TIME="$2"
+fi
 OCCURRENCES="$3"
 
 shift 3
@@ -36,22 +42,18 @@ fi
 
 set -x
 
-if [[ "$PROJ_ENVIRONMENT" =~ "production" ]]; then
-  ENV_NAME="production"
-else
-  ENV_NAME="development"
-fi
-# Note: key/value are lower-case keywords here.
-AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
+# Note: "key" and "value" are lower-case keywords here.
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=ETL"
 
 PIPELINE_NAME="ETL Refresh Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
+trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
 arthur.py render_template --prefix "$PROJ_ENVIRONMENT" refresh_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 aws datapipeline create-pipeline \
-    --unique-id refresh-etl-pipeline \
+    --unique-id dw-etl-refresh-pipeline \
     --name "$PIPELINE_NAME" \
     --tags $AWS_TAGS \
     | tee "$PIPELINE_ID_FILE"
@@ -67,8 +69,6 @@ fi
 aws datapipeline put-pipeline-definition \
     --pipeline-definition "file://$PIPELINE_DEFINITION_FILE" \
     --parameter-values \
-        myS3Bucket="$PROJ_BUCKET" \
-        myEtlEnvironment="$PROJ_ENVIRONMENT" \
         myStartDateTime="$START_DATE_TIME" \
         myOccurrences="$OCCURRENCES" \
         mySelection="$SELECTION" \

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -41,17 +41,16 @@ if ! GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD); then
 fi
 
 if [[ "$PROJ_ENVIRONMENT" =~ "production" ]]; then
-  ENV_NAME="production"
   PIPELINE_NAME="ETL Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 else
-  ENV_NAME="development"
   PIPELINE_NAME="Validation Pipeline ($USER:$GIT_BRANCH $PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 fi
-# Note: key/value are lower-case keywords here.
-AWS_TAGS="key=user:project,value=data-warehouse key=user:env,value=$ENV_NAME"
+# Note: "key" and "value" are lower-case keywords here.
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=ETL"
 
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER}_$$.json"
+trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
 arthur.py render_template --prefix "$PROJ_ENVIRONMENT" validation_pipeline > "$PIPELINE_DEFINITION_FILE"
 
@@ -72,8 +71,6 @@ fi
 aws datapipeline put-pipeline-definition \
     --pipeline-definition "file://${PIPELINE_DEFINITION_FILE}" \
     --parameter-values \
-        myS3Bucket="$PROJ_BUCKET" \
-        myEtlEnvironment="$PROJ_ENVIRONMENT" \
         myStartDateTime="$START_DATE_TIME" \
         myOccurrences="$OCCURRENCES" \
     --pipeline-id "$PIPELINE_ID"

--- a/python/scripts/launch_ec2_instance.sh
+++ b/python/scripts/launch_ec2_instance.sh
@@ -40,12 +40,7 @@ PROJ_ENVIRONMENT=$( arthur.py show_value --prefix "${1-$DEFAULT_PREFIX}" object_
 # === Derived configuration ===
 
 INSTANCE_NAME="Arthur (env=$PROJ_ENVIRONMENT\, user=$USER\, `date '+%s'`)"
-if [[ "$PROJ_ENVIRONMENT" =~ "production" ]]; then
-  ENV_NAME="production"
-else
-  ENV_NAME="development"
-fi
-AWS_TAGS="Key=user:project,Value=data-warehouse Key=user:env,Value=$ENV_NAME"
+AWS_TAGS="Key=user:project,Value=data-warehouse Key=user:sub-project,Value=ETL Key=Name,Value=$INSTANCE_NAME"
 
 # === Validate bucket and environment information (sanity check on args) ===
 
@@ -65,6 +60,7 @@ USER_DATA_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compa
 # ===  Start instance ===
 
 INSTANCE_ID_FILE="/tmp/instance_id_${USER}$$.json"
+trap "rm -f \"$INSTANCE_ID_FILE\"" EXIT
 
 aws ec2 run-instances --cli-input-json "$CLI_INPUT_JSON" --user-data "$USER_DATA_JSON" | tee "$INSTANCE_ID_FILE"
 
@@ -78,7 +74,7 @@ fi
 
 aws ec2 wait instance-exists --instance-ids "$INSTANCE_ID"
 aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
-aws ec2 create-tags --resources "$INSTANCE_ID" --tags "Key=Name,Value=$INSTANCE_NAME" "$AWS_TAGS"
+aws ec2 create-tags --resources "$INSTANCE_ID" --tags "$AWS_TAGS"
 
 PUBLIC_DNS_NAME=`aws ec2 describe-instances --instance-ids "$INSTANCE_ID" |
     jq --raw-output '.Reservations[0].Instances[0].PublicDnsName'`

--- a/python/scripts/launch_emr_cluster.sh
+++ b/python/scripts/launch_emr_cluster.sh
@@ -48,12 +48,7 @@ CLUSTER_REGION=$( arthur.py show_value resources.VPC.region )
 
 CLUSTER_LOGS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/logs/"
 CLUSTER_NAME="ETL Cluster ($PROJ_ENVIRONMENT, `date +'%Y-%m-%d %H:%M'`)"
-if [[ "$PROJ_ENVIRONMENT" =~ "production" ]]; then
-  ENV_NAME="production"
-else
-  ENV_NAME="development"
-fi
-AWS_TAGS="user:project=data-warehouse user:env=$ENV_NAME"
+AWS_TAGS="user:project=data-warehouse user:sub-project=ETL"
 
 # === Validate bucket and environment information (sanity check on args) ===
 
@@ -75,6 +70,7 @@ BOOTSTRAP_ACTIONS_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT"
 # ===  Start cluster ===
 
 CLUSTER_ID_FILE="/tmp/cluster_id_${USER}$$.json"
+trap "rm -f \"$CLUSTER_ID_FILE\"" EXIT
 
 aws emr create-cluster \
         --name "$CLUSTER_NAME" \

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -47,6 +47,7 @@ VALIDATION_NAME="redshift-etl-validation_$PROJ_ENVIRONMENT"
 # ===  Create topic and subscription ===
 
 TOPIC_ARN_FILE="/tmp/topic_arn_${USER}$$.json"
+trap "rm -f \"$TOPIC_ARN_FILE\"" EXIT
 
 for TOPIC in "$STATUS_NAME" "$PAGE_NAME" "$VALIDATION_NAME"; do
     aws sns create-topic --name "$TOPIC" | tee "$TOPIC_ARN_FILE"


### PR DESCRIPTION
User-visible changes
* Install scripts support `now` as the start time to make it easier to recover.
* Switch from Data Pipeline templates, like `#{myEtlEnvironment}` to Arthur templates, like `${object_store.s3.prefix}`
