### PR TITLE
Optionally check for recent successful extracts before running an update

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -727,8 +727,8 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
                                  " (leaves warehouse in inconsistent state, for debugging only, default: %(default)s)",
                             default=False, action="store_true")
         parser.add_argument("--extract-look-back", metavar="N", type=int, default=0,
-                            help="require recent successful extract events in the last N minutes "
-                                 "(or don't check if N <= 0, default: %(default)s)")
+                            help="require recent successful extract events for all selected source relations "
+                                 "in the last N minutes (or don't check if N <= 0, default: %(default)s)")
         parser.add_argument("--vacuum", help="run vacuum after the update to tidy up the place (default: %(default)s)",
                             default=False, action="store_true")
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -730,9 +730,9 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
                             help="only load data into selected relations"
                                  " (leaves warehouse in inconsistent state, for debugging only, default: %(default)s)",
                             default=False, action="store_true")
-        parser.add_argument("--scheduled-start-time", metavar="T", default=None, type=isoformat_datetime_string,
+        parser.add_argument("--scheduled-start-time", metavar="TIME", default=None, type=isoformat_datetime_string,
                             help="require recent successful extract events for all selected source relations "
-                                 "after UTC time T (or, by default, don't require extract events)")
+                                 "after UTC time TIME (or, by default, don't require extract events)")
         parser.add_argument("--vacuum", help="run vacuum after the update to tidy up the place (default: %(default)s)",
                             default=False, action="store_true")
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -726,6 +726,9 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
                             help="only load data into selected relations"
                                  " (leaves warehouse in inconsistent state, for debugging only, default: %(default)s)",
                             default=False, action="store_true")
+        parser.add_argument("--extract-look-back", metavar="N", type=int, default=0,
+                            help="require recent successful extract events in the last N minutes "
+                                 "(or don't check if N <= 0, default: %(default)s)")
         parser.add_argument("--vacuum", help="run vacuum after the update to tidy up the place (default: %(default)s)",
                             default=False, action="store_true")
 
@@ -737,6 +740,7 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
         etl.load.update_data_warehouse(relations, args.pattern,
                                        wlm_query_slots=wlm_query_slots,
                                        only_selected=args.only_selected, run_vacuum=args.vacuum,
+                                       extract_look_back=args.extract_look_back,
                                        dry_run=args.dry_run)
 
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -211,6 +211,10 @@ class FancyArgumentParser(argparse.ArgumentParser):
         return args
 
 
