### PR TITLE
Support / in prefix for SNS topics

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -116,6 +116,7 @@ def run_arg_as_command(my_name="arthur.py"):
             setattr(args, "bucket_name", etl.config.get_config_value("object_store.s3.bucket_name"))
             if hasattr(args, "prefix"):
                 etl.config.set_config_value("object_store.s3.prefix", args.prefix)
+                etl.config.set_config_value("object_store.sns_prefix", args.prefix.replace('/', '_'))
                 if getattr(args, "use_monitor"):
                     etl.monitor.set_environment(args.prefix)
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -116,7 +116,7 @@ def run_arg_as_command(my_name="arthur.py"):
             setattr(args, "bucket_name", etl.config.get_config_value("object_store.s3.bucket_name"))
             if hasattr(args, "prefix"):
                 etl.config.set_config_value("object_store.s3.prefix", args.prefix)
-                etl.config.set_config_value("object_store.sns_prefix", args.prefix.replace('/', '_'))
+                etl.config.set_config_value("resources.SNS.sns_suffix", args.prefix.replace('/', '_'))
                 if getattr(args, "use_monitor"):
                     etl.monitor.set_environment(args.prefix)
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -116,7 +116,7 @@ def run_arg_as_command(my_name="arthur.py"):
             setattr(args, "bucket_name", etl.config.get_config_value("object_store.s3.bucket_name"))
             if hasattr(args, "prefix"):
                 etl.config.set_config_value("object_store.s3.prefix", args.prefix)
-                etl.config.set_config_value("resources.SNS.sns_suffix", args.prefix.replace('/', '_'))
+                etl.config.set_safe_config_value("safe_environment", args.prefix)
                 if getattr(args, "use_monitor"):
                     etl.monitor.set_environment(args.prefix)
 
@@ -998,7 +998,7 @@ class EventsQueryCommand(SubCommand):
         add_standard_arguments(parser, ["pattern", "prefix"])
 
     def callback(self, args, config):
-        etl.monitor.query_for(args.pattern, args.prefix)
+        etl.monitor.query_for(args.pattern)
 
 
 class SelfTestCommand(SubCommand):

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -11,6 +11,7 @@ import logging
 import logging.config
 import os
 import os.path
+import re
 import sys
 from collections import OrderedDict
 from functools import lru_cache
@@ -75,6 +76,13 @@ def set_config_value(name: str, value: str) -> None:
     """
     if _mapped_config is not None:
         _mapped_config.setdefault(name, value)
+
+
+def set_safe_config_value(name: str, value: str) -> None:
+    """
+    Replace "unsafe" characters with '-' and set configuration value.
+    """
+    set_config_value(name, '-'.join(re.findall('[a-zA-Z0-9_.-]+', value)))
 
 
 def get_config_map() -> Dict[str, str]:

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -23,7 +23,7 @@
     "etl_events": {
         # Send ETL events to DynamoDB table
         "dynamodb": {
-            "table_prefix": "redshift-etl-events",
+            "table_prefix": "dw-etl-events",
             "capacity": 3,
             "region": "us-east-1"
         # },

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -274,8 +274,7 @@ class DynamoDBStorage(PayloadDispatcher):
     """
 
     def __init__(self, table_name, capacity, region_name):
-        # We need to make sure here that the table name is valid for DynamoDb.
-        self.table_name = '-'.join(re.findall('[a-zA-Z0-9_.-]+', table_name))
+        self.table_name = table_name
         self.initial_capacity = capacity
         self.region_name = region_name
         # Avoid default sessions and have one table reference per thread
@@ -549,7 +548,8 @@ def set_environment(environment):
     MonitorPayload.dispatchers.append(memory)
 
     if etl.config.get_config_value("etl_events.dynamodb.table_prefix") is not None:
-        table_name = etl.config.get_config_value("etl_events.dynamodb.table_prefix") + '_' + environment
+        table_name = '_'.join((etl.config.get_config_value("etl_events.dynamodb.table_prefix"),
+                               etl.config.get_config_value("safe_environment")))
         ddb = DynamoDBStorage(table_name,
                               etl.config.get_config_value("etl_events.dynamodb.capacity"),
                               etl.config.get_config_value("etl_events.dynamodb.region"))
@@ -561,9 +561,10 @@ def set_environment(environment):
         MonitorPayload.dispatchers.append(rel)
 
 
-def query_for(target_list, environment):
+def query_for(target_list):
     logger.warning("This is a bit experimental (good day) and temperamental (bad day)")
