### PR TITLE
Add milliseconds in prolix logging format

### DIFF
--- a/log_processing/README.md
+++ b/log_processing/README.md
@@ -1,11 +1,12 @@
 # Overview
 
 The goal of the log processing is to make the logs from Arthur ETLs
-available in Kibana (via Elasticsearch) in order to have dashboards
+available in Kibana (via an Elasticsearch Service) in order to have dashboards
 for some key metrics of the ETL, like
     * Top N sources that take the most time to extract
     * Top N relations that take the most time to load
     * Number of warnings or errors
+and to just more quickly get to the error message from validation pipelines.
 
 ## Setup and Requirements
 
@@ -15,12 +16,13 @@ You have to have an Elasticsearch sercie running.
 For more information about Elasticsearch in AWS, see [Getting Started Guide](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-gsg.html).
 See the cloudformation directory for an example setup.
 
-You will have to use the configure option to store the endpoint address in the
-parameter store.
+The `config_log` utility is used to store the endpoint address in the parameter store.
+
+See https://aws.amazon.com/blogs/security/how-to-control-access-to-your-amazon-elasticsearch-service-domain/
 
 ### Lambda Permissions
 
-To use the lambda function to automatically upload to ES any log files to show up in S3,
+To use the lambda function to automatically upload to ES any log files that show up in S3,
 you will have to create a new role to use with the lambda.
 
 The role must have these permissions:
@@ -33,7 +35,7 @@ TODO Create role automatically, `temp-log-parser`, add to config
 
 ## Installation
 
-This code uses Python 3. See the [toplevel README](../README.md) for installation instructions.
+This code uses Python 3. See the [toplevel INSTALL](../INSTALL.md) for general installation instructions.
 
 In order to run this code locally or to upload it as a lambda function, you have to have a
 virtual environment setup:
@@ -65,17 +67,16 @@ Examples:
 search_log ERROR examples
 # local files
 search_log FD1B9A50D12C41C3 ../arthur.log*
-# remote files (specified by prefix)
-search_log 'finished successfully' s3://example-bucket/logs/
+# remote files
+search_log 'finished successfully' s3://example-bucket/logs/example/StdError.gzip
 ```
 
 ### Configure endpoints
 
-XXX todo
-
 Need to pass in the "environment type" which comes from the VPC, like `dev`.
 Sets endpoint for env and also for bucket (so that lambda can use it).
 
+TODO -- currently there is only set (which also gets)
 ```shell
 config_log set_endpoint dev "your endpoint:443"
 config_log get_endpoint dev
@@ -85,7 +86,8 @@ config_log get_endpoint dev
 
 To leverage your Elasticsearch service domain, have the log records indexed.
 
-Need to pass in the "environment type" which comes from the VPC, like `dev`.
+Need to pass in the "environment type" which comes from the VPC, like `dev`,
+so that the endpoint address can be looked up in the parameter store.
 
 Example:
 ```shell
@@ -93,13 +95,13 @@ Example:
 upload_log dev examples
 # local files
 upload_log dev ../arthur.log
-# remote files (specified by prefix)
-upload_log dev s3://example/logs/df-pipeline-id
+# remote files
+upload_log dev s3://example/logs/df-pipeline-id/component/instance/attempt/StdError.gzip
 ```
 
 ### Deleting older indices
 
-XXX todo
+XXX TODO
 Should be called at least once a week.
 
 ```shell
@@ -132,4 +134,3 @@ add the log records to an ES domain.
 Set a trigger to have an S3 `PUT` call the Lambda function ("object created")
 
 
-See https://aws.amazon.com/blogs/security/how-to-control-access-to-your-amazon-elasticsearch-service-domain/

--- a/log_processing/README.md
+++ b/log_processing/README.md
@@ -76,9 +76,8 @@ search_log 'finished successfully' s3://example-bucket/logs/example/StdError.gzi
 Need to pass in the "environment type" which comes from the VPC, like `dev`.
 Sets endpoint for env and also for bucket (so that lambda can use it).
 
-TODO -- currently there is only set (which also gets)
 ```shell
-config_log set_endpoint dev "your endpoint:443"
+config_log set_endpoint dev "your bucket" "your endpoint:443"
 config_log get_endpoint dev
 ```
 
@@ -101,10 +100,8 @@ upload_log dev s3://example/logs/df-pipeline-id/component/instance/attempt/StdEr
 
 ### Deleting older indices
 
-XXX TODO
-Should be called at least once a week.
-
 ```shell
