### PR TITLE
Update upload script to use configuration files

### DIFF
--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -6,14 +6,31 @@ DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
 set -e
 
-if [[ $# -lt 1 || $# -gt 2 || $1 = "-h" ]]; then
-    echo "Usage: `basename $0` <bucket_name> [<target_env>]"
-    echo "    The <target_env> defaults to $DEFAULT_PREFIX."
+if [[ $# -gt 2 || "$1" = "-h" ]]; then
+    echo "Usage: `basename $0` [[<bucket_name>] <target_env>]"
+    echo "    The <target_env> defaults to \"$DEFAULT_PREFIX\"."
+    echo "    The <bucket_name> defaults to your object store setting."
+    echo "    If the bucket name is not specified, variable DATA_WAREHOUSE_CONFIG must be set."
     exit 0
 fi
 
-CLUSTER_BUCKET="$1"
-CLUSTER_TARGET_ENVIRONMENT="${2-$DEFAULT_PREFIX}"
+if [[ $# -lt 2 && -z "$DATA_WAREHOUSE_CONFIG" ]]; then
+    echo "You must set DATA_WAREHOUSE_CONFIG when not specifying the bucket name."
+    exit 1
+fi
+
+if [[ $# -eq 2 ]]; then
+    PROJ_BUCKET="$1"
+    PROJ_TARGET_ENVIRONMENT="$2"
+elif [[ $# -eq 1 ]]; then
+    echo "Finding bucket name in configuration..."
+    PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+    PROJ_TARGET_ENVIRONMENT="$1"
+else
+    echo "Finding bucket name and prefix in configuration..."
+    PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+    PROJ_TARGET_ENVIRONMENT=$( arthur.py show_value --prefix "$DEFAULT_PREFIX" object_store.s3.prefix )
+fi
 
 ask_to_confirm () {
     while true; do
@@ -36,16 +53,16 @@ if [[ ! -r ./setup.py ]]; then
     exit 2
 fi
 
-if ! aws s3 ls "s3://$CLUSTER_BUCKET/" > /dev/null; then
-    echo "Check whether the bucket \"$CLUSTER_BUCKET\" exists and you have access to it!"
+if ! aws s3 ls "s3://$PROJ_BUCKET/" > /dev/null; then
+    echo "Check whether the bucket \"$PROJ_BUCKET\" exists and you have access to it!"
     echo "(Hint: If you spelled the name correctly, is your VPN connected?)"
     exit 2
 fi
 
-if aws s3 ls "s3://$CLUSTER_BUCKET/$CLUSTER_TARGET_ENVIRONMENT/jars" > /dev/null; then
-    ask_to_confirm "Are you sure you want to overwrite '$CLUSTER_TARGET_ENVIRONMENT'?"
+if aws s3 ls "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/jars" > /dev/null; then
+    ask_to_confirm "Are you sure you want to overwrite 's3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT'?"
 else
-    ask_to_confirm "Are you sure you want to create '$CLUSTER_TARGET_ENVIRONMENT'?"
+    ask_to_confirm "Are you sure you want to create 's3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT'?"
 fi
 
 echo "Creating Python dist file, then uploading files (including configuration, excluding credentials) to S3"
@@ -71,10 +88,10 @@ python3 setup.py sdist
 LATEST_TAR_FILE=`ls -1t dist/redshift_etl*tar.gz | head -1`
 for FILE in requirements.txt "$LATEST_TAR_FILE"
 do
-    aws s3 cp "$FILE" "s3://$CLUSTER_BUCKET/$CLUSTER_TARGET_ENVIRONMENT/jars/"
+    aws s3 cp "$FILE" "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/jars/"
 done
 
-aws s3 sync --delete bin "s3://$CLUSTER_BUCKET/$CLUSTER_TARGET_ENVIRONMENT/bin"
+aws s3 sync --delete bin "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/bin"
 
 # Users who don't intend to use Spark may not have the jars directory.
 if [[ -d "jars" ]]; then
@@ -82,10 +99,10 @@ if [[ -d "jars" ]]; then
         --exclude "*" \
         --include postgresql-9.4.1208.jar \
         --include RedshiftJDBC41-1.2.1.1001.jar \
-        jars "s3://$CLUSTER_BUCKET/$CLUSTER_TARGET_ENVIRONMENT/jars"
+        jars "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/jars"
 fi
 
 set +x
 echo
-echo "# You should *now* run:"
-echo "arthur.py sync --deploy --prefix \"$CLUSTER_TARGET_ENVIRONMENT\""
+echo "# You should *now* run inside your warehouse repo directory:"
+echo "arthur.py sync --deploy --prefix \"$PROJ_TARGET_ENVIRONMENT\""


### PR DESCRIPTION
User visible changes:
* When using `upload_env.sh`, it is no longer necessary to specify the bucket if the environment variable `DATA_WAREHOUSE_CONFIG` is set. This makes uploading to buckets in different environments / accounts rather seamless.