### PR TITLE
Release Candidate v1.7.0

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -1,8 +1,9 @@
 {
     # General settings controlling how Arthur itself behaves
     "arthur_settings": {
-        # If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries
-        "extract_retries": 1
+        # If an extract from an upstream source or copy from S3 files fails due to some transient error, retry the extract at most this many times. Zero disables retries
+        "extract_retries": 1,
+        "copy_data_retries": 3
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -111,9 +111,14 @@
                     "description": "If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0
+                },
+                "copy_data_retries": {
+                    "description": "If a COPY command fails with a database internal error (which we optimistically hope are transient), retry the COPY at most this many times. Zero disables retries",
+                    "type": "integer",
+                    "minimum": 0
                 }
             },
-            "required": [ "extract_retries" ],
+            "required": [ "extract_retries", "copy_data_retries" ],
             "additionalProperties": false
         },
         "data_warehouse": {

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -1,3 +1,4 @@
+import time
 from typing import Callable, TypeVar
 
 T = TypeVar("T")
@@ -225,6 +226,7 @@ class RetriesExhaustedError(ETLRuntimeError):
 def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
     """
     Retry a function a maximum number of times and return its results.
+    Sleeps for 5 ^ attempt_number seconds if there are remaining retry attempts.
 
     The given callback function is only retried if it throws a TransientETLError. Any other error is considered
     permanent, and therefore no retry attempt is made.
@@ -238,9 +240,12 @@ def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
         except TransientETLError as e:
             # Only retry transient errors
             failure_reason = e
-            if max_retries - attempt:
-                logger.warning("Encountered the following error (retrying %s more times): %s",
-                               max_retries - attempt, str(e))
+            remaining_attempts = max_retries - attempt
+            if remaining_attempts:
+                sleep_time = 5 ** (attempt + 1)
+                logger.warning("Encountered the following error (retrying %s more times after %s second sleep): %s",
+                               remaining_attempts, sleep_time, str(e))
+                time.sleep(sleep_time)
             continue
         except:
             # We consider all other errors permanent and immediately re-raise without retrying

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Set
 import etl.monitor
 import etl.s3
 import etl.db
-from etl.config import get_config_int
+import etl.config
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import (
     DataExtractError,
@@ -73,7 +73,7 @@ class Extractor:
         """
         self.logger.info("Extracting %d relation(s) from source '%s'", len(relations), source.name)
         failed = []
-
+        extract_retries = etl.config.get_config_int("arthur_settings.extract_retries")
         with Timer() as timer:
             for i, relation in enumerate(relations):
                 try:
@@ -86,12 +86,12 @@ class Extractor:
                                                               'object_key': relation.manifest_file_name},
                                                  index={"current": i + 1, "final":
                                                         len(relations), "name": source.name},
-                                                 dry_run=self.dry_run,
-                                                 attempt_num=attempt_num + 1):
+                                                 attempt_num=attempt_num + 1,
+                                                 is_final_attempt=(attempt_num == extract_retries),
+                                                 dry_run=self.dry_run):
                                 self.extract_table(source, relation)
 
-                    retries = get_config_int("arthur_settings.extract_retries")
-                    retry(retries, _monitored_table_extract, self.logger)
+                    retry(extract_retries, _monitored_table_extract, self.logger)
 
                 except ETLRuntimeError:
                     self.failed_sources.add(source.name)

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -6,6 +6,7 @@ Extractors leave usable (ie, COPY-ready) manifests on S3 that reference data fil
 import concurrent.futures
 import logging
 from itertools import groupby
+from functools import partial
 from operator import attrgetter
 from typing import Dict, List, Set
 
@@ -77,22 +78,16 @@ class Extractor:
         with Timer() as timer:
             for i, relation in enumerate(relations):
                 try:
