### PR TITLE
Name resources consistently dw-etl-{env type}-{prefix}

### DIFF
--- a/cloudformation/dw_vpc.yaml
+++ b/cloudformation/dw_vpc.yaml
@@ -262,7 +262,7 @@ Resources:
                             "dynamodb:TagResource",
                             "dynamodb:UntagResource"
                         ],
-                        "Resource": !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/dw-etl-events_*"
+                        "Resource": !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/dw-etl-*"
                   }
                 ]
             }
@@ -753,7 +753,7 @@ Resources:
                             Action:
                                 - "dynamodb:Describe*"
                                 - "dynamodb:Scan"
-                            Resource: "arn:aws:dynamodb:*:*:table/dw-etl-events_*"
+                            Resource: "arn:aws:dynamodb:*:*:table/dw-etl-*"
 
 
 Outputs:

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -118,7 +118,7 @@ def run_arg_as_command(my_name="arthur.py"):
                 etl.config.set_config_value("object_store.s3.prefix", args.prefix)
                 # Create name used as prefix for resources, like DynamoDB tables or SNS topics
                 base_env = etl.config.get_config_value("resources.VPC.name").replace("dw-vpc-", "dw-etl-", 1)
-                etl.config.set_safe_config_value("safe_environment", "{}-{}".format(base_env, args.prefix))
+                etl.config.set_safe_config_value("resource_prefix", "{}-{}".format(base_env, args.prefix))
                 if getattr(args, "use_monitor"):
                     etl.monitor.start_monitors(args.prefix)
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -116,9 +116,11 @@ def run_arg_as_command(my_name="arthur.py"):
             setattr(args, "bucket_name", etl.config.get_config_value("object_store.s3.bucket_name"))
             if hasattr(args, "prefix"):
                 etl.config.set_config_value("object_store.s3.prefix", args.prefix)
-                etl.config.set_safe_config_value("safe_environment", args.prefix)
+                # Create name used as prefix for resources, like DynamoDB tables or SNS topics
+                base_env = etl.config.get_config_value("resources.VPC.name").replace("dw-vpc-", "dw-etl-", 1)
+                etl.config.set_safe_config_value("safe_environment", "{}-{}".format(base_env, args.prefix))
                 if getattr(args, "use_monitor"):
