### PR TITLE
Terminate Non-ETL Sessions Before Schema Promotion

### DIFF
--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -115,7 +115,7 @@
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
             "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ promote_schemas --from-position staging --prolix",
-            "dependsOn": { "ref": "ArthurUpgrade" }
+            "dependsOn": { "ref": "ArthurTerminateSessions" }
         },
         {
             "id": "PublishAndBackup",

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -102,6 +102,14 @@
             "dependsOn": { "ref": "Bootstrap" }
         },
         {
+            "id": "ArthurTerminateSessions",
+            "name": "Arthur Terminate Sessions (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ terminate_sessions --prolix",
+            "dependsOn": { "ref": "ArthurUpgrade" }
+        },
+        {
             "id": "ArthurPromote",
             "name": "Arthur Promote (EC2)",
             "type": "ShellCommandActivity",

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -133,7 +133,7 @@
             "name": "Arthur Terminate Sessions (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ terminate_sessions --prolix --dry-run",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ terminate_sessions --prolix",
             "dependsOn": { "ref": "Bootstrap" }
         },
         {


### PR DESCRIPTION
Take 'terminate sessions' from being a 'preview' (ie, running with `dry-run` flag) to an actual part of outside-transaction load pipelines.

User facing changes:
* remove `dry-run` from `terminate_sessions` in rebuild pipeline
* add `terminate_sessions` before promotion in pizza loader