-    table_name = etl.config.get_config_value("etl_events.dynamodb.table_prefix") + '_' + environment
+    table_name = '_'.join((etl.config.get_config_value("etl_events.dynamodb.table_prefix"),
+                           etl.config.get_config_value("safe_environment")))
     ddb = DynamoDBStorage(table_name,
                           etl.config.get_config_value("etl_events.dynamodb.capacity"),
                           etl.config.get_config_value("etl_events.dynamodb.region"))

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.sns_prefix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${resources.SNS.sns_suffix}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${object_store.s3.prefix}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${resources.SNS.sns_suffix}",
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.s3.prefix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.sns_prefix}"
         },
         {
             "id": "SuccessNotification",

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${resources.SNS.sns_suffix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-status_${safe_environment}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${resources.SNS.sns_suffix}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-page_${safe_environment}",
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.sns_prefix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${resources.SNS.sns_suffix}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${object_store.s3.prefix}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${resources.SNS.sns_suffix}",
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.s3.prefix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.sns_prefix}"
         },
         {
             "id": "SuccessNotification",

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${resources.SNS.sns_suffix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-status_${safe_environment}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${resources.SNS.sns_suffix}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-page_${safe_environment}",
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.sns_prefix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${resources.SNS.sns_suffix}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${object_store.s3.prefix}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${resources.SNS.sns_suffix",
             "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.s3.prefix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${object_store.sns_prefix}"
         },
         {
             "id": "SuccessNotification",

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-status_${resources.SNS.sns_suffix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-status_${safe_environment}"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-page_${resources.SNS.sns_suffix",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-page_${safe_environment}",
             "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-validation_${object_store.s3.prefix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-validation_${object_store.sns_prefix}"
         },
         {
             "id": "SuccessNotification",

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-validation_${object_store.sns_prefix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-validation_${resources.SNS.sns_suffix}"
         },
         {
             "id": "SuccessNotification",

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:redshift-etl-validation_${resources.SNS.sns_suffix}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-validation_${safe_environment}"
         },
         {
             "id": "SuccessNotification",

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -40,10 +40,10 @@ set -x
 
 # === Configuration ===
 
-SNS_SUFFIX=${PROJ_ENVIRONMENT//\//_}
-STATUS_NAME="redshift-etl-status_$SNS_SUFFIX"
-PAGE_NAME="redshift-etl-page_$SNS_SUFFIX"
-VALIDATION_NAME="redshift-etl-validation_$SNS_SUFFIX"
+SNS_SUFFIX=$( arthur.py show_value safe_environment --prefix $PROJ_ENVIRONMENT )
+STATUS_NAME="dw-etl-status_$SNS_SUFFIX"
+PAGE_NAME="dw-etl-page_$SNS_SUFFIX"
+VALIDATION_NAME="dw-etl-validation_$SNS_SUFFIX"
 
 # ===  Create topic and subscription ===
 
@@ -64,4 +64,4 @@ done
 set +x
 echo
 echo "List of subscriptions related to $PROJ_ENVIRONMENT"
-aws sns list-topics | jq --raw-output '.Topics[].TopicArn' | grep "redshift-etl-[^_]*_$PROJ_ENVIRONMENT"
+aws sns list-topics | jq --raw-output '.Topics[].TopicArn' | grep "dw-etl-[^_]*_$PROJ_ENVIRONMENT"

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -40,10 +40,10 @@ set -x
 
 # === Configuration ===
 
-SNS_PREFIX=${PROJ_ENVIRONMENT//\//_}
-STATUS_NAME="redshift-etl-status_$SNS_PREFIX"
-PAGE_NAME="redshift-etl-page_$SNS_PREFIX"
-VALIDATION_NAME="redshift-etl-validation_$SNS_PREFIX"
+SNS_SUFFIX=${PROJ_ENVIRONMENT//\//_}
+STATUS_NAME="redshift-etl-status_$SNS_SUFFIX"
+PAGE_NAME="redshift-etl-page_$SNS_SUFFIX"
+VALIDATION_NAME="redshift-etl-validation_$SNS_SUFFIX"
 
 # ===  Create topic and subscription ===
 

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -40,9 +40,10 @@ set -x
 
 # === Configuration ===
 
-STATUS_NAME="redshift-etl-status_$PROJ_ENVIRONMENT"
-PAGE_NAME="redshift-etl-page_$PROJ_ENVIRONMENT"
-VALIDATION_NAME="redshift-etl-validation_$PROJ_ENVIRONMENT"
+SNS_PREFIX=${PROJ_ENVIRONMENT//\//_}
+STATUS_NAME="redshift-etl-status_$SNS_PREFIX"
+PAGE_NAME="redshift-etl-page_$SNS_PREFIX"
+VALIDATION_NAME="redshift-etl-validation_$SNS_PREFIX"
 
 # ===  Create topic and subscription ===
 


### PR DESCRIPTION
Allow for `/` in prefix names when installing pipelines.

We add an attribute `sns_prefix` to the object store, which is the same as `s3.prefix` but with `/` replaced with `_`. Then we make sure to reference that attribute in all pipeline templates.

Do the same thing when creating SNS topics in `sns_subscribe.sh`.