-                    etl.monitor.set_environment(args.prefix)
+                    etl.monitor.start_monitors(args.prefix)
 
             dw_config = etl.config.get_dw_config()
             if isinstance(getattr(args, "pattern", None), etl.names.TableSelector):

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -81,6 +81,11 @@ def set_config_value(name: str, value: str) -> None:
 def set_safe_config_value(name: str, value: str) -> None:
     """
     Replace "unsafe" characters with '-' and set configuration value.
+
+    >>> etl.config._mapped_config = {}
+    >>> set_safe_config_value("test_value", "something/unsafe")
+    >>> get_config_value("test_value")
+    'something-unsafe'
     """
     set_config_value(name, '-'.join(re.findall('[a-zA-Z0-9_.-]+', value)))
 

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -21,13 +21,9 @@
     },
     # Logging of the ETL into events tables
     "etl_events": {
-        # Send ETL events to DynamoDB table
-        "dynamodb": {
-            "table_prefix": "dw-etl-events",
-            "capacity": 3,
-            # FIXME this should use the region in the settings of the VPC
-            "region": "us-east-1"
-        }
+        "enabled": True,  # required to be enabled for concurrent extract/load
+        "read_capacity": 3,
+        "write_capacity": 3
     },
     # Type information from source (PostgreSQL) to target (Redshift)
     "type_maps": {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -225,13 +225,14 @@
                 "VPC": {
                     "type": "object",
                     "properties": {
+                        "region": { "type": "string" },
+                        "account": { "type": "string" },
+                        "name": { "type": "string" },
                         "public_subnet": { "type": "string" },
                         "private_subnet": { "type": "string" },
-                        "whitelist_security_group": { "type": "string" },
-                        "region": { "type": "string" },
-                        "account": { "type": "string" }
+                        "whitelist_security_group": { "type": "string" }
                     },
-                    "required": [ "public_subnet", "whitelist_security_group", "region", "account" ],
+                    "required": [ "region", "account", "name", "public_subnet", "whitelist_security_group" ],
                     "additionalProperties": false
                 },
                 "EC2": {
@@ -305,26 +306,11 @@
         "etl_events": {
             "type": "object",
             "properties": {
-                "dynamodb": {
-                    "type": "object",
-                    "properties": {
-                        "table_prefix": { "type": "string" },
-                        "capacity": { "type": "integer" },
-                        "region": { "type": "string" }
-                    },
-                    "required": [ "table_prefix", "capacity", "region" ],
-                    "additionalProperties": false
-                },
-                "postgresql": {
-                    "type": "object",
-                    "properties": {
-                        "table_prefix": { "type": "string" },
-                        "write_access": { "type": "string" }
-                    },
-                    "required": [ "table_prefix", "write_access" ],
-                    "additionalProperties": false
-                }
+                "enabled": { "type": "boolean" },
+                "read_capacity": { "type": "integer" },
+                "write_capacity": { "type": "integer" }
             },
+            "required": [ "enabled", "read_capacity", "write_capacity" ],
             "additionalProperties": false
         }
     },

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -508,7 +508,7 @@ def start_monitors(environment):
     MonitorPayload.dispatchers.append(memory)
 
     if etl.config.get_config_value("etl_events.enabled"):
-        table_name = "{}-{}".format(etl.config.get_config_value("safe_environment"), "events")
+        table_name = "{}-{}".format(etl.config.get_config_value("resource_prefix"), "events")
         ddb = DynamoDBStorage(table_name,
                               etl.config.get_config_value("etl_events.read_capacity"),
                               etl.config.get_config_value("etl_events.write_capacity"),
@@ -521,7 +521,7 @@ def start_monitors(environment):
 def query_for(target_list):
     logger.warning("This is a bit experimental (good day) and temperamental (bad day)")
     # TODO refactor with start_monitors
-    table_name = "{}-{}".format(etl.config.get_config_value("safe_environment"), "events")
+    table_name = "{}-{}".format(etl.config.get_config_value("resource_prefix"), "events")
     ddb = DynamoDBStorage(table_name,
                           etl.config.get_config_value("etl_events.read_capacity"),
                           etl.config.get_config_value("etl_events.write_capacity"),

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -13,7 +13,6 @@ import logging
 import os
 import queue
 import random
-import re
 import socketserver
 import sys
 import threading
@@ -23,7 +22,6 @@ import urllib.parse
 import uuid
 from calendar import timegm
 from collections import Counter, OrderedDict
-from contextlib import closing
 from copy import deepcopy
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -273,9 +271,10 @@ class DynamoDBStorage(PayloadDispatcher):
     Note the table is created if it doesn't already exist when class is instantiated.
     """
 
-    def __init__(self, table_name, capacity, region_name):
+    def __init__(self, table_name, read_capacity, write_capacity, region_name):
         self.table_name = table_name
-        self.initial_capacity = capacity
+        self.initial_read_capacity = read_capacity
+        self.initial_write_capacity = write_capacity
         self.region_name = region_name
         # Avoid default sessions and have one table reference per thread
         self._thread_local_table = threading.local()
@@ -309,8 +308,8 @@ class DynamoDBStorage(PayloadDispatcher):
                     {'AttributeName': 'target', 'AttributeType': 'S'},
                     {'AttributeName': 'timestamp', 'AttributeType': 'N'}
                 ],
-                ProvisionedThroughput={'ReadCapacityUnits': self.initial_capacity,
-                                       'WriteCapacityUnits': self.initial_capacity}
+                ProvisionedThroughput={'ReadCapacityUnits': self.initial_read_capacity,
+                                       'WriteCapacityUnits': self.initial_write_capacity}
             )
             status = table.table_status
         if status != "ACTIVE":
@@ -350,45 +349,6 @@ class DynamoDBStorage(PayloadDispatcher):
                 self.store(payload, _retry=False)
             else:
                 raise
-
-
-class RelationalStorage(PayloadDispatcher):
-    """
-    Store ETL events in a PostgreSQL table.
-
-    Note the table is created if it doesn't already exist when class is instantiated.
-    """
-
-    def __init__(self, table_name, write_access):
-        self.table_name = table_name
-        write_value = etl.config.env.get(write_access)
-        self.dsn = etl.db.parse_connection_string(write_value)
-        logger.info("Creating table '%s' (unless it already exists)", table_name)
-        with closing(etl.db.connection(self.dsn)) as conn:
-            etl.db.execute(conn, """
-                CREATE TABLE IF NOT EXISTS "{0.table_name}" (
-                    environment CHARACTER VARYING(255),
-                    etl_id      CHARACTER VARYING(255) NOT NULL,
-                    target      CHARACTER VARYING(255) NOT NULL,
-                    step        CHARACTER VARYING(255) NOT NULL,
-                    monitor_id  CHARACTER VARYING(16) NOT NULL,
-                    event       CHARACTER VARYING(255) NOT NULL,
-                    "timestamp" TIMESTAMP WITHOUT TIME ZONE NOT NULL,
-                    payload     JSONB NOT NULL
-                )""".format(self))
-            conn.commit()
-
-    def store(self, payload):
-        data = {key: payload[key] for key in ["environment", "etl_id", "target", "step", "monitor_id", "event"]}
-        data["timestamp"] = payload["timestamp"].isoformat(' ')
-        data["payload"] = json.dumps(payload, sort_keys=True, cls=FancyJsonEncoder)
-
-        with closing(etl.db.connection(self.dsn, autocommit=True)) as conn:
-            with conn.cursor() as cursor:
-                quoted_column_names = ", ".join('"{}"'.format(column) for column in data)
-                column_values = tuple(data.values())
-                cursor.execute('INSERT INTO "{0.table_name}" ({1}) VALUES %s'.format(self, quoted_column_names),
-                               (column_values,))
 
 
 class _ThreadingSimpleServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
@@ -542,32 +502,30 @@ class InsertTraceKey(logging.Filter):
         return True
 
 
-def set_environment(environment):
+def start_monitors(environment):
     Monitor.environment = environment
     memory = MemoryStorage()
     MonitorPayload.dispatchers.append(memory)
 
-    if etl.config.get_config_value("etl_events.dynamodb.table_prefix") is not None:
-        table_name = '_'.join((etl.config.get_config_value("etl_events.dynamodb.table_prefix"),
-                               etl.config.get_config_value("safe_environment")))
+    if etl.config.get_config_value("etl_events.enabled"):
+        table_name = "{}-{}".format(etl.config.get_config_value("safe_environment"), "events")
         ddb = DynamoDBStorage(table_name,
-                              etl.config.get_config_value("etl_events.dynamodb.capacity"),
-                              etl.config.get_config_value("etl_events.dynamodb.region"))
+                              etl.config.get_config_value("etl_events.read_capacity"),
+                              etl.config.get_config_value("etl_events.write_capacity"),
+                              etl.config.get_config_value("resources.VPC.region"))
         MonitorPayload.dispatchers.append(ddb)
-    if etl.config.get_config_value("etl_events.postgresql.table_prefix") is not None:
-        table_name = etl.config.get_config_value("etl_events.postgresql.table_prefix") + '_' + environment
-        rel = RelationalStorage(table_name,
-                                etl.config.get_config_value("etl_events.postgresql.write_access"))
-        MonitorPayload.dispatchers.append(rel)
+    else:
+        logger.warning("Writing events to a DynamoDB table is disabled in settings.")
 
 
 def query_for(target_list):
     logger.warning("This is a bit experimental (good day) and temperamental (bad day)")
-    table_name = '_'.join((etl.config.get_config_value("etl_events.dynamodb.table_prefix"),
-                           etl.config.get_config_value("safe_environment")))
+    # TODO refactor with start_monitors
+    table_name = "{}-{}".format(etl.config.get_config_value("safe_environment"), "events")
     ddb = DynamoDBStorage(table_name,
-                          etl.config.get_config_value("etl_events.dynamodb.capacity"),
-                          etl.config.get_config_value("etl_events.dynamodb.region"))
+                          etl.config.get_config_value("etl_events.read_capacity"),
+                          etl.config.get_config_value("etl_events.write_capacity"),
+                          etl.config.get_config_value("resources.VPC.region"))
     table = ddb._get_table()
 
     recent_cutoff = datetime.utcnow() - timedelta(days=5)

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-status"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-status"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-page",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-status_${safe_environment}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-status"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-page_${safe_environment}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-page",
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-status"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-status"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-page",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-status_${safe_environment}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-status"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-page_${safe_environment}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-page",
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-status_${safe_environment}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-status"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-page_${safe_environment}",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-page",
             "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-status"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-status"
         },
         {
             "id": "SuccessNotification",
@@ -41,7 +41,7 @@
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-page",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
             "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-validation"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-validation"
         },
         {
             "id": "SuccessNotification",

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -22,7 +22,7 @@
         },
         {
             "id": "SNSParent",
-            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:dw-etl-validation_${safe_environment}"
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${safe_environment}-validation"
         },
         {
             "id": "SuccessNotification",

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -40,10 +40,10 @@ set -x
 
 # === Configuration ===
 
-SNS_SUFFIX=$( arthur.py show_value safe_environment --prefix $PROJ_ENVIRONMENT )
-STATUS_NAME="dw-etl-status_$SNS_SUFFIX"
-PAGE_NAME="dw-etl-page_$SNS_SUFFIX"
-VALIDATION_NAME="dw-etl-validation_$SNS_SUFFIX"
+ENV_PREFIX=$( arthur.py show_value safe_environment --prefix "$PROJ_ENVIRONMENT" )
+STATUS_NAME="$ENV_PREFIX-status"
+PAGE_NAME="$ENV_PREFIX-page"
+VALIDATION_NAME="$ENV_PREFIX-validation"
 
 # ===  Create topic and subscription ===
 
@@ -63,5 +63,5 @@ done
 
 set +x
 echo
-echo "List of subscriptions related to $PROJ_ENVIRONMENT"
-aws sns list-topics | jq --raw-output '.Topics[].TopicArn' | grep "dw-etl-[^_]*_$PROJ_ENVIRONMENT"
+echo "List of subscriptions related to $PROJ_ENVIRONMENT:"
+aws sns list-topics | jq --raw-output '.Topics[].TopicArn' | grep "$ENV_PREFIX"

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -40,7 +40,7 @@ set -x
 
 # === Configuration ===
 
-ENV_PREFIX=$( arthur.py show_value safe_environment --prefix "$PROJ_ENVIRONMENT" )
+ENV_PREFIX=$( arthur.py show_value resource_prefix --prefix "$PROJ_ENVIRONMENT" )
 STATUS_NAME="$ENV_PREFIX-status"
 PAGE_NAME="$ENV_PREFIX-page"
 VALIDATION_NAME="$ENV_PREFIX-validation"


### PR DESCRIPTION
User-visible changes:
* Resources like SNS topics and DynamoDB tables are now named `dw-etl-{env type}-{prefix}-{...}` where "env type" comes from the VPC (a value like `dev` or `prod`), "prefix" is the environment as usual, and the suffix depends on the topic of table
* Users will have to re-subscribe to the new topics

Other changes:
* Support for storing events in PostgreSQL is dropped since it has neither been tested or used recently.