+def isoformat_datetime_string(argument):
+    return datetime.strptime(argument, "%Y-%m-%dT%H:%M:%S")
+
+
 def build_basic_parser(prog_name, description=None):
     """
     Build basic parser that knows about the configuration setting.
@@ -726,9 +730,9 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
                             help="only load data into selected relations"
                                  " (leaves warehouse in inconsistent state, for debugging only, default: %(default)s)",
                             default=False, action="store_true")
-        parser.add_argument("--extract-look-back", metavar="N", type=int, default=0,
+        parser.add_argument("--scheduled-start-time", metavar="T", default=None, type=isoformat_datetime_string,
                             help="require recent successful extract events for all selected source relations "
-                                 "in the last N minutes (or don't check if N <= 0, default: %(default)s)")
+                                 "after UTC time T (or, by default, don't require extract events)")
         parser.add_argument("--vacuum", help="run vacuum after the update to tidy up the place (default: %(default)s)",
                             default=False, action="store_true")
 
@@ -740,7 +744,7 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
         etl.load.update_data_warehouse(relations, args.pattern,
                                        wlm_query_slots=wlm_query_slots,
                                        only_selected=args.only_selected, run_vacuum=args.vacuum,
-                                       extract_look_back=args.extract_look_back,
+                                       start_time=args.scheduled_start_time,
                                        dry_run=args.dry_run)
 
 
@@ -1069,17 +1073,12 @@ class TailEventsCommand(SubCommand):
         parser.add_argument("-s", "--step", choices=["extract", "load", "upgrade", "update", "unload"],
                             help="pick which step to tail")
         now = datetime.now(timezone.utc).replace(microsecond=0, tzinfo=None).isoformat()
-        parser.add_argument("-t", "--start-time", help="beginning of time window, e.g. '%s'" % now)
+        parser.add_argument("-t", "--start-time", help="beginning of time window, e.g. '%s'" % now,
+                            type=isoformat_datetime_string)
         parser.add_argument("-f", "--follow", help="keep checking for events", default=False, action="store_true")
 
     def callback(self, args, config):
-        if args.start_time:
-            try:
-                start_time = datetime.strptime(args.start_time, "%Y-%m-%dT%H:%M:%S")
-            except ValueError as exc:
-                raise InvalidArgumentError from exc
-        else:
-            start_time = datetime.utcnow() - timedelta(seconds=15 * 60)
+        start_time = args.start_time or (datetime.utcnow() - timedelta(seconds=15 * 60))
         if args.follow:
             update_interval = 30
             idle_time_out = 60 * 60

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -24,7 +24,7 @@ import etl.config.dw
 import etl.db
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import ETLRuntimeError, ETLConfigError
-from etl.names import join_with_quotes
+from etl.text import join_with_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -17,7 +17,7 @@ import etl.db
 import etl.file_sets
 import etl.s3
 from etl.errors import SchemaValidationError, TableDesignParseError, TableDesignSemanticError, TableDesignSyntaxError
-from etl.names import join_with_quotes
+from etl.text import join_with_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -13,7 +13,8 @@ from psycopg2.extensions import connection  # only for type annotation
 
 import etl.db
 from etl.errors import TransientETLError
-from etl.names import join_column_list, TableName
+from etl.names import TableName
+from etl.text import join_column_list
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -185,7 +186,8 @@ def copy_from_uri(conn: connection, table_name: TableName, column_list: List[str
         TRUNCATECOLUMNS
         STATUPDATE OFF
         COMPUPDATE {compupdate}
-        """.format(table=table_name, columns=join_column_list(column_list), compupdate="ON" if need_compupdate else "OFF")
+        """.format(table=table_name, columns=join_column_list(column_list),
+                   compupdate="ON" if need_compupdate else "OFF")
     if dry_run:
         logger.info("Dry-run: Skipping copying data into '%s' from '%s'", table_name.identifier, s3_uri)
         etl.db.skip_query(conn, stmt, (s3_uri, credentials))

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -1,6 +1,9 @@
 import time
 from functools import partial
 
+# This module is import-free besides Arthur text utilities
+from etl.text import join_with_quotes
+
 
 class ETLError(Exception):
     """
@@ -182,8 +185,8 @@ class MissingExtractEventError(RelationDataError):
     def __init__(self, source_relations, extracted_targets):
         missing_relations = [relation for relation in source_relations
                              if relation.identifier not in extracted_targets]
-        self.message = "Some source relations did not have extract events after the step start time: {}".format(
-            ", ".join([relation.identifier for relation in missing_relations]))
+        self.message = ("Some source relations did not have extract events after the step start time: " +
+                        join_with_quotes(missing_relations))
 
     def __str__(self):
         return self.message
@@ -197,7 +200,7 @@ class FailedConstraintError(RelationDataError):
         self.columns = columns
         self.example_string = ',\n  '.join(map(str, examples))
         self.message = ("relation {0.identifier} violates {0.constraint_type} constraint.\n"
-                "Example duplicate values of {0.columns} are:\n  {0.example_string}".format(self))
+                        "Example duplicate values of {0.columns} are:\n  {0.example_string}".format(self))
 
     def __str__(self):
         return self.message
@@ -206,9 +209,7 @@ class FailedConstraintError(RelationDataError):
 class RequiredRelationLoadError(ETLRuntimeError):
 
     def __init__(self, failed_relations, bad_apple=None):
-        # Avoiding `join_with_quotes` here to keep this module import-free
-        self.message = "required relation(s) with failure: "
-        self.message += ", ".join("'{}'".format(name) for name in failed_relations)
+        self.message = "required relation(s) with failure: " + join_with_quotes(failed_relations)
         if bad_apple:
             self.message += ", triggered by load failure of '{}'".format(bad_apple)
 

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -177,6 +177,18 @@ class UpdateTableError(RelationDataError):
     pass
 
 
+class MissingExtractEventError(RelationDataError):
+
+    def __init__(self, source_relations, extracted_targets):
+        missing_relations = [relation for relation in source_relations
+                             if relation.identifier not in extracted_targets]
+        self.message = "Some source relations did not have extract events after the step start time: {}".format(
+            ", ".join([relation.identifier for relation in missing_relations]))
+
+    def __str__(self):
+        return self.message
+
+
 class FailedConstraintError(RelationDataError):
 
     def __init__(self, relation, constraint_type, columns, examples):
