### PR TITLE
Pick up identifier from dependencies of a relation

### DIFF
--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -460,7 +460,7 @@ def find_dependents(relations: List[RelationDescription], seed_relations: List[R
     seeds = frozenset(relation.identifier for relation in seed_relations)
     in_dependency_path = set(seeds)
     for relation in relations:
-        if any(dependency in in_dependency_path for dependency in relation.dependencies):
+        if any(dependency.identifier in in_dependency_path for dependency in relation.dependencies):
             in_dependency_path.add(relation.identifier)
     dependents = in_dependency_path - seeds
     return [relation for relation in relations if relation.identifier in dependents]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.6.1",
+    version="1.6.2",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
Bug fix ... observable by running `arthur.py show_dependents source.table` which would only should that table instead of the table and all of its dependents.