### PR TITLE
Ignore unmanaged schemas

### DIFF
--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -112,7 +112,10 @@ class LoadableRelation:
         the position (staging or not) of a table.
 
         >>> import etl.file_sets
-        >>> fs = etl.file_sets.TableFileSet(TableName("a", "b"), TableName("c", "b"), None)
+        >>> from etl.config.dw import DataWarehouseSchema
+        >>> target_table_name = TableName("c", "b")
+        >>> target_table_name._base_schemas = [DataWarehouseSchema(schema_info={'name': 'c', 'owner': ''})]
+        >>> fs = etl.file_sets.TableFileSet(TableName("a", "b"), target_table_name, None)
         >>> relation = LoadableRelation(RelationDescription(fs), {}, skip_copy=True)
         >>> "As delimited identifier: {:s}, as string: {:x}".format(relation, relation)
         'As delimited identifier: "c"."b", as string: \\'c.b\\''

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -188,7 +188,7 @@ class LoadableRelation:
         if self.use_staging:
             # Rewrite the query to use staging schemas:
             for dependency in self.dependencies:
-                staging_dependency = TableName.from_identifier(dependency).as_staging_table_name()
+                staging_dependency = dependency.as_staging_table_name()
                 stmt = re.sub(r'\b' + dependency + r'\b', staging_dependency.identifier, stmt)
         return stmt
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1077,7 +1077,7 @@ def show_upstream_dependencies(relations: List[RelationDescription], selector: T
     """
     List the relations upstream (towards sources) from the selected ones, report in execution order.
     """
-    execution_order = etl.relation.order_by_dependencies(relations)
+    execution_order = etl.relation.order_by_dependencies(relations, selector.base_schemas)
     selected_relations = etl.relation.find_matches(execution_order, selector)
     if len(selected_relations) == 0:
         logger.warning("Found no matching relations for: %s", selector)

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1077,7 +1077,7 @@ def show_upstream_dependencies(relations: List[RelationDescription], selector: T
     """
     List the relations upstream (towards sources) from the selected ones, report in execution order.
     """
-    execution_order = etl.relation.order_by_dependencies(relations, selector.base_schemas)
+    execution_order = etl.relation.order_by_dependencies(relations)
     selected_relations = etl.relation.find_matches(execution_order, selector)
     if len(selected_relations) == 0:
         logger.warning("Found no matching relations for: %s", selector)

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -112,10 +112,12 @@ class LoadableRelation:
         the position (staging or not) of a table.
 
         >>> import etl.file_sets
-        >>> from etl.config.dw import DataWarehouseSchema
-        >>> target_table_name = TableName("c", "b")
-        >>> target_table_name._base_schemas = [DataWarehouseSchema(schema_info={'name': 'c', 'owner': ''})]
-        >>> fs = etl.file_sets.TableFileSet(TableName("a", "b"), target_table_name, None)
+        >>> import etl.config
+        >>> from collections import namedtuple
+        >>> MockDWConfig = namedtuple('MockDWConfig', ['schemas'])
+        >>> MockSchema = namedtuple('MockSchema', ['name'])
+        >>> etl.config._dw_config = MockDWConfig(schemas=[MockSchema(name='c')])
+        >>> fs = etl.file_sets.TableFileSet(TableName("a", "b"), TableName("c", "b"), None)
         >>> relation = LoadableRelation(RelationDescription(fs), {}, skip_copy=True)
         >>> "As delimited identifier: {:s}, as string: {:x}".format(relation, relation)
         'As delimited identifier: "c"."b", as string: \\'c.b\\''

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -129,17 +129,17 @@ class TableName:
 
     @property
     def managed_schemas(self) -> frozenset:
-        if self._managed_schemas is not None:
-            return self._managed_schemas
-        try:
-            schemas = etl.config.get_dw_config().schemas
-        except AttributeError:
-            raise ETLSystemError("dw_config has not been set!")
-        return frozenset(schema.name for schema in schemas)
+        if self._managed_schemas is None:
+            try:
+                schemas = etl.config.get_dw_config().schemas
+            except AttributeError:
+                raise ETLSystemError("dw_config has not been set!")
+            self._managed_schemas = frozenset(schema.name for schema in schemas)
+        return self._managed_schemas
 
     @managed_schemas.setter
-    def managed_schemas(self, schemas: List) -> None:
-        self._managed_schemas = frozenset(schemas)
+    def managed_schemas(self, schema_names: List) -> None:
+        self._managed_schemas = frozenset(schema_names)
 
     def to_tuple(self):
         """

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -69,6 +69,12 @@ class TableName:
 
     Comparisons (for schema and table names) are case-insensitive.
 
+    TableNames have a notion of known "managed" schemas, which include both
+    sources and transformations listed in configuration files. A TableName
+    is considered unmanaged if its schema does not belong to the list of
+    managed schemas, and in that case its schema property is never translated
+    into a staging version.
+
     >>> from etl.config.dw import DataWarehouseSchema
     >>> orders = TableName.from_identifier("www.orders")
     >>> str(orders)
@@ -108,7 +114,6 @@ class TableName:
 
     @property
     def schema(self):
-        # for unmanaged dependencies, the schema should not be in a "staging" version
         if self.staging and self.is_managed:
             return as_staging_name(self._schema)
         else:

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -11,6 +11,8 @@ import fnmatch
 import uuid
 from typing import Optional, List
 
+import etl.config
+
 
 def join_with_quotes(names):
     """
@@ -102,7 +104,7 @@ class TableName:
     @property
     def schema(self):
         # for system table dependencies, the schema should not be in a "staging" version
-        if self.staging and not self._schema.startswith('pg_catalog'):
+        if self.staging and self.is_managed:
             return as_staging_name(self._schema)
         else:
             return self._schema
@@ -136,6 +138,11 @@ class TableName:
         'hello.world'
         """
         return "{}.{}".format(*self.to_tuple())
+
+    @property
+    def is_managed(self) -> bool:
+        base_schemas = etl.config.get_dw_config().schemas
+        return self._schema in [s.name for s in base_schemas]
 
     @classmethod
     def from_identifier(cls, identifier: str):

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -96,7 +96,6 @@ class TableName:
     """
 
     __slots__ = ("_schema", "_table", "_staging", "_base_schemas")
-    _identifier_slots = ("_schema", "_table", "_staging")
 
     def __init__(self, schema: Optional[str], table: str) -> None:
         # Concession to subclasses ... schema is optional
@@ -213,7 +212,7 @@ class TableName:
             return False
 
     def __hash__(self):
-        return hash(tuple(getattr(self, slot) for slot in self._identifier_slots))
+        return hash(self.to_tuple())
 
     def __lt__(self, other: "TableName"):
         """

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -385,8 +385,8 @@ def order_by_dependencies(relation_descriptions):
             # Drop the unknowns from the list of dependencies so that the loop below doesn't wait for their resolution.
             description.dependencies = description.dependencies.difference(unknowns)
         if unmanaged_dependencies:
-            logger.info("The following dependencies are not managed by Arthur: %s",
-                        join_with_quotes([dep.identifier for dep in unmanaged_dependencies]))
+            logger.info("The following dependencies for relation '%s' are not managed by Arthur: %s",
+                        description.identifier, join_with_quotes([dep.identifier for dep in unmanaged_dependencies]))
         if pg_internal_dependencies:
             has_internal_dependencies.add(description.target_table_name)
         queue.put((1, initial_order, description))

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -352,7 +352,7 @@ def order_by_dependencies(relation_descriptions):
     Sort the relations such that any dependents surely are loaded afterwards.
 
     If a table (or view) depends on other tables, then its order is larger
-    than any of its dependencies. Ties are resolved based on the initial order
+    than any of its managed dependencies. Ties are resolved based on the initial order
     of the tables. (This motivates the use of a priority queue.)
 
     If a table depends on some system catalogs (living in pg_catalog), then the table

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -384,15 +384,15 @@ def order_by_dependencies(relation_descriptions):
             has_unknown_dependencies.add(description.target_table_name)
         if unmanaged_dependencies:
             logger.info("The following dependent relations are not managed by Arthur: %s",
-                        join_with_quotes(unmanaged_dependencies))
+                        join_with_quotes([dep.identifier for dep in unmanaged_dependencies]))
         if pg_internal_dependencies:
             has_internal_dependencies.add(description.target_table_name)
         queue.put((1, initial_order, description))
     if has_unknown_dependencies:
         logger.warning("These relations were unknown during dependency ordering: %s",
-                       join_with_quotes([d.identifier for d in known_unknowns]))
+                       join_with_quotes([dep.identifier for dep in known_unknowns]))
         logger.warning('This caused these relations to have dependencies that are not known: %s',
-                       join_with_quotes([d.identifier for d in has_unknown_dependencies]))
+                       join_with_quotes([dep.identifier for dep in has_unknown_dependencies]))
     has_no_internal_dependencies = known_tables - known_unknowns - has_internal_dependencies
     for description in descriptions:
         if description.target_table_name in has_internal_dependencies:

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -72,7 +72,7 @@ class RelationDescription:
         # Lazy-loading of table design and query statement and any derived information from the table design
         self._table_design = None  # type: Optional[Dict[str, Any]]
         self._query_stmt = None  # type: Optional[str]
-        self._dependencies = None  # type: Optional[FrozenSet[str]]
+        self._dependencies = None  # type: Optional[FrozenSet[TableName]]
         self._is_required = None  # type: Union[None, bool]
 
     @property

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -382,6 +382,8 @@ def order_by_dependencies(relation_descriptions):
         if unknowns:
             known_unknowns.update(unknowns)
             has_unknown_dependencies.add(description.target_table_name)
+            # Drop the unknowns from the list of dependencies so that the loop below doesn't wait for their resolution.
+            description.dependencies = description.dependencies.difference(unknowns)
         if unmanaged_dependencies:
             logger.info("The following dependent relations are not managed by Arthur: %s",
                         join_with_quotes([dep.identifier for dep in unmanaged_dependencies]))

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -433,7 +433,7 @@ def set_required_relations(relations: List[RelationDescription], required_select
                           if required_selector.match(description.target_table_name)]
     # Walk through descriptions in reverse dependency order, expanding required set based on dependency fan-out
     for description in ordered_descriptions[::-1]:
-        if any([description.identifier in required.dependencies for required in required_relations]):
+        if any([description.target_table_name in required.dependencies for required in required_relations]):
             required_relations.append(description)
 
     for relation in ordered_descriptions:

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -391,12 +391,12 @@ def validate_upstream_sources(schemas: List[DataWarehouseSchema], relations: Lis
                 validate_upstream_table(conn, table, keep_going=keep_going)
 
 
-def validate_execution_order(relations: List[RelationDescription], base_schemas: List[str], keep_going=False):
+def validate_execution_order(relations: List[RelationDescription], keep_going=False):
     """
     Wrapper around order_by_dependencies to deal with our keep_going predilection.
     """
     try:
-        ordered_relations = etl.relation.order_by_dependencies(relations, base_schemas)
+        ordered_relations = etl.relation.order_by_dependencies(relations)
     except ETLConfigError:
         if keep_going:
             _error_occurred.set()
@@ -417,8 +417,7 @@ def validate_designs(config: DataWarehouseConfig, relations: List[RelationDescri
     _error_occurred.clear()
 
     valid_descriptions = validate_semantics(relations, keep_going=keep_going)
-    base_schemas = [s.name for s in config.schemas]
-    ordered_descriptions = validate_execution_order(valid_descriptions, base_schemas, keep_going=keep_going)
+    ordered_descriptions = validate_execution_order(valid_descriptions, keep_going=keep_going)
 
     validate_reload(config.schemas, valid_descriptions, keep_going=keep_going)
 

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -391,12 +391,12 @@ def validate_upstream_sources(schemas: List[DataWarehouseSchema], relations: Lis
                 validate_upstream_table(conn, table, keep_going=keep_going)
 
 
-def validate_execution_order(relations: List[RelationDescription], keep_going=False):
+def validate_execution_order(relations: List[RelationDescription], base_schemas: List[str], keep_going=False):
     """
     Wrapper around order_by_dependencies to deal with our keep_going predilection.
     """
     try:
-        ordered_relations = etl.relation.order_by_dependencies(relations)
+        ordered_relations = etl.relation.order_by_dependencies(relations, base_schemas)
     except ETLConfigError:
         if keep_going:
             _error_occurred.set()
@@ -417,7 +417,8 @@ def validate_designs(config: DataWarehouseConfig, relations: List[RelationDescri
     _error_occurred.clear()
 
     valid_descriptions = validate_semantics(relations, keep_going=keep_going)
-    ordered_descriptions = validate_execution_order(valid_descriptions, keep_going=keep_going)
+    base_schemas = [s.name for s in config.schemas]
+    ordered_descriptions = validate_execution_order(valid_descriptions, base_schemas, keep_going=keep_going)
 
     validate_reload(config.schemas, valid_descriptions, keep_going=keep_going)
 


### PR DESCRIPTION
Defines the concept of "managed" schemas to be those specified in your DW config, and allow Arthur to ignore unmanaged schemas 1) when determining dependency ordering, and 2) when loading a relation with unmanaged dependencies in staging mode.

The most prominent change is that RelationDescription dependencies are now TableName objects instead of strings, and those objects have an `is_managed` property that references `etl.config`.