### PR TITLE
Don't monitor retries

### DIFF
--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -223,12 +223,12 @@ class RetriesExhaustedError(ETLRuntimeError):
     """
 
 
-def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
+def retry(max_retries: int, func: Callable[[], T], logger) -> T:
     """
     Retry a function a maximum number of times and return its results.
     Sleeps for 5 ^ attempt_number seconds if there are remaining retry attempts.
 
-    The given callback function is only retried if it throws a TransientETLError. Any other error is considered
+    The given func function is only retried if it throws a TransientETLError. Any other error is considered
     permanent, and therefore no retry attempt is made.
     """
     failure_reason = None
@@ -236,7 +236,7 @@ def retry(max_retries: int, callback: Callable[[int], T], logger) -> T:
 
     for attempt in range(max_retries + 1):
         try:
-            successful_result = callback(attempt)
+            successful_result = func()
         except TransientETLError as e:
             # Only retry transient errors
             failure_reason = e

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -1,7 +1,5 @@
 import time
-from typing import Callable, TypeVar
-
-T = TypeVar("T")
+from functools import partial
 
 
 class ETLError(Exception):
@@ -223,9 +221,10 @@ class RetriesExhaustedError(ETLRuntimeError):
     """
 
 
-def retry(max_retries: int, func: Callable[[], T], logger) -> T:
+def retry(max_retries: int, func: partial, logger):
     """
     Retry a function a maximum number of times and return its results.
+    The function should be a functools.partial called with no arguments.
     Sleeps for 5 ^ attempt_number seconds if there are remaining retry attempts.
 
     The given func function is only retried if it throws a TransientETLError. Any other error is considered

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -6,6 +6,7 @@ Extractors leave usable (ie, COPY-ready) manifests on S3 that reference data fil
 import concurrent.futures
 import logging
 from itertools import groupby
+from functools import partial
 from operator import attrgetter
 from typing import Dict, List, Set
 
@@ -77,22 +78,16 @@ class Extractor:
         with Timer() as timer:
             for i, relation in enumerate(relations):
                 try:
-                    def _monitored_table_extract(attempt_num):
-                        with etl.monitor.Monitor(relation.identifier,
-                                                 "extract",
-                                                 options=self.options_info(),
-                                                 source=self.source_info(source, relation),
-                                                 destination={'bucket_name': relation.bucket_name,
-                                                              'object_key': relation.manifest_file_name},
-                                                 index={"current": i + 1, "final":
-                                                        len(relations), "name": source.name},
-                                                 attempt_num=attempt_num + 1,
-                                                 is_final_attempt=(attempt_num == extract_retries),
-                                                 dry_run=self.dry_run):
-                                self.extract_table(source, relation)
-
-                    retry(extract_retries, _monitored_table_extract, self.logger)
-
+                    extract_func = partial(self.extract_table, source, relation)
+                    with etl.monitor.Monitor(relation.identifier,
+                                             "extract",
+                                             options=self.options_info(),
+                                             source=self.source_info(source, relation),
+                                             destination={'bucket_name': relation.bucket_name,
+                                                           'object_key': relation.manifest_file_name},
+                                              index={"current": i + 1, "final": len(relations), "name": source.name},
+                                             dry_run=self.dry_run):
+                        retry(extract_retries, extract_func, self.logger)
                 except ETLRuntimeError:
                     self.failed_sources.add(source.name)
                     failed.append(relation)

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -47,7 +47,6 @@ logger.addHandler(logging.NullHandler())
 STEP_START = "start"
 STEP_FINISH = "finish"
 STEP_FAIL = "fail"
-STEP_FAIL_BEFORE_RETRY = "fail_before_retry"
 _DUMMY_TARGET = "#.dummy"
 
 
@@ -156,12 +155,11 @@ class Monitor(metaclass=MetaMonitor):
     _environment = None
     _cluster_info = None
 
-    def __init__(self, target: str, step: str, is_final_attempt: bool=True, dry_run: bool=False, **kwargs) -> None:
+    def __init__(self, target: str, step: str, dry_run: bool=False, **kwargs) -> None:
         self._monitor_id = trace_key()
         self._target = target
         self._step = step
         self._dry_run = dry_run
-        self._is_final_attempt = is_final_attempt
         # Create a deep copy so that changes that the caller might make later do not alter our payload
         self._extra = deepcopy(dict(**kwargs))
         self._index = self._extra.get("index")
@@ -211,10 +209,7 @@ class Monitor(metaclass=MetaMonitor):
             errors = None
             logger.info("Finished %s step for '%s' (%0.2fs)", self._step, self._target, seconds)
         else:
-            if self._is_final_attempt:
-                event = STEP_FAIL
-            else:
-                event = STEP_FAIL_BEFORE_RETRY
+            event = STEP_FAIL
             errors = [{'code': (exc_type.__module__ + '.' + exc_type.__qualname__).upper(),
                        'message': traceback.format_exception_only(exc_type, exc_value)[0].strip()}]
             logger.warning("Failed %s step for '%s' (%0.2fs)", self._step, self._target, seconds)


### PR DESCRIPTION
Rather than monitor intermediate results in a special way to ignore them, simply don't monitor them

User facing changes:
* Removes user facing changes re: new monitor event
* Removes all monitor payloads around retried extracts