-                    def _monitored_table_extract(attempt_num):
-                        with etl.monitor.Monitor(relation.identifier,
-                                                 "extract",
-                                                 options=self.options_info(),
-                                                 source=self.source_info(source, relation),
-                                                 destination={'bucket_name': relation.bucket_name,
-                                                              'object_key': relation.manifest_file_name},
-                                                 index={"current": i + 1, "final":
-                                                        len(relations), "name": source.name},
-                                                 attempt_num=attempt_num + 1,
-                                                 is_final_attempt=(attempt_num == extract_retries),
-                                                 dry_run=self.dry_run):
-                                self.extract_table(source, relation)
-
-                    retry(extract_retries, _monitored_table_extract, self.logger)
-
+                    extract_func = partial(self.extract_table, source, relation)
+                    with etl.monitor.Monitor(relation.identifier,
+                                             "extract",
+                                             options=self.options_info(),
+                                             source=self.source_info(source, relation),
+                                             destination={'bucket_name': relation.bucket_name,
+                                                           'object_key': relation.manifest_file_name},
+                                              index={"current": i + 1, "final": len(relations), "name": source.name},
+                                             dry_run=self.dry_run):
+                        retry(extract_retries, extract_func, self.logger)
                 except ETLRuntimeError:
                     self.failed_sources.add(source.name)
                     failed.append(relation)

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -60,7 +60,7 @@ import etl.design.redshift
 import etl.relation
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import (ETLRuntimeError, FailedConstraintError, MissingManifestError, RelationDataError,
-                        RelationConstructionError, RequiredRelationLoadError, UpdateTableError)
+                        RelationConstructionError, RequiredRelationLoadError, UpdateTableError, retry)
 from etl.names import join_column_list, join_with_quotes, TableName, TableSelector, TempTableName
 from etl.relation import RelationDescription
 from etl.timer import Timer

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -47,6 +47,7 @@ logger.addHandler(logging.NullHandler())
 STEP_START = "start"
 STEP_FINISH = "finish"
 STEP_FAIL = "fail"
+STEP_FAIL_BEFORE_RETRY = "fail_before_retry"
 _DUMMY_TARGET = "#.dummy"
 
 
@@ -155,11 +156,12 @@ class Monitor(metaclass=MetaMonitor):
     _environment = None
     _cluster_info = None
 
-    def __init__(self, target: str, step: str, dry_run: bool=False, **kwargs) -> None:
+    def __init__(self, target: str, step: str, is_final_attempt: bool=True, dry_run: bool=False, **kwargs) -> None:
         self._monitor_id = trace_key()
         self._target = target
         self._step = step
         self._dry_run = dry_run
+        self._is_final_attempt = is_final_attempt
         # Create a deep copy so that changes that the caller might make later do not alter our payload
         self._extra = deepcopy(dict(**kwargs))
         self._index = self._extra.get("index")
@@ -205,13 +207,19 @@ class Monitor(metaclass=MetaMonitor):
         self._end_time = utc_now()
         seconds = elapsed_seconds(self._start_time, self._end_time)
         if exc_type is None:
+            event = STEP_FINISH
+            errors = None
             logger.info("Finished %s step for '%s' (%0.2fs)", self._step, self._target, seconds)
-            payload = MonitorPayload(self, STEP_FINISH, self._end_time, elapsed=seconds, extra=self._extra)
         else:
+            if self._is_final_attempt:
+                event = STEP_FAIL
+            else:
+                event = STEP_FAIL_BEFORE_RETRY
+            errors = [{'code': (exc_type.__module__ + '.' + exc_type.__qualname__).upper(),
+                       'message': traceback.format_exception_only(exc_type, exc_value)[0].strip()}]
             logger.warning("Failed %s step for '%s' (%0.2fs)", self._step, self._target, seconds)
-            payload = MonitorPayload(self, STEP_FAIL, self._end_time, elapsed=seconds, extra=self._extra)
-            payload.errors = [{'code': (exc_type.__module__ + '.' + exc_type.__qualname__).upper(),
-                               'message': traceback.format_exception_only(exc_type, exc_value)[0].strip()}]
+
+        payload = MonitorPayload(self, event, self._end_time, elapsed=seconds, errors=errors, extra=self._extra)
         payload.emit(dry_run=self._dry_run)
 
     @classmethod
