### PR TITLE
Add terminate_backends command

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -15,7 +15,7 @@ _arthur_completion()
                   design auto_design bootstrap_sources bootstrap_transformations
                   sync validate explain ls
                   extract load upgrade update unload
-                  create_schemas promote_schemas
+                  create_schemas promote_schemas terminate_backends
                   show_downstream_dependents show_dependents show_upstream_dependencies
                   render_template show_value show_vars show_pipelines
                   selftest

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -315,7 +315,9 @@ def terminate_sessions_with_transaction_locks(cx, dry_run=False):
     stmt = """
         SELECT DISTINCT pid AS proc_pid
           FROM pg_catalog.svv_transactions AS st
-         WHERE txn_owner <> current_user AND st.relation IS NOT NULL
+          JOIN pg_catalog.pg_class AS pc ON st.relation = pc.oid
+          JOIN pg_catalog.pg_namespace AS pn ON pc.relnamespace = pn.oid
+         WHERE txn_owner <> current_user
          ORDER BY proc_pid
         """
     pids = etl.db.query(cx, stmt)

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -290,10 +290,10 @@ def create_new_user(config, new_user, group=None, add_user_schema=False, skip_us
 
 def list_transactions(cx):
     stmt = """
-        SELECT pid AS proc_pid, txn_owner, txn_start, pn.nspname || '.' || pc.relname AS table_name
+        SELECT pid AS proc_pid, txn_owner, txn_start, COALESCE(pn.nspname || '.' || pc.relname, 'Unknown') AS table_name
           FROM pg_catalog.svv_transactions AS st
-          JOIN pg_catalog.pg_class AS pc ON st.relation = pc.oid
-          JOIN pg_catalog.pg_namespace AS pn ON pc.relnamespace = pn.oid
+          LEFT JOIN pg_catalog.pg_class AS pc ON st.relation = pc.oid
+          LEFT JOIN pg_catalog.pg_namespace AS pn ON pc.relnamespace = pn.oid
          WHERE txn_owner <> current_user
          ORDER BY pid, txn_owner, txn_start, table_name
         """
@@ -315,8 +315,6 @@ def terminate_sessions_with_transaction_locks(cx, dry_run=False):
     stmt = """
         SELECT DISTINCT pid AS proc_pid
           FROM pg_catalog.svv_transactions AS st
-          JOIN pg_catalog.pg_class AS pc ON st.relation = pc.oid
-          JOIN pg_catalog.pg_namespace AS pn ON pc.relnamespace = pn.oid
          WHERE txn_owner <> current_user
          ORDER BY proc_pid
         """

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -15,10 +15,13 @@ create_user: Create new user.  Optionally add a personal schema in the database.
 
 Oddly enough, it is possible to skip the "create user" step but that comes in
 handy when you want to update the user's search path.
+
+This module also contains "user management" in terms of disconnecting their sessions.
 """
 
 import logging
 from contextlib import closing
+from itertools import groupby
 from typing import List
 
 import psycopg2
@@ -283,3 +286,51 @@ def create_new_user(config, new_user, group=None, add_user_schema=False, skip_us
             else:
                 logger.info("Setting search path for user '%s' to: %s", user.name, search_path)
                 etl.db.alter_search_path(conn, user.name, search_path)
+
+
+def list_transactions(cx):
+    stmt = """
+        SELECT pid AS proc_pid, txn_owner, txn_start, pn.nspname || '.' || pc.relname AS table_name
+          FROM pg_catalog.svv_transactions AS st
+          JOIN pg_catalog.pg_class AS pc ON st.relation = pc.oid
+          JOIN pg_catalog.pg_namespace AS pn ON pc.relnamespace = pn.oid
+         WHERE txn_owner <> current_user
+         ORDER BY pid, txn_owner, txn_start, table_name
+        """
+    tx_locks = etl.db.query(cx, stmt)
+    tx_info = []
+    for (proc_pid, txn_owner, txn_start), rows in groupby(tx_locks, lambda row: row[:3]):
+        table_names = ', '.join(row["table_name"] for row in rows)
+        logger.info("Transaction: pid = %d owner = %s start = %s tables = %s",
+                    proc_pid, txn_owner, txn_start, table_names)
+        tx_info.append((proc_pid, txn_owner, txn_start, table_names))
+
+    print("List of sessions that have locks on tables inside transactions:")
+    print("proc_pid", "txn_owner", "txn_start", "list of table names", sep=', ')
+    for proc_pid, txn_owner, txn_start, table_names in tx_info:
+        print(proc_pid, txn_owner, txn_start, table_names, sep=', ')
+
+
+def terminate_sessions_with_transaction_locks(cx, dry_run=False):
+    stmt = """
+        SELECT DISTINCT pid AS proc_pid
+          FROM pg_catalog.svv_transactions AS st
+         WHERE txn_owner <> current_user AND st.relation IS NOT NULL
+         ORDER BY proc_pid
+        """
+    pids = etl.db.query(cx, stmt)
+    for (pid,) in pids:
+        msg = "Terminate backend for session {:d} with transaction locks".format(pid)
+        term = "SELECT PG_TERMINATE_BACKEND({:d})".format(pid)
+        etl.db.run(cx, msg, term, dry_run=dry_run)
+
+
+def terminate_backends(dry_run=False):
+    """
+    Terminate backends that currently hold locks on tables.
+    """
+    dsn_admin = etl.config.get_dw_config().dsn_admin
+    with closing(etl.db.connection(dsn_admin, autocommit=True)) as conn:
+        etl.db.execute(conn, "SET query_group TO 'superuser'")
+        list_transactions(conn)
+        terminate_sessions_with_transaction_locks(conn, dry_run=dry_run)

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -364,18 +364,6 @@ def set_search_path(cx, schemas):
     execute(cx, """SET SEARCH_PATH = {}""".format(', '.join(schemas)))
 
 
-def list_connections(cx):
-    return query(cx, """SELECT datname, procpid, usesysid, usename
-                          FROM pg_catalog.pg_stat_activity""")
-
-
-def list_transactions(cx):
-    return query(cx, """SELECT t.*
-                             , c.relname
-                          FROM pg_catalog.svv_transactions t
-                          JOIN pg_catalog.pg_class c ON t.relation = c.OID""")
-
-
 # ---- SCHEMAS ----
 
 def select_schemas(cx, names) -> List[str]:

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -946,8 +946,7 @@ def load_data_warehouse(all_relations: List[RelationDescription], selector: Tabl
 
     dsn_etl = etl.config.get_dw_config().dsn_etl
     with closing(etl.db.connection(dsn_etl, autocommit=True)) as conn:
-        logger.info("Open connections:\n%s", etl.db.format_result(etl.db.list_connections(conn)))
-        logger.info("Open transactions:\n%s", etl.db.format_result(etl.db.list_transactions(conn)))
+        etl.data_warehouse.list_transactions(conn)
 
     create_schemas_for_rebuild(traversed_schemas, use_staging=use_staging, dry_run=dry_run)
     try:


### PR DESCRIPTION
Sometimes we encounter sessions that have transactions with locks that interfere with the ETL.
This command allows to terminate those.

@bhtucker @triplec1988 Should we make this part of the rebuild ETL?