### PR TITLE
Add tag to release information

### DIFF
--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -76,7 +76,9 @@ trap "rm \"$RELEASE_FILE\"" EXIT
 
 echo "toplevel=`git rev-parse --show-toplevel`" >> "$RELEASE_FILE"
 GIT_COMMIT_HASH=$(git rev-parse HEAD)
-if GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD); then
+if GIT_LATEST_TAG=$(git describe --exact-match --tags HEAD); then
+    echo "commit=$GIT_COMMIT_HASH ($GIT_LATEST_TAG)" >> "$RELEASE_FILE"
+elif GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD); then
     echo "commit=$GIT_COMMIT_HASH ($GIT_BRANCH)" >> "$RELEASE_FILE"
 else
     echo "commit=$GIT_COMMIT_HASH" >> "$RELEASE_FILE"


### PR DESCRIPTION
This changes the release information from:
```
2017-11-10 06:01:26 - INFO - Release information: toplevel=.../gits/arthur-redshift-etl, commit=1598a7977edfdb1743f7d31ed4a098b85fe223f3 (next), date=2017-11-10 06:01:19-0500
```
to:
```
2017-11-10 06:01:03 - INFO - Release information: toplevel=.../gits/arthur-redshift-etl, commit=1598a7977edfdb1743f7d31ed4a098b85fe223f3 (v1.5.1), date=2017-11-10 05:39:18-0500
```
but only if there's actually a tag available. If there's not tag, it reverts to the branch (first example).