### PR TITLE
Specify columns in copy from S3

### DIFF
--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -166,15 +166,19 @@ def log_load_error(cx):
         raise
 
 
-def copy_from_uri(conn: connection, table_name: TableName, s3_uri: str, aws_iam_role: str,
+def copy_from_uri(conn: connection, relation, s3_uri: str, aws_iam_role: str,
                   need_compupdate=False, dry_run=False) -> None:
     """
     Load data into table in the data warehouse using the COPY command.
     """
     credentials = "aws_iam_role={}".format(aws_iam_role)
+    table_name = relation.target_table_name
+    columns = join_column_list(relation.unquoted_columns)
 
     stmt = """
-        COPY {table}
+        COPY {table} (
+            {columns}
+        )
         FROM %s
         CREDENTIALS %s MANIFEST
         DELIMITER ',' ESCAPE REMOVEQUOTES GZIP
@@ -182,7 +186,7 @@ def copy_from_uri(conn: connection, table_name: TableName, s3_uri: str, aws_iam_
         TRUNCATECOLUMNS
         STATUPDATE OFF
         COMPUPDATE {compupdate}
-        """.format(table=table_name, compupdate="ON" if need_compupdate else "OFF")
+        """.format(table=table_name, columns=columns, compupdate="ON" if need_compupdate else "OFF")
     if dry_run:
         logger.info("Dry-run: Skipping copying data into '%s' from '%s'", table_name.identifier, s3_uri)
         etl.db.skip_query(conn, stmt, (s3_uri, credentials))

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -166,14 +166,12 @@ def log_load_error(cx):
         raise
 
 
-def copy_from_uri(conn: connection, relation, s3_uri: str, aws_iam_role: str,
+def copy_from_uri(conn: connection, table_name: TableName, column_list: List[str], s3_uri: str, aws_iam_role: str,
                   need_compupdate=False, dry_run=False) -> None:
     """
     Load data into table in the data warehouse using the COPY command.
     """
     credentials = "aws_iam_role={}".format(aws_iam_role)
-    table_name = relation.target_table_name
-    columns = join_column_list(relation.unquoted_columns)
 
     stmt = """
         COPY {table} (
@@ -186,7 +184,7 @@ def copy_from_uri(conn: connection, relation, s3_uri: str, aws_iam_role: str,
         TRUNCATECOLUMNS
         STATUPDATE OFF
         COMPUPDATE {compupdate}
-        """.format(table=table_name, columns=columns, compupdate="ON" if need_compupdate else "OFF")
+        """.format(table=table_name, columns=join_column_list(column_list), compupdate="ON" if need_compupdate else "OFF")
     if dry_run:
         logger.info("Dry-run: Skipping copying data into '%s' from '%s'", table_name.identifier, s3_uri)
         etl.db.skip_query(conn, stmt, (s3_uri, credentials))

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -366,7 +366,7 @@ def copy_data(conn: connection, relation: LoadableRelation, dry_run=False):
             raise MissingManifestError("relation '{}' is missing manifest file '{}'".format(
                                            relation.identifier, s3_uri))
 
-    etl.design.redshift.copy_from_uri(conn, relation, s3_uri, aws_iam_role,
+    etl.design.redshift.copy_from_uri(conn, relation.target_table_name, relation.unquoted_columns, s3_uri, aws_iam_role,
                                       need_compupdate=relation.is_missing_encoding, dry_run=dry_run)
 
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -366,7 +366,7 @@ def copy_data(conn: connection, relation: LoadableRelation, dry_run=False):
             raise MissingManifestError("relation '{}' is missing manifest file '{}'".format(
                                            relation.identifier, s3_uri))
 
-    etl.design.redshift.copy_from_uri(conn, relation.target_table_name, s3_uri, aws_iam_role,
+    etl.design.redshift.copy_from_uri(conn, relation, s3_uri, aws_iam_role,
                                       need_compupdate=relation.is_missing_encoding, dry_run=dry_run)
 
 


### PR DESCRIPTION
Specify column list in the copy command from S3 to Redshift. This allows static sources to possibly have extra columns (to the right) not loaded by Arthur.

I couldn't add a type annotation to `relation` in `copy_from_uri` because importing `LoadableRelation` would introduce circular dependencies.