### PR TITLE
Fix query_stmt dependency replacement

### DIFF
--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -189,7 +189,7 @@ class LoadableRelation:
             # Rewrite the query to use staging schemas:
             for dependency in self.dependencies:
                 staging_dependency = dependency.as_staging_table_name()
-                stmt = re.sub(r'\b' + dependency + r'\b', staging_dependency.identifier, stmt)
+                stmt = re.sub(r'\b' + dependency.identifier + r'\b', staging_dependency.identifier, stmt)
         return stmt
 
     @property


### PR DESCRIPTION
Since dependencies are now TableNames, we need to sub out `dependency.identifier` when building query statements in staging mode.