### PR TITLE
[Load fault tolerance] Retry COPY, fall back to prior contents on failure

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -3,7 +3,15 @@
     "arthur_settings": {
         # If an extract from an upstream source or copy from S3 files fails due to some transient error, retry the extract at most this many times. Zero disables retries
         "extract_retries": 3, 
-        "copy_data_retries": 3
+        "copy_data_retries": 3,
+        # If normal approach to refreshing a materialized relation (CTAS or source) fails, fill the relation with
+        # data already in the warehouse from a prior build of that relation.
+        # Setting determines when Arthur should fallback to prior data:
+        #   "designed" - use (instead of query) only on relations whose design file explicitly sets "loads_from_prior_data"
+        #   "source" - use for source relations where load has failed or concurrent extract failed or timed out
+        #   "non_key" - use for any failed materialized relation other than CTAS with non-"identity" columns named '*_key'
+        #   "all" - use for any failed materialized relation
+        "loads_from_prior_data": "source"
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -1,8 +1,9 @@
 {
     # General settings controlling how Arthur itself behaves
     "arthur_settings": {
-        # If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries
-        "extract_retries": 1
+        # If an extract from an upstream source or copy from S3 files fails due to some transient error, retry the extract at most this many times. Zero disables retries
+        "extract_retries": 3, 
+        "copy_data_retries": 3
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -116,6 +116,11 @@
                     "description": "If a COPY command fails with a database internal error (which we optimistically hope are transient), retry the COPY at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0
+                },
+                "loads_from_prior_data": {
+                    "description": "If a COPY command fails with a database internal error (which we optimistically hope are transient), retry the COPY at most this many times. Zero disables retries",
+                    "type" : "string",
+                    "pattern": "^(designed|source|non_key|all)$"
                 }
             },
             "required": [ "extract_retries", "copy_data_retries" ],

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -111,9 +111,14 @@
                     "description": "If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0
+                },
+                "copy_data_retries": {
+                    "description": "If a COPY command fails with a database internal error (which we optimistically hope are transient), retry the COPY at most this many times. Zero disables retries",
+                    "type": "integer",
+                    "minimum": 0
                 }
             },
-            "required": [ "extract_retries" ],
+            "required": [ "extract_retries", "copy_data_retries" ],
             "additionalProperties": false
         },
         "data_warehouse": {

--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -79,6 +79,10 @@
             "type" : "string",
             "pattern": "^(CTAS|VIEW|\\w[^.]*[.]\\w[^.]*[.]\\w[^.]*)$"
         },
+        "load_from_prior": {
+            "type": "boolean",
+            "description": "Optional. Indicates an unhealthy table that should retain its last successful contents rather than be updated."
+        },
         "unload_target" : {
             "type": "string",
             "description": "Optional. If the relation is unloadable will specify to which schemas."

--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -79,7 +79,7 @@
             "type" : "string",
             "pattern": "^(CTAS|VIEW|\\w[^.]*[.]\\w[^.]*[.]\\w[^.]*)$"
         },
