### PR TITLE
Add visibility into running ETLs by "tailing" events

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -18,6 +18,7 @@ _arthur_completion()
                   create_schemas promote_schemas terminate_sessions
                   show_downstream_dependents show_dependents show_upstream_dependencies
                   render_template show_value show_vars settings show_pipelines
+                  query_events
                   selftest
                   --submit --config"
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )

--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -18,7 +18,7 @@ _arthur_completion()
                   create_schemas promote_schemas terminate_sessions
                   show_downstream_dependents show_dependents show_upstream_dependencies
                   render_template show_value show_vars settings show_pipelines
-                  query_events
+                  query_events tail_events
                   selftest
                   --submit --config"
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )

--- a/python/etl/assets/index.css
+++ b/python/etl/assets/index.css
@@ -33,7 +33,7 @@ table {
 }
 
 th, td {
-    border: 1px solid darkgray;
+    border: 2px solid darkgray;
     text-align: left;
     padding: 8px;
 }

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -859,8 +859,10 @@ class ListFilesCommand(SubCommand):
 
     def __init__(self):
         super().__init__("ls",
-                         "list files in S3",
-                         "List files in the S3 bucket and starting with prefix by source, table, and file type.")
+                         "list files in local directory or in S3",
+                         "List files in local directory or in the S3 bucket and starting with prefix by"
+                         " source, table, and file type."
+                         " (If sorting by timestamp, only print filename and timestamp.)")
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern", "prefix", "scheme"])
@@ -1009,7 +1011,7 @@ class ShowPipelinesCommand(SubCommand):
     def __init__(self):
         super().__init__("show_pipelines",
                          "show installed pipelines",
-                         "Show additional information about currently installed pipelines.")
+                         "Show information about currently installed pipelines.")
 
     def add_arguments(self, parser):
         parser.add_argument("selection", help="pick pipelines to show", nargs="*")

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -26,7 +26,7 @@ import yaml
 import etl.config.dw
 import etl.monitor
 from etl.config.dw import DataWarehouseConfig
