### PR TITLE
Add default mapping for unknown column types

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -50,7 +50,7 @@
             "date": "string",
             "timestamp without time zone": "string"
         },
-        # Map of known PostgreSQL attribute types to usable types in Redshift.  Missing types will cause an exception
+        # Map of known PostgreSQL attribute types to usable types in Redshift.
         # The first element in the list is the new type, the second element is the necessary cast expression,
         # the third element is the serialization format in Avro files.
         # Note that in every expression, %s is replaced by the column name within quotes.
@@ -73,6 +73,8 @@
             "numeric": ["decimal(18,4)", "%s::decimal(18,4)", "string"],
             # The bytea data type is probably not useful, but we'll try to pull it in base64 format.
             "bytea": ["varchar(65535)", "encode(%s, 'base64')", "string"]
-        }
+        },
+        # Default type as a fallback solution. Example use case is for enumeration types.
+        "default_att_type": ["varchar(10000)", "%s::varchar(10000)", "string"],
     }
 }

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -186,9 +186,15 @@
                         "minItems": 3,
                         "maxItems": 3
                     }
+                },
+                "default_att_type": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 3,
+                    "maxItems": 3
                 }
             },
-            "required": [ "as_is_att_type", "cast_needed_att_type" ],
+            "required": [ "as_is_att_type", "cast_needed_att_type", "default_att_type" ],
             "additionalProperties": false
         },
         "data_lake": {

--- a/python/etl/design/__init__.py
+++ b/python/etl/design/__init__.py
@@ -1,6 +1,8 @@
 import re
+import logging
 
-from etl.errors import MissingMappingError
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class Attribute:
@@ -44,7 +46,7 @@ class ColumnDefinition:
         return d
 
     @staticmethod
-    def from_attribute(attribute, as_is_att_type, cast_needed_att_type):
+    def from_attribute(attribute, as_is_att_type, cast_needed_att_type, default_att_type):
         """
         Turn a table attribute into a "column" of a table design. This adds the generic type and
         possibly a cast into a supported type.
@@ -60,7 +62,10 @@ class ColumnDefinition:
                     # Found tuple with new SQL type, expression and generic type.  Rejoice.
                     break
             else:
-                raise MissingMappingError("Unknown type '{}' of '{}'".format(attribute.sql_type, attribute.name))
+                logger.warning("Unknown type '{}' of column '{}' (using default)".format(attribute.sql_type,
+                                                                                         attribute.name))
+                mapping_sql_type, mapping_expression, mapping_type = default_att_type
+
         delimited_name = '"{}"'.format(attribute.name)
         return ColumnDefinition(attribute.name,
                                 attribute.sql_type,

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -82,12 +82,6 @@ class InvalidEnvironmentError(ETLRuntimeError):
     """
 
 
-class MissingMappingError(ETLConfigError):
-    """
-    Exception when an attribute type's target type is unknown
-    """
-
-
 class TableDesignError(ETLConfigError):
     """
     Exception when a table design file is incorrect


### PR DESCRIPTION
Closes #64 

User-facing changes:
* When bootstrapping the design file for a table where a column has a user-defined type (PostgreSQL enumeration), then the default is now a cast to a string (`varchar(10000)`) instead of an error.