### PR TITLE
Enable "--continue-from=:transformations" for upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,15 +201,18 @@ arthur.py show_downstream_dependents -q | grep 'kind=DATA' | tee sources.txt
 arthur.py ls --remote @sources.txt
 ```
 
-The above also works when we're just interested in transformations. This can
-save time while iterating on transformations since the sources won't be reloaded.
+Note that you should use the special value `:transformations` when you're interested
+to work with transformations.
 
 Example:
 ```shell
-arthur.py show_downstream_dependents -q | grep -v 'kind=DATA' | tee transformations.txt
+arthur.py show_downstream_dependents -q --continue-from=:transformations | tee transformations.txt
 
 arthur.py sync @transformations.txt
 arthur.py upgrade --only @transformations.txt
+
+# If you don't make changes to transformations.txt, then you might as well use
+arthur.py upgrade --continue-from=:transformations
 ```
 
 ### Working with a table and everything feeding it

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -321,7 +321,8 @@ def add_standard_arguments(parser, options):
     if "continue-from" in options:
         parser.add_argument("--continue-from",
                             help="skip forward in execution until the specified relation, then work forward from it"
-                            " (the special token '*' is allowed to signify continuing from the first relation)")
+                            " (the special token '*' is allowed to signify continuing from the first relation;"
+                            " use ':transformations' as the argument to continue from the first transformation)")
     if "pattern" in options:
         parser.add_argument("pattern", help="glob pattern or identifier to select table(s) or view(s)",
                             nargs='*', action=StorePatternAsSelector)
@@ -1092,6 +1093,8 @@ class TailEventsCommand(SubCommand):
         # (If events for all tables already happen to exist, then this matches the desired execution order.)
         all_relations = self.find_relation_descriptions(args, default_scheme="s3", return_all=True)
         selected_relations = etl.relation.select_in_execution_order(all_relations, args.pattern)
+        if not selected_relations:
+            return
         etl.monitor.tail_events(selected_relations,
                                 start_time=start_time, update_interval=update_interval, idle_time_out=idle_time_out,
                                 step=args.step)

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -768,8 +768,7 @@ def tail_events(relations, start_time, update_interval=None, idle_time_out=None,
         # Keep printing tail of table that accumulates the events.
         if len(events) > n_printed:
             lines = etl.text.format_lines(
-                [[event[header] for header in query.keys] for event in events],
-                header_row=query.keys).split('\n')
+                [[event[header] for header in query.keys] for event in events], header_row=query.keys).split('\n')
             if n_printed:
                 print('\n'.join(lines[n_printed + 2:-1]))  # skip header and final "(x rows)" line
             else:


### PR DESCRIPTION
Closes #87 

User visible changes:
* It is now possible to skip past source relations when upgrading (or checking downstream dependents).
    * Anticipated use cases are around loading the source relations and then iterating over just transformations (either during development or during incidents)
    * It's possibly to simply run transformations alone or to combine this feature with the selection of a sub "tree": 
```
arthur.py upgrade --continue-from=:transformations
arthur.py upgrade --continue-from=:transformations www
# Remember that it's easy to see the list of dependents using `--dry-run` or directly:
arthur.py show_downstream_dependents --continue-from=:transformations www
# If you need to run a pizza pipeline:
install_pizza_load_pipeline.sh production :transformations
```