@@ -184,10 +196,11 @@ class FailedConstraintError(RelationDataError):
         self.constraint_type = constraint_type
         self.columns = columns
         self.example_string = ',\n  '.join(map(str, examples))
+        self.message = ("relation {0.identifier} violates {0.constraint_type} constraint.\n"
+                "Example duplicate values of {0.columns} are:\n  {0.example_string}".format(self))
 
     def __str__(self):
-        return ("relation {0.identifier} violates {0.constraint_type} constraint.\n"
-                "Example duplicate values of {0.columns} are:\n  {0.example_string}".format(self))
+        return self.message
 
 
 class RequiredRelationLoadError(ETLRuntimeError):

--- a/python/etl/extract/__init__.py
+++ b/python/etl/extract/__init__.py
@@ -35,7 +35,7 @@ from etl.extract.manifest_only import ManifestOnlyExtractor
 from etl.extract.spark import SparkExtractor
 from etl.extract.sqoop import SqoopExtractor
 from etl.extract.static import StaticExtractor
-from etl.names import join_with_quotes
+from etl.text import join_with_quotes
 from etl.relation import RelationDescription
 
 logger = logging.getLogger(__name__)

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -21,7 +21,7 @@ from etl.errors import (
     MissingCsvFilesError,
     retry
 )
-from etl.names import join_with_quotes
+from etl.text import join_with_quotes
 from etl.relation import RelationDescription
 from etl.timer import Timer
 
@@ -84,8 +84,8 @@ class Extractor:
                                              options=self.options_info(),
                                              source=self.source_info(source, relation),
                                              destination={'bucket_name': relation.bucket_name,
-                                                           'object_key': relation.manifest_file_name},
-                                              index={"current": i + 1, "final": len(relations), "name": source.name},
+                                                          'object_key': relation.manifest_file_name},
+                                             index={"current": i + 1, "final": len(relations), "name": source.name},
                                              dry_run=self.dry_run):
                         retry(extract_retries, extract_func, self.logger)
                 except ETLRuntimeError:

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -717,10 +717,10 @@ def recently_extracted_targets(source_relations, start_time):
 
     query = EventsQuery('extract')
     consumer_queue = queue.Queue()  # type: ignore
-    cutoff_epoch = timegm(start_time.utctimetuple())
+    start_as_epoch = timegm(start_time.utctimetuple())
     timeout = 60 * 60
     extract_querying_thread = BackgroundQueriesRunner(
-        targets, query, consumer_queue, cutoff_epoch,
+        targets, query, consumer_queue, start_as_epoch,
         update_interval=30, idle_time_out=timeout, daemon=True)
     extract_querying_thread.start()
     extracted_targets = set()

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -13,34 +13,7 @@ from typing import Optional, List
 
 import etl.config
 from etl.errors import ETLSystemError
-
-
-def join_with_quotes(names):
-    """
-    Individually wrap the names in quotes and return comma-separated names in a string.
-
-    If the input is a set of names, the names are sorted first.
-    If the input is a list of names, the order of the list is respected.
-    If the input is cheese, the order is for more red wine.
-
-    >>> join_with_quotes(["foo", "bar"])
-    "'foo', 'bar'"
-    >>> join_with_quotes({"foo", "bar"})
-    "'bar', 'foo'"
-    >>> join_with_quotes(frozenset(["foo", "bar"]))
-    "'bar', 'foo'"
-    """
-    if isinstance(names, (set, frozenset)):
-        return ', '.join("'{}'".format(name) for name in sorted(names))
-    else:
-        return ', '.join("'{}'".format(name) for name in names)
-
-
-def join_column_list(columns):
-    """
-    Return string with comma-separated, delimited column names
-    """
-    return ", ".join('"{}"'.format(column) for column in columns)
+from etl.text import join_with_quotes
 
 
 def as_staging_name(name):

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -10,7 +10,7 @@ from typing import List
 import boto3
 
 import etl.text
-from etl.names import join_with_quotes
+from etl.text import join_with_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -33,7 +33,8 @@ import etl.s3
 import etl.timer
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import CyclicDependencyError, ETLRuntimeError, MissingQueryError
-from etl.names import join_with_quotes, TableName, TableSelector, TempTableName
+from etl.names import TableName, TableSelector, TempTableName
+from etl.text import join_with_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -103,7 +103,6 @@
             "type": "EmrActivity",
             "step": "/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar,/tmp/redshift_etl/venv/bin/arthur.py,--config,/tmp/redshift_etl/config/,extract,--keep-going,--prolix,--prefix,${object_store.s3.prefix}/current,#{myCommaSeparatedSelection}",
             "runsOn": { "ref": "ETLCluster" },