-from etl.errors import InvalidArgumentError, SchemaInvalidError, SchemaValidationError
+from etl.errors import ETLRuntimeError, InvalidArgumentError, SchemaInvalidError, SchemaValidationError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -241,7 +241,7 @@ def load_config(config_files: Sequence[str], default_file: str="default_settings
 
     # Need to load at least the defaults and some installation specific file:
     if count_settings < 2:
-        raise RuntimeError("Failed to find enough configuration files (need at least default and local config)")
+        raise ETLRuntimeError("Failed to find enough configuration files (need at least default and local config)")
 
     validate_with_schema(settings, "settings.schema")
 

--- a/python/etl/config/env.py
+++ b/python/etl/config/env.py
@@ -10,9 +10,9 @@ def get(name: str, default: Union[str, None]=None) -> str:
     """
     value = os.environ.get(name, default)
     if value is None:
-        raise KeyError('Environment variable "%s" not set' % name)
+        raise KeyError('environment variable "%s" not set' % name)
     if not value:
-        raise ValueError('Environment variable "%s" is empty' % name)
+        raise ValueError('environment variable "%s" is empty' % name)
     return value
 
 

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -24,6 +24,7 @@ import psycopg2.extras
 import psycopg2.pool
 import pgpasslib
 
+import etl.text
 from etl.errors import ETLRuntimeError
 from etl.timer import Timer
 
@@ -238,27 +239,16 @@ def run(cx, message, stmt, args=(), return_result=False, dry_run=False):
         return execute(cx, stmt, args=args, return_result=return_result)
 
 
-def format_result(dict_rows) -> str:
-    """
-    Take result from query() and pretty-format it into one string, ready for print or log.
-    """
-    keys = list(dict_rows[0].keys())
-    content = [keys]  # header
-    for row in dict_rows:
-        content.append([
-            str(row[k]).strip() for k in keys
-        ])
-    return '\n'.join([', '.join(c) for c in content])
-
-
-def print_result(header, dict_rows) -> None:
+def print_result(title, dict_rows) -> None:
     """
     Print query result
     """
-    print(header)
+    print(title)
     if dict_rows:
-        print(format_result(dict_rows))
-    print("({:d} rows)".format(len(dict_rows)))
+        keys = list(dict_rows[0].keys())
+    else:
+        keys = []
+    print(etl.text.format_lines([[row[key] for key in keys] for row in dict_rows], header_row=keys))
 
 
 def explain(cx, stmt, args=()):

--- a/python/etl/extract/sqoop.py
+++ b/python/etl/extract/sqoop.py
@@ -2,12 +2,10 @@ import logging
 import os.path
 import shlex
 import subprocess
-from contextlib import closing
 from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional
 
 import etl.config
-import etl.monitor
 import etl.db
 import etl.s3
 from etl.config.dw import DataWarehouseSchema

--- a/python/etl/file_sets.py
+++ b/python/etl/file_sets.py
@@ -18,13 +18,13 @@ For CTAS or views, the directory after 'schemas' is the name of the schema in th
 configuration.  The 'source_schema_name' is only used for sorting.
 """
 
-from datetime import datetime
 import logging
-from itertools import groupby
-from operator import attrgetter
 import os
 import os.path
 import re
+from datetime import datetime
+from itertools import groupby
+from operator import attrgetter
 
 import etl.config
 import etl.s3
@@ -96,7 +96,7 @@ class TableFileSet:
         elif self.scheme == "file":
             return filename
         else:
-            raise RuntimeError("illegal scheme in file set")
+            raise ETLSystemError("illegal scheme in file set")
 
     def stat(self, filename):
         """
@@ -107,7 +107,7 @@ class TableFileSet:
         elif self.scheme == "file":
             return local_file_stat(filename)
         else:
-            raise RuntimeError("illegal scheme in file set")
+            raise ETLSystemError("illegal scheme in file set")
 
     @property
     def source_name(self):

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -208,9 +208,9 @@ class LoadableRelation:
         Build a list of "loadable" relations
         """
         dsn_etl = etl.config.get_dw_config().dsn_etl
-        dbname = dsn_etl["database"]
-        base_index = {"name": dbname, "current": 0, "final": len(relations)}
-        base_destination = {"name": dbname}
+        database = dsn_etl["database"]
+        base_index = {"name": database, "current": 0, "final": len(relations)}
+        base_destination = {"name": database}
 
         loadable = []
         for i, relation in enumerate(relations):
@@ -659,7 +659,7 @@ def create_source_tables_when_ready(relations: List[LoadableRelation], max_concu
 
     for dispatcher in etl.monitor.MonitorPayload.dispatchers:
         if isinstance(dispatcher, etl.monitor.DynamoDBStorage):
-            table = dispatcher._get_table()  # Note, not thread-safe, so we can only have one poller
+            table = dispatcher.get_table()  # Note, not thread-safe, so we can only have one poller
 
     def poll_worker():
         """

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -79,7 +79,7 @@ class MetaMonitor(type):
     @property
     def environment(cls):
         if cls._environment is None:
-            raise ValueError("Value of 'environment' is None")
+            raise ValueError("value of 'environment' is None")
         return cls._environment
 
     @environment.setter
@@ -134,7 +134,7 @@ class Monitor(metaclass=MetaMonitor):
     >>> Monitor.environment
     Traceback (most recent call last):
         ...
-    ValueError: Value of 'environment' is None
+    ValueError: value of 'environment' is None
     >>> Monitor.environment = 'saturn'
     >>> Monitor.environment
     'saturn'

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -179,14 +179,14 @@ class TableName:
         "Table 'public.users' contains users"
         >>> "Oops: {:y}".format(pu)
         Traceback (most recent call last):
-        ValueError: Unknown format code 'y' for TableName
+        ValueError: unknown format code 'y' for TableName
         """
         if (not code) or (code == 's'):
             return str(self)
         elif code == 'x':
             return "'{:s}'".format(self.identifier)
         else:
-            raise ValueError("Unknown format code '{}' for {}".format(code, self.__class__.__name__))
+            raise ValueError("unknown format code '{}' for {}".format(code, self.__class__.__name__))
 
     def __eq__(self, other: object):
         if isinstance(other, TableName):

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -202,7 +202,7 @@ class TableName:
         Order two table names, case-insensitive. (Used by sort.)
 
         >>> ta = TableName("Iowa", "Cedar Rapids")
-        >>> tb = TableName("Iowa", "Desmoines")
+        >>> tb = TableName("Iowa", "Davenport")
         >>> ta < tb
         True
         """
@@ -295,7 +295,7 @@ class TempTableName(TableName):
         >>> str(temp)
         '"#public$speakeasy"'
 
-        >>> too_long = "public." + "abcd" * 32
+        >>> too_long = "public." + "long" * 32
         >>> tt = TempTableName.for_table(TableName.from_identifier(too_long))
         >>> len(tt.identifier)
         127

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -9,8 +9,8 @@ from typing import List
 
 import boto3
 
-from etl.names import join_with_quotes
 import etl.text
+from etl.names import join_with_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -10,6 +10,7 @@ from typing import List
 import boto3
 
 from etl.names import join_with_quotes
+import etl.text
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -23,16 +24,20 @@ class DataPipeline:
         self.fields = {
             field['key']: field['stringValue']
             for field in description['fields']
-            if field['key'] not in ('name', '@id', '*tags')
+            if field['key'] != '*tags'  # tags are an ugly list of dicts
         }
 
     def __str__(self):
         return "DataPipeline('{}','{}')".format(self.pipeline_id, self.name)
 
+    @property
+    def health_status(self):
+        return self.fields.get('@healthStatus', '---')
+
 
 def list_pipelines(selection: List[str]) -> List[DataPipeline]:
     """
-    List pipelines related to this project (which must have the tag for 'DataWarehouseEnvironment' set)
+    List pipelines related to this project (which must have the tag for our project set)
 
     The :selection should be a list of glob patterns to select specific pipelines by their ID.
     If the selection is an empty list, then all pipelines are used.
@@ -62,7 +67,7 @@ def list_pipelines(selection: List[str]) -> List[DataPipeline]:
         resp = client.describe_pipelines(pipelineIds=selected_pipeline_ids[block:block+chunk_size])
         for description in resp['pipelineDescriptionList']:
             for tag in description['tags']:
-                if tag['key'] == 'DataWarehouseEnvironment':
+                if tag['key'] == 'user:project' and tag['value'] == 'data-warehouse':
                     dw_pipelines.append(DataPipeline(description))
     return sorted(dw_pipelines, key=attrgetter("name"))
 
@@ -79,14 +84,19 @@ def show_pipelines(selection: List[str]) -> None:
     if not pipelines:
         logger.warning("Found no pipelines")
         print("*** No pipelines found ***")
-    elif not selection:
-        logger.info("Currently active pipelines: %s", join_with_quotes(pipeline.pipeline_id for pipeline in pipelines))
-        for pipeline in pipelines:
-            print('{:24s} "{:s}"'.format(pipeline.pipeline_id, pipeline.name))
-    else:
-        logger.info("Currently active and selected pipelines: %s",
-                    join_with_quotes(pipeline.pipeline_id for pipeline in pipelines))
-        for pipeline in pipelines:
-            print('{:24s} "{:s}"'.format(pipeline.pipeline_id, pipeline.name))
-            for key in sorted(pipeline.fields):
-                print("    {}: {}".format(key, pipeline.fields[key]))
+    elif selection and len(pipelines) > 1:
+        logger.warning("Selection matches more than one pipeline")
+    if pipelines:
+        if selection:
+            logger.info("Currently active and selected pipelines: %s",
+                        join_with_quotes(pipeline.pipeline_id for pipeline in pipelines))
+        else:
+            logger.info("Currently active pipelines: %s",
+                        join_with_quotes(pipeline.pipeline_id for pipeline in pipelines))
+        print(etl.text.format_lines([(pipeline.pipeline_id, pipeline.name, pipeline.health_status)
+                                     for pipeline in pipelines],
+                                    header_row=["Pipeline ID", "Name", "Health"], max_column_width=80))
+    if selection and len(pipelines) == 1:
+        pipeline = pipelines[0]
+        print(etl.text.format_lines([[key, pipeline.fields[key]] for key in sorted(pipeline.fields)],
+                                    header_row=["Key", "Value"]))

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -31,7 +31,7 @@ import etl.db
 import etl.s3
 import etl.timer
 from etl.config.dw import DataWarehouseSchema
-from etl.errors import CyclicDependencyError, MissingQueryError
+from etl.errors import CyclicDependencyError, ETLRuntimeError, MissingQueryError
 from etl.names import join_with_quotes, TableName, TableSelector, TempTableName
 
 logger = logging.getLogger(__name__)
@@ -163,7 +163,8 @@ class RelationDescription:
     @property
     def is_required(self) -> bool:
         if self._is_required is None:
-            raise RuntimeError("State of 'is_required' unknown for RelationDescription '{0.identifier}'".format(self))
+            raise ETLRuntimeError("state of 'is_required' unknown for RelationDescription '{0.identifier}'"
+                                  .format(self))
         return self._is_required
 
     @property

--- a/python/etl/render_template.py
+++ b/python/etl/render_template.py
@@ -9,8 +9,9 @@ import pkg_resources
 import simplejson
 import yaml
 
-from etl.errors import InvalidArgumentError, MissingValueTemplateError
 import etl.config
+import etl.text
+from etl.errors import InvalidArgumentError, MissingValueTemplateError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -114,6 +115,4 @@ def show_vars(name: Optional[str]) -> None:
         if not keys:
             raise InvalidArgumentError("no matching setting for '{}'".format(name))
     values = [config_mapping[key] for key in keys]
-    width = max(map(len, keys))
-    for key, value in zip(keys, values):
-        print("{key:{width}} = {value}".format(key=key, value=value, width=width))
+    print(etl.text.format_lines(zip(keys, values), header_row=["Name", "Value"]))

--- a/python/etl/selftest.py
+++ b/python/etl/selftest.py
@@ -34,6 +34,7 @@ import etl.relation
 import etl.render_template
 import etl.s3
 import etl.sync
+import etl.text
 import etl.timer
 import etl.unload
 import etl.validate

--- a/python/etl/text.py
+++ b/python/etl/text.py
@@ -1,0 +1,67 @@
+"""
+Deal with text, mostly around matrices of texts which we want to pretty print.
+"""
+
+import textwrap
+
+
+def format_lines(value_rows, header_row=None, has_header=False, max_column_width=100) -> str:
+    """
+    Format a list of rows which each have a list of values, optionally with a header.
+
+    We process whitespace by expanding tabs and then replacing all whitespace but actual spaces.
+    If any column is longer than the max_column_width, a placeholder will be inserted after cutting the value.
+
+    >>> print(format_lines([["aa", "b", "ccc"], ["a", "bb", "c"]]))
+    #1 | #2 | #3
+    ---+----+----
+    aa | b  | ccc
+    a  | bb | c
+    (2 rows)
+    >>> print(format_lines([["name", "breed"], ["monty", "spaniel"], ["cody", "poodle"], ["cooper", "shepherd"]],
+    ...                    has_header=True))
+    name   | breed
+    -------+---------
+    monty  | spaniel
+    cody   | poodle
+    cooper | shepherd
+    (3 rows)
+    >>> print(format_lines([["windy"]], header_row=["weather"]))
+    weather
+    -------
+    windy
+    (1 row)
+    >>> print(format_lines([]))
+    (0 rows)
+    >>> format_lines([["a", "b"], ["c"]])
+    Traceback (most recent call last):
+    ValueError: unexpected row length: got 1, expected 2
+    """
+    if header_row is not None and has_header is True:
+        raise ValueError("cannot have separate header row and mark first row as header")
+    # Make sure that we are working with a list of lists of strings (and not generators and such).
+    wrapper = textwrap.TextWrapper(width=max_column_width, max_lines=1, placeholder="...",
+                                   expand_tabs=True, replace_whitespace=True, drop_whitespace=False)
+    matrix = [[wrapper.fill(str(column)) for column in row] for row in value_rows]
+    n_columns = len(matrix[0]) if len(matrix) > 0 else 0
+    # Add header row as needed
+    if header_row is not None:
+        matrix.insert(0, [str(column) for column in header_row])
+    elif not has_header:
+        matrix.insert(0, ["#{:d}".format(i + 1) for i in range(n_columns)])
+    for i, row in enumerate(matrix):
+        if len(row) != n_columns:
+            raise ValueError("unexpected row length: got {:d}, expected {:d}".format(len(row), n_columns))
+    if len(matrix) == 1:
+        return "(0 rows)"
+    final = "\n({:d} {})".format(len(matrix) - 1, "row" if len(matrix) == 2 else "rows")
+    # Determine column widths, add separator between header and body as dashed line
+    column_width = [max(len(row[i]) for row in matrix) for i in range(n_columns)]
+    if max_column_width is not None:
+        column_width = [min(actual_width, max_column_width) for actual_width in column_width]
+    matrix.insert(1, ["-" * width for width in column_width])
+    # Now rewrite the matrix values to fill the columns
+    matrix = [["{:{}s}".format(row[i], column_width[i]) for i in range(n_columns)] for row in matrix]
+    rows = [' | '.join(row).rstrip() for row in matrix]
+    rows[1] = rows[1].replace(' | ', '-+-')
+    return '\n'.join(rows) + final

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -264,7 +264,7 @@ def validate_upstream_columns(conn: connection, table: RelationDescription) -> N
 
     columns_info = etl.design.bootstrap.fetch_attributes(conn, source_table_name)
     if not columns_info:
-        raise UpstreamValidationError("Table '%s' is gone or has no columns left" % source_table_name.identifier)
+        raise UpstreamValidationError("table '%s' is gone or has no columns left" % source_table_name.identifier)
     logger.info("Found %d column(s) in relation '%s'", len(columns_info), source_table_name.identifier)
 
     current_columns = frozenset(column.name for column in columns_info)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
-mypy>=0.521
 -rrequirements.txt
+mypy>=0.521
+# q>=2.6
+# ipython>=6.2


### PR DESCRIPTION
User-visible changes:
* Add commands to query and tail events sent out by other ETLs
    * Query events can be used to discover ETLs or all events tied to a specific ETL
    * Tail events is used to start at a specific time and then keep checking for new events

Other changes:
* The output of many command is now "prettier" and printed in a table style.
* There is a new "marker" event that is tied to a dummy event and allows to discover the start of ETLs.

Other notes:
* This works as advertised but is also the start of refactoring my little weekend project.
* We are currently guessing a start time in the concurrent load / extract.  But we could use the latest start time of the pipeline instead. And we should refactor a bunch...