### PR TITLE
Dockerize Arthur for local development and update PyYAML

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+*.sw*
+*.log
+*.log.[0-9]
+*.out
+*.pyc
+*.RData
+
+# temp data (including generated files)
+/data/
+/tmp/
+
+# virtual environment and local install
+venv/
+/dist/
+/build/
+*.egg-info
+/.mypy_cache
+
+# In case you accidentally download your credentials here
+credentials*
+
+# ignore jars
+jars/
+
+# Mac stuff
+.DS_Store
+.idea/
+
+/.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+#
+# This attempts to create an environment as close to what ./bin/bootstrap.sh
+# creates as possible with the images available. TODO: Resolve assumptions
+# from bootstrap.sh so it can be used here to remove code duplication.
+#
+FROM amazonlinux:2017.03
+
+WORKDIR /tmp/redshift_etl
+
+RUN yum install -y \
+        postgresql95-devel \
+        python35 \
+        python35-pip \
+        python35-devel \
+        aws-cli \
+        gcc \
+        libyaml-devel \
+        tmux \
+        jq && \
+    pip-3.5 install --upgrade --disable-pip-version-check virtualenv
+
+
+COPY requirements.txt ./
+COPY requirements-dev.txt ./
+RUN virtualenv --python=python3 venv && \
+    source venv/bin/activate && \
+    pip3 install --upgrade pip --disable-pip-version-check && \
+    pip3 install --requirement ./requirements-dev.txt
+
+COPY . .
+RUN source venv/bin/activate && \
+    python3 setup.py develop
+
+# Use the self tests to check if everything was installed properly
+RUN source venv/bin/activate && \
+    run_tests.py
+
+# Ensure the venv is activated when running interactive shells
+RUN echo "source /tmp/redshift_etl/venv/bin/activate" > /root/.bashrc
+
+WORKDIR /data-warehouse
+
+# From here, bind-mount your data warehouse code directory to /data-warehouse.
+# All of the normal Arthur configuration for accessing and managing the data
+# warehouse is assumed to have already been set up in that directory.

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eu
+
+show_usage_and_exit () {
+    cat <<EOF
+Usage: `basename $0`
+
+Builds the Docker image you can use to run Arthur locally instead of manually
+configuring your enviornment. Docker itself must already be preinstalled.
+EOF
+    exit ${1-0}
+}
+
+profile=""
+
+while getopts "hp:" opt; do
+    case "$opt" in
+      h)
+        show_usage_and_exit
+        ;;
+      \?)
+        echo "Invalid option: -$OPTARG" >&2
+        exit 1
+      ;;
+    esac
+done
+
+docker build -t harrystech/arthur .

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eu
+
+show_usage_and_exit () {
+    cat <<EOF
+Usage: `basename $0` [-p aws_profile] <config_dir> <target_env>
+
+Drops you into a shell in a Docker container with Arthur installed and
+configured to point at <config_dir> and <target_env>. This script should be
+run with your data warehouse directory as the current directory.
+
+The optional -p flag lets you use the given profile from your AWS CLI config
+within the container.
+
+NOTE: You must build the Docker image with docker_build.sh before using this
+script.
+EOF
+    exit ${1-0}
+}
+
+profile=""
+
+while getopts "hp:" opt; do
+    case "$opt" in
+      h)
+        show_usage_and_exit
+        ;;
+      p)
+        profile="-e AWS_PROFILE=$OPTARG"
+        shift
+        ;;
+      \?)
+        echo "Invalid option: -$OPTARG" >&2
+        exit 1
+      ;;
+    esac
+done
+
+if [[ $# -lt 3 ]]; then
+    show_usage_and_exit 1
+fi
+
+config_dir="$1"
+target_env="$2"
+
+docker run --rm -it -v "$PWD":/data-warehouse -v ~/.aws:/root/.aws -e DATA_WAREHOUSE_CONFIG=/data-warehouse/$config_dir -e USER=$target_env $profile harrystech/arthur

--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 
 # This will create a new distribution locally and upload everything into S3.
+#
+# NOTE: This won't work inside the Docker container because we don't add git
+# or the Arthur git repository this needs. Run this script directly from your
+# local clone of the repo. You'll most likely need to use the 2-argument form
+# of this script in that case, because otherwise you must have a proper data
+# warehouse config set up locally, pointed to by DATA_WAREHOUSE_CONFIG.
+# Additionally, you'll need to set AWS_PROFILE to something with permissions
+# if your default profile doesn't have the needed S3 access.
+#
+# Example:
+#   AWS_PROFILE=my-prof bin/upload_env.sh my-warehouse-bucket my-env
+
 
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -304,7 +304,7 @@ def gather_setting_files(config_files: Sequence[str]) -> List[str]:
 
 @lru_cache()
 def load_json(filename: str):
-    return json.loads(pkg_resources.resource_string(__name__, filename))
+    return json.loads(pkg_resources.resource_string(__name__, filename))  # type: ignore
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 simplejson~=3.8
 jsonschema~=2.5
-PyYAML~=3.11
+pyyaml>=4.2b1
 boto3~=1.4,>=1.4.7
 botocore~=1.7,>=1.7.17
 jmespath~=0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ PyYAML~=3.11
 boto3~=1.4,>=1.4.7
 botocore~=1.7,>=1.7.17
 jmespath~=0.9
-psycopg2~=2.6
+psycopg2-binary~=2.6
 pep8>=1.7
 pgpasslib~=1.1


### PR DESCRIPTION
This is branched off master (aka tag 1.7.1) so that we can deploy it to production without hitting the incompatibility of the log processing directory move introduced in 1.8.0.

This is meant for local development, but we want to deploy to production so that the updated PyYAML and psycopg2-binary dependencies get picked up and used.