@@ -231,7 +239,7 @@ class MonitorPayload:
     # Append instances with a 'store' method here (skipping writing a metaclass this time)
     dispatchers = []  # type: List[PayloadDispatcher]
 
-    def __init__(self, monitor, event, timestamp, elapsed=None, extra=None):
+    def __init__(self, monitor, event, timestamp, elapsed=None, errors=None, extra=None):
         # Basic info
         self.environment = monitor.environment
         self.etl_id = monitor.etl_id
@@ -243,8 +251,8 @@ class MonitorPayload:
         # Premium info (when available)
         self.cluster_info = monitor.cluster_info
         self.elapsed = elapsed
+        self.errors = errors
         self.extra = extra
-        self.errors = None
 
     def emit(self, dry_run=False):
         payload = vars(self)

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -47,7 +47,6 @@ logger.addHandler(logging.NullHandler())
 STEP_START = "start"
 STEP_FINISH = "finish"
 STEP_FAIL = "fail"
-STEP_FAIL_BEFORE_RETRY = "fail_before_retry"
 _DUMMY_TARGET = "#.dummy"
 
 
@@ -156,12 +155,11 @@ class Monitor(metaclass=MetaMonitor):
     _environment = None
     _cluster_info = None
 
-    def __init__(self, target: str, step: str, is_final_attempt: bool=True, dry_run: bool=False, **kwargs) -> None:
+    def __init__(self, target: str, step: str, dry_run: bool=False, **kwargs) -> None:
         self._monitor_id = trace_key()
         self._target = target
         self._step = step
         self._dry_run = dry_run
-        self._is_final_attempt = is_final_attempt
         # Create a deep copy so that changes that the caller might make later do not alter our payload
         self._extra = deepcopy(dict(**kwargs))
         self._index = self._extra.get("index")
@@ -211,10 +209,7 @@ class Monitor(metaclass=MetaMonitor):
             errors = None
             logger.info("Finished %s step for '%s' (%0.2fs)", self._step, self._target, seconds)
         else:
-            if self._is_final_attempt:
-                event = STEP_FAIL
-            else:
-                event = STEP_FAIL_BEFORE_RETRY
+            event = STEP_FAIL
             errors = [{'code': (exc_type.__module__ + '.' + exc_type.__qualname__).upper(),
                        'message': traceback.format_exception_only(exc_type, exc_value)[0].strip()}]
             logger.warning("Failed %s step for '%s' (%0.2fs)", self._step, self._target, seconds)

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -102,12 +102,20 @@
             "dependsOn": { "ref": "Bootstrap" }
         },
         {
+            "id": "ArthurTerminateSessions",
+            "name": "Arthur Terminate Sessions (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ terminate_sessions --prolix",
+            "dependsOn": { "ref": "ArthurUpgrade" }
+        },
+        {
             "id": "ArthurPromote",
             "name": "Arthur Promote (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
             "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ promote_schemas --from-position staging --prolix",
-            "dependsOn": { "ref": "ArthurUpgrade" }
+            "dependsOn": { "ref": "ArthurTerminateSessions" }
         },
         {
             "id": "PublishAndBackup",

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -133,7 +133,7 @@
             "name": "Arthur Terminate Sessions (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ terminate_sessions --prolix --dry-run",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ terminate_sessions --prolix",
             "dependsOn": { "ref": "Bootstrap" }
         },
         {

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.6.3",
+    version="1.7.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
User facing changes:
* Retry COPY from S3 whenever a Redshift InternalServerError is encountered
* remove `dry-run` from `terminate_sessions` in rebuild pipeline
* add `terminate_sessions` before promotion in pizza loader

Internal changes:
* Concurrent load event polling now looks for only the events it can handle ('fail' and 'finish' events) rather than 'everything but start'
* Add exponential backoff to retries
 