### PR TITLE
Enable "description" field for users

### DIFF
--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -20,6 +20,7 @@
             "type": "object",
             "properties": {
                 "name": { "$ref": "#/definitions/identifier" },
+                "description": { "type": "string" },
                 "group": { "$ref": "#/definitions/identifier" },
                 "schema": { "$ref": "#/definitions/identifier" }
             },


### PR DESCRIPTION
Allows to add a "description" for system users, like for a BI tool `looker` user.