### PR TITLE
Release candidate for v1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,15 +201,18 @@ arthur.py show_downstream_dependents -q | grep 'kind=DATA' | tee sources.txt
 arthur.py ls --remote @sources.txt
 ```
 
-The above also works when we're just interested in transformations. This can
-save time while iterating on transformations since the sources won't be reloaded.
+Note that you should use the special value `:transformations` when you're interested
+to work with transformations.
 
 Example:
 ```shell
-arthur.py show_downstream_dependents -q | grep -v 'kind=DATA' | tee transformations.txt
+arthur.py show_downstream_dependents -q --continue-from=:transformations | tee transformations.txt
 
 arthur.py sync @transformations.txt
 arthur.py upgrade --only @transformations.txt
+
+# If you don't make changes to transformations.txt, then you might as well use
+arthur.py upgrade --continue-from=:transformations
 ```
 
 ### Working with a table and everything feeding it

--- a/cloudformation/dw_admin.yaml
+++ b/cloudformation/dw_admin.yaml
@@ -39,32 +39,40 @@ Resources:
                 PolicyDocument:
                     Version: "2012-10-17"
                     Statement:
-                      - Sid: "CreateAnything"
+                      - Sid: "ReadAnything"
                         Effect: "Allow"
                         Action:
                             - "cloudwatch:DescribeAlarms"
+                            - "cloudwatch:GetDashboard"
+                            - "cloudwatch:ListDashboards"
+                            - "cloudwatch:GetMetricStatistics"
+                            - "cloudwatch:ListMetrics"
                             - "datapipeline:Describe*"
                             - "datapipeline:Get*"
                             - "datapipeline:List*"
                             - "datapipeline:Query*"
+                            - "ec2:Describe*"
+                            - "iam:GetRole*"
+                            - "iam:ListInstanceProfiles"
+                            - "iam:ListRolePolicies"
+                            - "s3:Get*"
+                            - "s3:List*"
+                            - "sns:Get*"
+                            - "sns:List*"
+                        Resource: "*"
+                      # This should be much more selective in the resources!
+                      - Sid: "CreateAnything"
+                        Effect: "Allow"
+                        Action:
+                            - "datapipeline:Query*"
                             - "ec2:AuthorizeSecurityGroup*"
                             - "ec2:CreateNetworkInterface"
                             - "ec2:CreateTags"
-                            - "ec2:Describe*"
                             - "ec2:RunInstances"
                             - "elasticmapreduce:*"
                             - "emr:*"
-                            - "iam:GetRole"
-                            - "iam:GetRolePolicy"
-                            - "iam:ListInstanceProfiles"
-                            - "iam:ListRolePolicies"
                             - "iam:PassRole"
-                            - "lambda:*"
-                            - "s3:Get*"
-                            - "s3:List*"
                             - "sns:Create*"
-                            - "sns:Get*"
-                            - "sns:List*"
                             - "sns:Publish"
                         Resource: "*"
                       - Sid: "ModifyOnlyOursInS3"
@@ -120,8 +128,6 @@ Resources:
                             - "ec2:TerminateInstances"
                         Resource: "*"
 
-
-
     AssumeAdminPolicy:
         Type: AWS::IAM::Policy
         Properties:
@@ -137,6 +143,8 @@ Resources:
                       Condition:
                           IpAddress:
                               "aws:SourceIp": !Ref OfficeIPs
+                          Bool:
+                              "aws:SecureTransport": true
 
 
 Outputs:

--- a/cloudformation/dw_cluster.yaml
+++ b/cloudformation/dw_cluster.yaml
@@ -139,6 +139,43 @@ Resources:
     # Note that an option to set enhanced VPC routing is missing in CloudFormation, so this must be done using the CLI
     # aws redshift modify-cluster --cluster-identifier "[cluster identifier]" --enhanced-vpc-routing
 
+    ClusterAlertTopic:
+        Type: AWS::SNS::Topic
+
+    DiskSpaceUsageTooHighAlarm:
+        Type: AWS::CloudWatch::Alarm
+        Properties:
+            AlarmDescription: "Disk space usage too high"
+            AlarmActions:
+                - !Ref ClusterAlertTopic
+            MetricName: PercentageDiskSpaceUsed
+            Namespace: AWS/Redshift
+            Statistic: Average
+            ComparisonOperator: GreaterThanThreshold
+            Threshold: 60
+            Period: 300
+            EvaluationPeriods: 3
+            Dimensions:
+                - Name: ClusterIdentifier
+                  Value: !Ref RedshiftCluster
+
+    ClusterUnhealthyAlarm:
+        Type: AWS::CloudWatch::Alarm
+        Properties:
+            AlarmDescription: "Cluster unhealthy"
+            AlarmActions:
+                - !Ref ClusterAlertTopic
+            MetricName: HealthStatus
+            Namespace: AWS/Redshift
+            Statistic: Minimum
+            ComparisonOperator: LessThanThreshold
+            Threshold: 1
+            Period: 60
+            EvaluationPeriods: 3
+            Dimensions:
+                - Name: ClusterIdentifier
+                  Value: !Ref RedshiftCluster
+
 
 Outputs:
 
@@ -155,3 +192,7 @@ Outputs:
     RedshiftParamterGroupName:
         Description: Used as value for '--parameter-group-name' in AWS CLI
         Value: !Ref RedshiftClusterParameterGroup
+
+    ClusterAlertTopicArn:
+        Description: ARN of SNS topic to publish CloudWatch alarms
+        Value: !Ref ClusterAlertTopic

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -321,7 +321,8 @@ def add_standard_arguments(parser, options):
     if "continue-from" in options:
         parser.add_argument("--continue-from",
                             help="skip forward in execution until the specified relation, then work forward from it"
-                            " (the special token '*' is allowed to signify continuing from the first relation)")
+                            " (the special token '*' is allowed to signify continuing from the first relation;"
+                            " use ':transformations' as the argument to continue from the first transformation)")
     if "pattern" in options:
         parser.add_argument("pattern", help="glob pattern or identifier to select table(s) or view(s)",
                             nargs='*', action=StorePatternAsSelector)
@@ -1092,6 +1093,8 @@ class TailEventsCommand(SubCommand):
         # (If events for all tables already happen to exist, then this matches the desired execution order.)
         all_relations = self.find_relation_descriptions(args, default_scheme="s3", return_all=True)
         selected_relations = etl.relation.select_in_execution_order(all_relations, args.pattern)
+        if not selected_relations:
+            return
         etl.monitor.tail_events(selected_relations,
                                 start_time=start_time, update_interval=update_interval, idle_time_out=idle_time_out,
                                 step=args.step)

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1127,9 +1127,11 @@ class SelfTestCommand(SubCommand):
         # For self-tests, dial logging back to (almost) nothing so that logging in console doesn't mix with test output.
         parser.set_defaults(log_level="CRITICAL")
         parser.add_argument("test_family", help="select which family of tests to run",
-                            nargs='?', choices=["doctest", "type-check", "all"], default="all")
+                            nargs='?', choices=["pep8", "doctest", "type-check", "all"], default="all")
 
     def callback(self, args, config):
+        if args.test_family in ("pep8", "all"):
+            etl.selftest.run_pep8("etl", args.log_level)
         if args.test_family in ("doctest", "all"):
             etl.selftest.run_doctest("etl", args.log_level)
         if args.test_family in ("type-check", "all"):

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -50,7 +50,7 @@
             "date": "string",
             "timestamp without time zone": "string"
         },
-        # Map of known PostgreSQL attribute types to usable types in Redshift.  Missing types will cause an exception
+        # Map of known PostgreSQL attribute types to usable types in Redshift.
         # The first element in the list is the new type, the second element is the necessary cast expression,
         # the third element is the serialization format in Avro files.
         # Note that in every expression, %s is replaced by the column name within quotes.
@@ -73,6 +73,8 @@
             "numeric": ["decimal(18,4)", "%s::decimal(18,4)", "string"],
             # The bytea data type is probably not useful, but we'll try to pull it in base64 format.
             "bytea": ["varchar(65535)", "encode(%s, 'base64')", "string"]
-        }
+        },
+        # Default type as a fallback solution. Example use case is for enumeration types.
+        "default_att_type": ["varchar(10000)", "%s::varchar(10000)", "string"],
     }
 }

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -186,9 +186,15 @@
                         "minItems": 3,
                         "maxItems": 3
                     }
+                },
+                "default_att_type": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 3,
+                    "maxItems": 3
                 }
             },
-            "required": [ "as_is_att_type", "cast_needed_att_type" ],
+            "required": [ "as_is_att_type", "cast_needed_att_type", "default_att_type" ],
             "additionalProperties": false
         },
         "data_lake": {

--- a/python/etl/design/__init__.py
+++ b/python/etl/design/__init__.py
@@ -1,6 +1,8 @@
 import re
+import logging
 
-from etl.errors import MissingMappingError
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class Attribute:
@@ -44,7 +46,7 @@ class ColumnDefinition:
         return d
 
     @staticmethod
-    def from_attribute(attribute, as_is_att_type, cast_needed_att_type):
+    def from_attribute(attribute, as_is_att_type, cast_needed_att_type, default_att_type):
         """
         Turn a table attribute into a "column" of a table design. This adds the generic type and
         possibly a cast into a supported type.
@@ -60,7 +62,10 @@ class ColumnDefinition:
                     # Found tuple with new SQL type, expression and generic type.  Rejoice.
                     break
             else:
-                raise MissingMappingError("Unknown type '{}' of '{}'".format(attribute.sql_type, attribute.name))
+                logger.warning("Unknown type '{}' of column '{}' (using default)".format(attribute.sql_type,
+                                                                                         attribute.name))
+                mapping_sql_type, mapping_expression, mapping_type = default_att_type
+
         delimited_name = '"{}"'.format(attribute.name)
         return ColumnDefinition(attribute.name,
                                 attribute.sql_type,

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -82,12 +82,6 @@ class InvalidEnvironmentError(ETLRuntimeError):
     """
 
 
-class MissingMappingError(ETLConfigError):
-    """
-    Exception when an attribute type's target type is unknown
-    """
-
-
 class TableDesignError(ETLConfigError):
     """
     Exception when a table design file is incorrect

--- a/python/etl/extract/database_extractor.py
+++ b/python/etl/extract/database_extractor.py
@@ -4,8 +4,6 @@ DatabaseExtractors query upstream databases and save their data on S3 before wri
 from contextlib import closing
 from typing import Dict, List, Optional
 
-from psycopg2.extensions import connection  # only for type annotation
-
 import etl.db
 from etl.extract.extractor import Extractor
 from etl.config.dw import DataWarehouseSchema

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -768,8 +768,7 @@ def tail_events(relations, start_time, update_interval=None, idle_time_out=None,
         # Keep printing tail of table that accumulates the events.
         if len(events) > n_printed:
             lines = etl.text.format_lines(
-                [[event[header] for header in query.keys] for event in events],
-                header_row=query.keys).split('\n')
+                [[event[header] for header in query.keys] for event in events], header_row=query.keys).split('\n')
             if n_printed:
                 print('\n'.join(lines[n_printed + 2:-1]))  # skip header and final "(x rows)" line
             else:

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -18,14 +18,14 @@ from etl.text import join_with_quotes
 
 def as_staging_name(name):
     """
-    The canonical transformation of a (schema) name to its staging position
+    The canonical transformation of a schema name to its staging position
     """
     return '$'.join(("etl_staging", name))
 
 
 def as_backup_name(name):
     """
-    The canonical transformation of a (schema) name to its backup position
+    The canonical transformation of a schema name to its backup position
     """
     return '$'.join(("etl_backup", name))
 
@@ -71,24 +71,25 @@ class TableName:
     >>> purchases.managed_schemas = ['www']
     >>> staging_purchases = purchases.as_staging_table_name()
     >>> staging_purchases.managed_schemas = ['www']
+    >>> # Now the table names are the same but they are in different schemas (staging vs. not)
     >>> staging_purchases.table == purchases.table
     True
     >>> staging_purchases.schema == purchases.schema
     False
     """
 
-    __slots__ = ("_schema", "_table", "_staging", "_managed_schemas")
+    __slots__ = ("_schema", "_table", "_is_staging", "_managed_schemas")
 
-    def __init__(self, schema: Optional[str], table: str) -> None:
+    def __init__(self, schema: Optional[str], table: str, is_staging=False) -> None:
         # Concession to subclasses ... schema is optional
         self._schema = schema.lower() if schema else None
         self._table = table.lower()
-        self._staging = False
+        self._is_staging = is_staging
         self._managed_schemas = None  # type: Optional[frozenset]
 
     @property
     def schema(self):
-        if self.staging and self.is_managed:
+        if self.is_staging and self.is_managed:
             return as_staging_name(self._schema)
         else:
             return self._schema
@@ -98,11 +99,16 @@ class TableName:
         return self._table
 
     @property
-    def staging(self):
-        return self._staging
+    def is_staging(self):
+        return self._is_staging
 
     @property
     def managed_schemas(self) -> frozenset:
+        """
+        (Cached) list of schemas that are managed by Arthur
+
+        This contains all schemas not just the schema of this relation.
+        """
         if self._managed_schemas is None:
             try:
                 schemas = etl.config.get_dw_config().schemas
@@ -249,9 +255,7 @@ class TableName:
         return fnmatch.fnmatch(self.identifier, pattern)
 
     def as_staging_table_name(self):
-        tn = TableName(*self.to_tuple())
-        tn._staging = True
-        return tn
+        return TableName(*self.to_tuple(), is_staging=True)
 
 
 class TempTableName(TableName):

--- a/python/etl/selftest.py
+++ b/python/etl/selftest.py
@@ -13,6 +13,8 @@ import sys
 import unittest
 from typing import Optional
 
+import pep8
+
 
 # Skip etl.commands to avoid circular dependency
 import etl.config
@@ -41,6 +43,19 @@ import etl.validate
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+
+def run_pep8(module_: Optional[str]=None, log_level: str= "INFO") -> None:
+    print("Running pep8...")
+    if module_ is None:
+        module_ = __name__
+    quiet = log_level not in ("DEBUG", "INFO")
+    style_guide = pep8.StyleGuide(parse_argv=False, quiet=quiet)
+    report = style_guide.check_files(['python'])
+    if report.total_errors > 0:
+        raise etl.errors.SelfTestError("Unsuccessful (warning=%d, errors=%d)" %
+                                       (report.get_count('W'), report.get_count('E')))
+    print("OK")
 
 
 def load_tests(loader, tests, pattern):
@@ -92,8 +107,13 @@ def run_type_checker() -> None:
 
 
 def run_tests() -> None:
-    run_doctest()
-    run_type_checker()
+    try:
+        run_pep8()
+        run_doctest()
+        run_type_checker()
+    except Exception as exc:
+        print(exc)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -8,7 +8,7 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "${resources.EC2.iam_instance_profile}",
             "role": "${resources.DataPipeline.role}",
-            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/logs/",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/",
             "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -8,7 +8,7 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "${resources.EC2.iam_instance_profile}",
             "role": "${resources.DataPipeline.role}",
-            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/logs/",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/",
             "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -8,7 +8,7 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "${resources.EC2.iam_instance_profile}",
             "role": "${resources.DataPipeline.role}",
-            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/current/logs/",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/current/",
             "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -8,7 +8,7 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "${resources.EC2.iam_instance_profile}",
             "role": "${resources.DataPipeline.role}",
-            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/logs/",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/",
             "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.7.1",
+    version="1.8.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
User visible changes:
* It is now possible to skip past source relations when upgrading (or checking downstream dependents).
    * Anticipated use cases are around loading the source relations and then iterating over just transformations (either during development or during incidents)
    * It's possibly to simply run transformations alone or to combine this feature with the selection of a sub "tree": 
```
arthur.py upgrade --continue-from=:transformations
arthur.py upgrade --continue-from=:transformations www
# Remember that it's easy to see the list of dependents using `--dry-run` or directly:
arthur.py show_downstream_dependents --continue-from=:transformations www
# If you need to run a pizza pipeline:
install_pizza_load_pipeline.sh production :transformations
```

* When bootstrapping the design file for a table where a column has a user-defined type (PostgreSQL enumeration), then the default is now a cast to a string (`varchar(10000)`) instead of an error.

* All logfiles will now be under a top-level "folder" in the S3 bucket: `_logs`
* Some log messages are better harmonized with respect to their levels.
* We've added alarms for the Redshift clusters when they are running low on disk space or are unhealthy
* Running self-tests now includes running pep8.
