### PR TITLE
[Load fault tolerance] Retry COPY

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -1,8 +1,9 @@
 {
     # General settings controlling how Arthur itself behaves
     "arthur_settings": {
-        # If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries
-        "extract_retries": 1
+        # If an extract from an upstream source or copy from S3 files fails due to some transient error, retry the extract at most this many times. Zero disables retries
+        "extract_retries": 1,
+        "copy_data_retries": 3
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -111,9 +111,14 @@
                     "description": "If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0
+                },
+                "copy_data_retries": {
+                    "description": "If a COPY command fails with a database internal error (which we optimistically hope are transient), retry the COPY at most this many times. Zero disables retries",
+                    "type": "integer",
+                    "minimum": 0
                 }
             },
-            "required": [ "extract_retries" ],
+            "required": [ "extract_retries", "copy_data_retries" ],
             "additionalProperties": false
         },
         "data_warehouse": {

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -1,3 +1,4 @@
+import time
 from typing import Callable, TypeVar
 
 T = TypeVar("T")
@@ -238,9 +239,12 @@ def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
         except TransientETLError as e:
             # Only retry transient errors
             failure_reason = e
-            if max_retries - attempt:
-                logger.warning("Encountered the following error (retrying %s more times): %s",
-                               max_retries - attempt, str(e))
+            remaining_attempts = max_retries - attempt
+            if remaining_attempts:
+                sleep_time = 5 ** attempt
+                logger.warning("Encountered the following error (retrying %s more times after %s second sleep): %s",
+                               remaining_attempts, sleep_time, str(e))
+                time.sleep(sleep_time)
             continue
         except:
             # We consider all other errors permanent and immediately re-raise without retrying

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -226,6 +226,7 @@ class RetriesExhaustedError(ETLRuntimeError):
 def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
     """
     Retry a function a maximum number of times and return its results.
+    Sleeps for 5 ^ attempt_number seconds if there are remaining retry attempts.
 
     The given callback function is only retried if it throws a TransientETLError. Any other error is considered
     permanent, and therefore no retry attempt is made.
@@ -241,7 +242,7 @@ def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
             failure_reason = e
             remaining_attempts = max_retries - attempt
             if remaining_attempts:
-                sleep_time = 5 ** attempt
+                sleep_time = 5 ** (attempt + 1)
                 logger.warning("Encountered the following error (retrying %s more times after %s second sleep): %s",
                                remaining_attempts, sleep_time, str(e))
                 time.sleep(sleep_time)


### PR DESCRIPTION
We see transient-looking errors from S3 data files not being found/readable during COPY commands. We're optimistic that retrying might succeed.

User facing changes:
* Retry COPY from S3 whenever a Redshift InternalServerError is encountered

Internal changes:
* Add exponential backoff to retries

Note that this has a difference in monitor output from extract, where the entire monitored step is retried, with monitor logging of attempts. Since this retry is for one part of a monitored step but much of the step won't be retried, I don't think it makes sense to expect these retries to look the same to the monitor.

(HA-734)