+config_log put_index_template dev
 config_log list_indices dev
 config_log delete_old_indices dev
 ```

--- a/log_processing/etl_log_processing/config.py
+++ b/log_processing/etl_log_processing/config.py
@@ -2,6 +2,7 @@
 Access to shared settings and managing indices
 """
 
+import argparse
 import sys
 import time
 import datetime
@@ -24,6 +25,8 @@ def log_index(date=None):
     # Smallest supported granularity is a day
     if date is None:
         instant = datetime.date.today()
+    elif isinstance(date, datetime.date):
+        instant = date
     else:
         instant = datetime.datetime.strptime(date, "%Y-%m-%d").date()
     return instant.strftime(LOG_INDEX_PATTERN.replace("-*", "-%Y-%W"))
@@ -109,7 +112,9 @@ def put_index_template(client):
         "template": LOG_INDEX_PATTERN,
         "version": version,
         "settings": {
-            "index.mapper.dynamic": False
+            "index.mapper.dynamic": False,
+            "number_of_shards": 2,
+            "number_of_replicas": 1
         },
         "mappings": {
             LOG_DOC_TYPE: parse.LogParser.index_fields()
@@ -119,30 +124,84 @@ def put_index_template(client):
     client.indices.put_template(template_id, body)
 
 
-def get_indices(client):
+def get_current_indices(client):
     print("Looking for indices matching {}".format(LOG_INDEX_PATTERN))
     response = client.indices.get(index=LOG_INDEX_PATTERN, allow_no_indices=True)
-    for index in sorted(response):
-        print(response[index]['settings']['index'])
+    names = [response[index]["settings"]["index"]["provided_name"] for index in response]
+    return sorted(names)
+
+
+def get_active_indices():
+    today = datetime.datetime.utcnow()
+    names = [log_index(today - datetime.timedelta(days=days)) for days in range(0, 380)]
+    return sorted(names)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Configure log processing")
+    subparsers = parser.add_subparsers()
+    # Retrieve current configuration
+    get_config_parser = subparsers.add_parser("get_config", help="get configuration values")
+    get_config_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
+    get_config_parser.set_defaults(func=sub_get_config)
+    # Set new configuration
+    set_config_parser = subparsers.add_parser("set_config", help="set configuration values")
+    set_config_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
+    set_config_parser.add_argument("bucket_name", help="name of S3 bucket with log files")
+    set_config_parser.add_argument("endpoint", help="endpoint for Elasticsearch service (host:port)")
+    set_config_parser.set_defaults(func=sub_set_config)
+    # Upload (new) index template
+    put_index_template_parser = subparsers.add_parser("put_index_template", help="upload (new) index template")
+    put_index_template_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
+    put_index_template_parser.set_defaults(func=sub_put_index_template)
+    # Get list of current indices matching our pattern
+    get_indices_parser = subparsers.add_parser("get_indices", help="get current indices")
+    get_indices_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
+    get_indices_parser.set_defaults(func=sub_get_indices)
+    # Delete indices for records older than a year
+    delete_stale_indices_parser = subparsers.add_parser("delete_stale_indices", help="delete older indices")
+    delete_stale_indices_parser.add_argument("env_type", help="environment type (like 'dev' or 'prod')")
+    delete_stale_indices_parser.set_defaults(func=sub_delete_stale_indices)
+    return parser
+
+
+def sub_get_config(args):
+    host, port = get_es_endpoint(env_type=args.env_type)
+    print("Found ES domain at '{}:{}'".format(host, port))
+
+
+def sub_set_config(args):
+    set_es_endpoint(args.env_type, args.bucket_name, args.endpoint)
+
+
+def sub_put_index_template(args):
+    host, port = get_es_endpoint(env_type=args.env_type)
+    es = connect_to_es(host, port, use_auth=False)
+    put_index_template(es)
+
+
+def sub_get_indices(args):
+    host, port = get_es_endpoint(env_type=args.env_type)
+    es = connect_to_es(host, port, use_auth=False)
+    current_names = get_current_indices(es)
+    active_names = frozenset(get_active_indices())
+    for name in current_names:
+        if name in active_names:
+            print("   ", name)
+        else:
+            print("** ", name)
+    if frozenset(current_names).difference(active_names):
+        print("Indices marked '**' should be deleted")
+
+
+def sub_delete_stale_indices(args):
+    raise NotImplementedError("left to the reader as an exercise")
 
 
 def main():
-    if len(sys.argv) != 4:
-        print("Usage: {} env_type bucket_name endpoint")
-        exit(1)
-    prg_name, env_type, bucket_name, endpoint = sys.argv
-
-    # TODO Split these out into subcommands!
-
-    set_es_endpoint(env_type, bucket_name, endpoint)
-    host, port = get_es_endpoint(env_type=env_type)
-    print("Found ES domain at '{}:{}'".format(host, port))
-
-    es = connect_to_es(host, port, use_auth=False)
-    put_index_template(es)
-    get_indices(es)
-
-    # TODO Delete old indices
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/log_processing/etl_log_processing/parse.py
+++ b/log_processing/etl_log_processing/parse.py
@@ -39,6 +39,7 @@ _INDEX_FIELDS = {
         "datetime": {
             "properties": {
                 "epoch_time": {"type": "long"},  # "format": "epoch_millis"
+                "date": {"type": "date", "format": "strict_date"},   # used to select index
                 "year": {"type": "integer"},
                 "month": {"type": "integer"},
                 "day": {"type": "integer"},
@@ -156,6 +157,7 @@ class LogRecord(collections.UserDict):
             "timestamp": timestamp.isoformat(),  # Drops milliseconds if value is 0.
             "datetime": {
                 "epoch_time": calendar.timegm(timestamp.timetuple()) * 1000 + timestamp.microsecond // 1000,
+                "date": timestamp.date().isoformat(),
                 "year": timestamp.year,
                 "month": timestamp.month,
                 "day": timestamp.day,
@@ -277,6 +279,8 @@ class LogParser:
     def split_log_lines(self, lines):
         """
         Split the log lines into records.
+
+        An exception is raised if no records are found at all.
         """
         record = None
         for match in self._log_line_re.finditer(lines):
@@ -297,6 +301,9 @@ class LogParser:
                 record.message += trailing_lines
                 record.end_pos += len(trailing_lines)
             yield record
+
+        if record is None:
+            raise ValueError("found no records")
 
 
 def create_example_records():

--- a/log_processing/setup.py
+++ b/log_processing/setup.py
@@ -10,10 +10,10 @@ setup(
     packages=find_packages(),
     entry_points={
         "console_scripts": [
-            "show_log_examples= etl_log_processing.parse:main",
+            "show_log_examples = etl_log_processing.parse:main",
             "search_log = etl_log_processing.compile:main",
-            "upload_log = etl_log_processing.upload:main",
-            "config_log = etl_log_processing.config:main"
+            "config_log = etl_log_processing.config:main",
+            "upload_log = etl_log_processing.upload:main"
         ]
     }
 )

--- a/log_processing/setup.py
+++ b/log_processing/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="etl_log_processing",
-    version="1.1.0",
+    version="1.2.0",
     author="Harry's Data Engineering and Contributors",
     license="MIT",
     url="https://github.com/harrystech/arthur-redshift-etl",

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -126,7 +126,7 @@ def run_arg_as_command(my_name="arthur.py"):
             if isinstance(getattr(args, "pattern", None), etl.names.TableSelector):
                 args.pattern.base_schemas = [s.name for s in dw_config.schemas]
 
-            # TODO Remove dw_config and let subcommands handle it!
+            # TODO Remove dw_config and let sub-commands handle it!
             args.func(args, dw_config)
 
 
@@ -408,7 +408,7 @@ class SubCommand:
 
 class MonitoredSubCommand(SubCommand):
     """
-    A subcommand that will also use monitors to update some event table
+    A sub-command that will also use monitors to update some event table
     """
     def add_to_parser(self, parent_parser) -> argparse.ArgumentParser:
         parser = super().add_to_parser(parent_parser)

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -133,7 +133,7 @@ def configure_logging(full_format: bool=False, log_level: str=None) -> None:
     """
     config = load_json('logging.json')
     if full_format:
-        config["formatters"]["console"]["format"] = config["formatters"]["file"]["format"]
+        config["formatters"]["console"] = dict(config["formatters"]["file"])
         config["handlers"]["console"]["level"] = logging.DEBUG
     elif log_level:
         config["handlers"]["console"]["level"] = log_level

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 setup(
     name="redshift_etl",
     version="1.5.0",
-    author="Harry's Data Engineering and Contributors",
+    author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",
     keywords="redshift postgresql ETL ELT extract transform load",


### PR DESCRIPTION
When choosing `--prolix` for logging, the milliseconds were missing in the timestamp. (So log lines that happened in the same second appeared out of order in ES searches.)