### PR TITLE
Add upgrade pipeline to scripts arsenal

### DIFF
--- a/python/etl/templates/upgrade_pipeline.json
+++ b/python/etl/templates/upgrade_pipeline.json
@@ -1,0 +1,120 @@
+{
+    "objects": [
+        {
+            "id": "Default",
+            "name": "Default",
+            "schedule": { "ref": "ETLSchedule" },
+            "scheduleType": "cron",
+            "failureAndRerunMode": "CASCADE",
+            "resourceRole": "${resources.EC2.iam_instance_profile}",
+            "role": "${resources.DataPipeline.role}",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/",
+            "region": "${resources.VPC.region}",
+            "maximumRetries": "2"
+        },
+        {
+            "id": "ETLSchedule",
+            "name": "Run once on demand",
+            "type": "Schedule",
+            "period": "1 days",
+            "startDateTime": "#{myStartDateTime}",
+            "occurrences": "1"
+        },
+        {
+            "id": "SNSParent",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-status"
+        },
+        {
+            "id": "SuccessNotification",
+            "type": "SnsAlarm",
+            "parent": {"ref": "SNSParent"},
+            "subject": "ETL Rebuild Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
+        },
+        {
+            "id": "FailureNotification",
+            "type": "SnsAlarm",
+            "parent": {"ref": "SNSParent"},
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
+        },
+        {
+            "id": "ResourceParent",
+            "keyPair": "${resources.key_name}",
+            "subnetId": "${resources.VPC.public_subnet}",
+            "terminateAfter": "6 Hours"
+        },
+        {
+            "id": "ArthurDriverEC2Resource",
+            "type": "Ec2Resource",
+            "parent": { "ref": "ResourceParent" },
+            "actionOnTaskFailure": "terminate",
+            "actionOnResourceFailure": "retryAll",
+            "instanceType": "${resources.EC2.instance_type}",
+            "imageId": "${resources.EC2.image_id}",
+            "securityGroupIds": [
+                "${resources.EC2.public_security_group}",
+                "${resources.VPC.whitelist_security_group}"
+            ],
+            "associatePublicIpAddress": "true"
+        },
+        {
+            "id": "Ec2CommandGrandParent",
+            "runsOn": {"ref": "ArthurDriverEC2Resource"}
+        },
+        {
+            "id": "ShellCommandParent",
+            "parent": {"ref": "Ec2CommandGrandParent"}
+        },
+        {
+            "id": "ArthurCommandParent",
+            "parent": {"ref": "Ec2CommandGrandParent"},
+            "maximumRetries": "0"
+        },
+        {
+            "id": "CopyBootstrap",
+            "name": "Copy Bootstrap (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh /tmp/bootstrap.sh"
+        },
+        {
+            "id": "Bootstrap",
+            "name": "Bootstrap (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}",
+            "dependsOn": { "ref": "CopyBootstrap" }
+        },
+        {
+            "id": "ArthurUpgrade",
+            "name": "Arthur Upgrade (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --continue-from '#{mySelection}' --prolix --prefix ${object_store.s3.prefix}",
+            "dependsOn": { "ref": "Bootstrap" }
+        }
+    ],
+    "parameters": [
+        {
+            "id": "myStartDateTime",
+            "type": "String",
+            "optional": "false",
+            "description": "UTC ISO formatted string giving the datetime to start the pipeline",
+            "watermark": "2525-01-01T00:00:00",
+            "helpText": "When should the pipeline start?"
+        },
+        {
+            "id": "mySelection",
+            "type": "String",
+            "optional": "false",
+            "description": "Relation name to start upgrade at (or use '*' for all, ':transformations' to skip load",
+            "watermark": "*",
+            "helpText": "Which table should we continue from?"
+        }
+    ],
+    "values": {
+        "myStartDateTime": "2525-01-01T00:00:00",
+        "mySelection": "*"
+    }
+}

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+if [[ $# -lt 1 || $# -gt 2 || "$1" = "-h" ]]; then
+
+    cat <<EOF
+
+Single-shot upgrade pipeline. This will run without staging schemas and without alerting.
+
+Usage: `basename $0` <environment> [<continue-from>]
+
+The upgrade will start from the "continue-from" relation if specified.
+
+EOF
+    exit 0
+
+fi
+
+set -e -u
+
+# Verify that there is a local configuration directory
+DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
+if [[ ! -d "$DEFAULT_CONFIG" ]]; then
+    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
+    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+    exit 1
+fi
+
+PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_ENVIRONMENT="$1"
+CONTINUE_FROM_RELATION="${2:-*}"
+
+START_DATE_TIME=`date -u +"%Y-%m-%dT%H:%M:%S"`
+
+# Verify that this bucket/environment pair is set up on s3
+BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
+if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
+    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+    exit 1
+fi
+
+set -x
+
+# Note: "key" and "value" are lower-case keywords here.
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
+
+PIPELINE_NAME="Upgrade Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
+PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
+PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
+
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" upgrade_pipeline > "$PIPELINE_DEFINITION_FILE"
+
+aws datapipeline create-pipeline \
+    --unique-id dw-etl-upgrade-pipeline \
+    --name "$PIPELINE_NAME" \
+    --tags $AWS_TAGS \
+    | tee "$PIPELINE_ID_FILE"
+
+PIPELINE_ID=`jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId'`
+
+if [[ -z "$PIPELINE_ID" ]]; then
+    set +x
+    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+    exit 1
+fi
+
+aws datapipeline put-pipeline-definition \
+    --pipeline-definition "file://$PIPELINE_DEFINITION_FILE" \
+    --parameter-values \
+        myStartDateTime="$START_DATE_TIME" \
+        mySelection="$CONTINUE_FROM_RELATION" \
+    --pipeline-id "$PIPELINE_ID"
+
+aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 
-if [[ $# -lt 1 || $# -gt 2 || "$1" = "-h" ]]; then
+START_NOW=`date -u +"%Y-%m-%dT%H:%M:%S"`
+USER="${USER-nobody}"
+DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
+
+if [[ $# -gt 2 || "$1" = "-h" ]]; then
 
     cat <<EOF
 
 Single-shot upgrade pipeline. This will run without staging schemas and without alerting.
 
-Usage: `basename $0` <environment> [<continue-from>]
+Usage: `basename $0` [<environment> [<continue-from>]]
 
+The environment defaults to \"$DEFAULT_PREFIX\".
 The upgrade will start from the "continue-from" relation if specified.
 
 EOF
@@ -26,10 +31,10 @@ if [[ ! -d "$DEFAULT_CONFIG" ]]; then
 fi
 
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
-PROJ_ENVIRONMENT="$1"
-CONTINUE_FROM_RELATION="${2:-*}"
+PROJ_ENVIRONMENT="${1:-$DEFAULT_PREFIX}"
 
-START_DATE_TIME=`date -u +"%Y-%m-%dT%H:%M:%S"`
+CONTINUE_FROM_RELATION="${2:-*}"
+START_DATE_TIME="$START_NOW"
 
 # Verify that this bucket/environment pair is set up on s3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "python/scripts/install_pizza_load_pipeline.sh",
         "python/scripts/install_rebuild_pipeline.sh",
         "python/scripts/install_refresh_pipeline.sh",
+        "python/scripts/install_upgrade_pipeline.sh",
         "python/scripts/install_validation_pipeline.sh",
         "python/scripts/launch_ec2_instance.sh",
         "python/scripts/launch_emr_cluster.sh",


### PR DESCRIPTION
This enables to run:
```
install_upgrade_pipeline.sh development "schema.table"
```
and avoids having to spin up (and not to forget to spin down!) an EC2 box to run the `upgrade` on.

There's a slight oddness in the implementation. The definition of the upgrade pipeline is closely related to the pizza load pipeline (both leverage "upgrade" steps). But the installation of the upgrade pipeline is more closely related to the validation pipeline (both are "development activities").