-            "failureAndRerunMode": false,
             "maximumRetries": "0"
         },
         {
@@ -134,10 +133,9 @@
             "name": "Arthur Update (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ update --prolix --prefix ${object_store.s3.prefix}/current --extract-look-back 300 #{mySelection}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ update --prolix --prefix ${object_store.s3.prefix}/current --scheduled-start-time #{node.@scheduledStartTime} #{mySelection}",
             "dependsOn": [
-                { "ref": "Bootstrap" },
-                { "ref": "EmrActivityUpstreamExtract" }
+                { "ref": "Bootstrap" }
             ]
         },
         {

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -103,6 +103,7 @@
             "type": "EmrActivity",
             "step": "/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar,/tmp/redshift_etl/venv/bin/arthur.py,--config,/tmp/redshift_etl/config/,extract,--keep-going,--prolix,--prefix,${object_store.s3.prefix}/current,#{myCommaSeparatedSelection}",
             "runsOn": { "ref": "ETLCluster" },
+            "failureAndRerunMode": false,
             "maximumRetries": "0"
         },
         {

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -134,7 +134,7 @@
             "name": "Arthur Update (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ update --prolix --prefix ${object_store.s3.prefix}/current #{mySelection}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ update --prolix --prefix ${object_store.s3.prefix}/current --extract-look-back 300 #{mySelection}",
             "dependsOn": [
                 { "ref": "Bootstrap" },
                 { "ref": "EmrActivityUpstreamExtract" }

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -133,7 +133,7 @@
             "name": "Arthur Update (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ update --prolix --prefix ${object_store.s3.prefix}/current --scheduled-start-time #{node.@scheduledStartTime} #{mySelection}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ update --prolix --prefix ${object_store.s3.prefix}/current --scheduled-start-time #{@scheduledStartTime} #{mySelection}",
             "dependsOn": [
                 { "ref": "Bootstrap" }
             ]

--- a/python/etl/text.py
+++ b/python/etl/text.py
@@ -1,8 +1,37 @@
 """
-Deal with text, mostly around matrices of texts which we want to pretty print.
+Deal with text, mostly around iterables of texts which we want to pretty print.
+Should not import Arthur modules (so that etl.errors remains widely importable)
 """
 
 import textwrap
+
+
+def join_with_quotes(names):
+    """
+    Individually wrap the names in quotes and return comma-separated names in a string.
+
+    If the input is a set of names, the names are sorted first.
+    If the input is a list of names, the order of the list is respected.
+    If the input is cheese, the order is for more red wine.
+
+    >>> join_with_quotes(["foo", "bar"])
+    "'foo', 'bar'"
+    >>> join_with_quotes({"foo", "bar"})
+    "'bar', 'foo'"
+    >>> join_with_quotes(frozenset(["foo", "bar"]))
+    "'bar', 'foo'"
+    """
+    if isinstance(names, (set, frozenset)):
+        return ', '.join("'{}'".format(name) for name in sorted(names))
+    else:
+        return ', '.join("'{}'".format(name) for name in names)
+
+
+def join_column_list(columns):
+    """
+    Return string with comma-separated, delimited column names
+    """
+    return ", ".join('"{}"'.format(column) for column in columns)
 
 
 class ColumnWrapper(textwrap.TextWrapper):

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -34,7 +34,8 @@ import etl.relation
 from etl.config.dw import DataWarehouseConfig, DataWarehouseSchema
 from etl.errors import ETLConfigError, ETLDelayedExit, ETLRuntimeError  # Exception classes that we might catch
 from etl.errors import TableDesignValidationError, UpstreamValidationError  # Exception classes that we might raise
-from etl.names import join_with_quotes, TableName
+from etl.names import TableName
+from etl.text import join_with_quotes
 from etl.relation import RelationDescription
 from etl.timer import Timer
 


### PR DESCRIPTION
Attempt to solve https://github.com/harrystech/arthur-redshift-etl/issues/89 by checking for recent extracts during `update` and de-coupling these Data Pipeline Activities.
