### PR TITLE
Load (= create) relation even during failed concurrent extract

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -98,6 +98,7 @@ if [[ "$RUNNING_LOCAL" = "no" ]]; then
     TMP_DOCUMENT="$PROJ_TEMP/document"
     trap "rm -f '$TMP_DOCUMENT'" EXIT
     curl --silent --show-error http://169.254.169.254/latest/dynamic/instance-identity/document | tee "$TMP_DOCUMENT"
+    echo
     INSTANCE_ID=`jq -r ".instanceId" "$TMP_DOCUMENT"`
     REGION=`jq -r ".region" "$TMP_DOCUMENT"`
     JOB_FLOW_ID=$( aws ec2 describe-tags --region "$REGION" \


### PR DESCRIPTION
Bug fix:
* Failed to create tables during load when their concurrent extract failed.
    * Load promises to create all tables and set permissions and then leaves tables empty when there was an error during extract (sources) or somewhere along the way (transformations)
    * This means that tables like our delta tables will be empty on failure.