-        "load_from_prior": {
+        "loads_from_prior_data": {
             "type": "boolean",
             "description": "Optional. Indicates an unhealthy table that should retain its last successful contents rather than be updated."
         },

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -13,7 +13,7 @@ from psycopg2.extensions import connection  # only for type annotation
 
 import etl.db
 from etl.names import join_column_list, TableName
-from etl.errors import TransientETLError, retry
+from etl.errors import TransientETLError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -13,6 +13,7 @@ from psycopg2.extensions import connection  # only for type annotation
 
 import etl.db
 from etl.names import join_column_list, TableName
+from etl.errors import TransientETLError, retry
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -189,7 +190,10 @@ def copy_from_uri(conn: connection, table_name: TableName, s3_uri: str, aws_iam_
     else:
         logger.info("Copying data into '%s' from '%s'", table_name.identifier, s3_uri)
         with log_load_error(conn):
-            etl.db.execute(conn, stmt, (s3_uri, credentials))
+            try:
+                etl.db.execute(conn, stmt, (s3_uri, credentials))
+            except psycopg2.InternalError as exc:
+                raise TransientETLError(exc) from exc
             row_count = etl.db.query(conn, "SELECT pg_last_copy_count()")
             logger.info("Copied %d rows into '%s'", row_count[0][0], table_name.identifier)
 

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -1,3 +1,4 @@
+import time
 from typing import Callable, TypeVar
 
 T = TypeVar("T")
@@ -238,9 +239,12 @@ def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
         except TransientETLError as e:
             # Only retry transient errors
             failure_reason = e
-            if max_retries - attempt:
-                logger.warning("Encountered the following error (retrying %s more times): %s",
-                               max_retries - attempt, str(e))
+            remaining_attempts = max_retries - attempt
+            if remaining_attempts:
+                sleep_time = 5 ** attempt
+                logger.warning("Encountered the following error (retrying %s more times after %s second sleep): %s",
+                               remaining_attempts, sleep_time, str(e))
+                time.sleep(sleep_time)
             continue
         except:
             # We consider all other errors permanent and immediately re-raise without retrying

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -99,7 +99,7 @@ class TableName:
     False
     """
 
-    __slots__ = ("_schema", "_table", "_staging")
+    __slots__ = ("_schema", "_table", "_staging", "_backup", "_managed_schemas")
 
     def __init__(self, schema: Optional[str], table: str) -> None:
         # Concession to subclasses ... schema is optional

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -162,6 +162,10 @@ class RelationDescription:
         return "unload_target" in self.table_design
 
     @property
+    def load_from_prior(self):
+        return self.table_design.get("load_from_prior", False)
+
+    @property
     def is_required(self) -> bool:
         if self._is_required is None:
             raise ETLRuntimeError("state of 'is_required' unknown for RelationDescription '{0.identifier}'"

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -74,6 +74,7 @@ class RelationDescription:
         self._query_stmt = None  # type: Optional[str]
         self._dependencies = None  # type: Optional[FrozenSet[TableName]]
         self._is_required = None  # type: Union[None, bool]
+        self._load_from_prior = None  # type: Union[None, bool]
 
     @property
     def target_table_name(self) -> TableName:
@@ -163,7 +164,11 @@ class RelationDescription:
 
     @property
     def load_from_prior(self):
-        return self.table_design.get("load_from_prior", False)
+        return self.table_design.get("load_from_prior", False) if self._load_from_prior is None else self._load_from_prior
+
+    @load_from_prior.setter
+    def load_from_prior(self, value):
+        self._load_from_prior = value
 
     @property
     def is_required(self) -> bool:

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -74,7 +74,7 @@ class RelationDescription:
         self._query_stmt = None  # type: Optional[str]
         self._dependencies = None  # type: Optional[FrozenSet[TableName]]
         self._is_required = None  # type: Union[None, bool]
-        self._load_from_prior = None  # type: Union[None, bool]
+        self._loads_from_prior_data = None  # type: Union[None, bool]
 
     @property
     def target_table_name(self) -> TableName:
@@ -163,11 +163,13 @@ class RelationDescription:
         return "unload_target" in self.table_design
 
     @property
-    def load_from_prior(self):
-        return self.table_design.get("load_from_prior", False) if self._load_from_prior is None else self._load_from_prior
+    def loads_from_prior_data(self) -> bool:
+        if self._loads_from_prior_data is None:
+            self._loads_from_prior_data = self.table_design.get("loads_from_prior_data", False)
+        return self._loads_from_prior_data
 
-    @load_from_prior.setter
-    def load_from_prior(self, value):
+    @loads_from_prior_data.setter
+    def loads_from_prior_data(self, value):
         self._load_from_prior = value
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.6.0",
+    version="1.7.0b",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
On the retry side:
* Add retry support for COPY following the pattern used in extract (assume any error that might be temporary is temporary)
* Add exponential backoff to retry, increase default retry attempts to 3
* In transaction: Don't retry if you're  (even a system error will spoil your transaction, you must give up)

Unclear if retrying COPY helps us or not (it already [claims to retry files when loading from manifests](http://docs.aws.amazon.com/redshift/latest/dg/copy-usage_notes-multiple-files.html)) but it seems possible. Exponential sleep is known to be useful for extract, as scarce resources (eg, driver memory) may free up between attempts if you wait before retrying.

On the prior contents side:
* No change is usually preferable to total failure (new data may violate uniqueness constraints, but prior data apparently didn't), so try filling a failed relation from prior contents before bubbling error up
* To avoid restoring data referencing out-of-date warehouse-generated row keys, tables with `*_key` columns that aren't generated using the `"identity"` column property cannot be restored.
* Concurrent load will load from prior when data source relations' `extract`s failed or timed out
* Sometimes the failure will occur several relations after the root cause, so developers ought to be able to flag relations for `load_from_prior` so that they can re-load the warehouse with working contents at the root cause relation
* In transaction: Check transaction status and attempt to use prior contents if the transaction is not in an error state (could be fine if problem was a uniqueness constraint or missing SQL file)
