### PR TITLE
RC v1.8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ cat /tmp/redshift_etl/etc/motd' > /root/.bashrc
 
 WORKDIR /data-warehouse
 
+# Whenever there is an ETL running, it offerst progress information on port 8086.
+EXPOSE 8086
+
 # From here, bind-mount your data warehouse code directory to /data-warehouse.
 # All of the normal Arthur configuration for accessing and managing the data
 # warehouse is assumed to have already been set up in that directory.

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -88,7 +88,7 @@ fi
 #   - ARTHUR_DEFAULT_PREFIX to pick the default "environment" (same as S3 prefix)
 #   - AWS_PROFILE to pick the right user or role with access to ETL admin privileges
 set -x
-docker run --rm -it \
+docker run --rm -it --publish 8086:8086/tcp \
     --volume "$data_warehouse_path":/data-warehouse \
     --volume ~/.aws:/root/.aws \
     --volume ~/.ssh:/root/.ssh \

--- a/etc/motd
+++ b/etc/motd
@@ -36,10 +36,10 @@ Here are some frequently-used commands to work on a table design
   arthur.py help load
 
 
-Most likely command to run if a production pipeline failed
-==========================================================
+Most likely command to run if a pipeline failed
+===============================================
 
-  install_pizza_load_pipeline.sh ":transformations"
+  install_pizza_load_pipeline.sh development ":transformations"
 
 
 Installed:

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -1,9 +1,11 @@
 {
     # General settings controlling how Arthur itself behaves
     "arthur_settings": {
-        # If an extract from an upstream source or copy from S3 files fails due to some transient error, retry the extract at most this many times. Zero disables retries
+        # If an extract from an upstream source or copy from S3 files fails due to some transient error,
+        # retry the extract at most this many times. Zero disables retries.
         "extract_retries": 1,
-        "copy_data_retries": 3
+        "copy_data_retries": 3,
+        "insert_data_retries": 1
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -125,6 +125,11 @@
                     "description": "If a COPY command fails with a database internal error (which we optimistically hope are transient), retry the COPY at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0
+                },
+                "insert_data_retries": {
+                    "description": "If an INSERT command fails to load data with an error pointing to S3 fetch, retry the INSERT at most this many times. Zero disables retries",
+                    "type": "integer",
+                    "minimum": 0
                 }
             },
             "required": [ "extract_retries", "copy_data_retries" ],

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -96,7 +96,8 @@ def connection(dsn_dict: Dict[str, str], application_name=psycopg2.__name__, aut
     """
     dsn_values = _dsn_connection_values(dsn_dict, application_name)
     logger.info("Connecting to: %s", unparse_connection(dsn_values))
-    cx = psycopg2.connect(**dsn_values)
+    dsn_values.update(keepalives=1, keepalives_idle=30)
+    cx = psycopg2.connect(**dsn_values, )
     cx.set_session(autocommit=autocommit, readonly=readonly)
     logger.debug("Connected successfully (backend pid: %d, server version: %s, is_superuser: %s)",
                  cx.get_backend_pid(), cx.server_version, cx.get_parameter_status("is_superuser"))

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -232,6 +232,7 @@ class RetriesExhaustedError(ETLRuntimeError):
 def retry(max_retries: int, func: partial, logger):
     """
     Retry a function a maximum number of times and return its results.
+
     The function should be a functools.partial called with no arguments.
     Sleeps for 5 ^ attempt_number seconds if there are remaining retry attempts.
 
@@ -244,14 +245,14 @@ def retry(max_retries: int, func: partial, logger):
     for attempt in range(max_retries + 1):
         try:
             successful_result = func()
-        except TransientETLError as e:
+        except TransientETLError as exc:
             # Only retry transient errors
-            failure_reason = e
+            failure_reason = exc
             remaining_attempts = max_retries - attempt
             if remaining_attempts:
                 sleep_time = 5 ** (attempt + 1)
-                logger.warning("Encountered the following error (retrying %s more times after %s second sleep): %s",
-                               remaining_attempts, sleep_time, str(e))
+                logger.warning("Encountered the following error (retrying %s more time(s) after %s second sleep): %s",
+                               remaining_attempts, sleep_time, str(exc))
                 time.sleep(sleep_time)
             continue
         except Exception:
@@ -260,6 +261,6 @@ def retry(max_retries: int, func: partial, logger):
         else:
             break
     else:
-        raise RetriesExhaustedError("reached max number of retries (={:d})".format(max_retries)) from failure_reason
+        raise RetriesExhaustedError("reached max number of retries ({:d})".format(max_retries)) from failure_reason
 
     return successful_result

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -381,23 +381,22 @@ def insert_from_query(conn: connection, relation: LoadableRelation,
                       query_stmt: Optional[str]=None, dry_run=False) -> None:
     """
     Load data into table from its query (aka materializing a view).
+
     The table name, query, and columns may be overridden from their defaults, which are the values from the relation.
-    (If the table name is specified, we'll assume that it's a temp table for logging.)
     """
     if table_name is None:
         table_name = relation.target_table_name
-        message = "Loading data into {:x} from query".format(relation)
-    else:
-        message = "Loading data into temporary table for {:x} from query".format(relation)
     if columns is None:
         columns = relation.unquoted_columns
     if query_stmt is None:
         query_stmt = relation.query_stmt
 
-    stmt = """INSERT INTO {table} (\n  {columns}\n)""".format(table=table_name, columns=join_column_list(columns))
-    stmt += "\n" + query_stmt
+    insert_func = partial(etl.design.redshift.insert_from_query, conn, table_name, columns, query_stmt, dry_run=dry_run)
 
-    etl.db.run(conn, message, stmt, dry_run=dry_run)
+    if relation.in_transaction:
+        insert_func()
+    else:
+        retry(etl.config.get_config_int("arthur_settings.insert_data_retries"), insert_func, logger)
 
 
 def load_ctas_directly(conn: connection, relation: LoadableRelation, dry_run=False) -> None:
@@ -603,7 +602,7 @@ def build_one_relation(conn: connection, relation: LoadableRelation, dry_run=Fal
         if relation.is_view_relation:
             pass
         elif relation.skip_copy:
-            logger.info("Skipping loading data into {:x}".format(relation))
+            logger.info("Skipping loading data into {:x} (skip copy is active)".format(relation))
         elif relation.failed:
             logger.info("Bypassing already failed relation {:x}".format(relation))
         else:

--- a/python/etl/selftest.py
+++ b/python/etl/selftest.py
@@ -46,7 +46,7 @@ logger.addHandler(logging.NullHandler())
 
 
 def run_pep8(module_: Optional[str]=None, log_level: str= "INFO") -> None:
-    print("Running pep8...")
+    print("Running PEP8 check...")
     if module_ is None:
         module_ = __name__
     quiet = log_level not in ("DEBUG", "INFO")

--- a/python/etl/templates/upgrade_pipeline.json
+++ b/python/etl/templates/upgrade_pipeline.json
@@ -1,0 +1,120 @@
+{
+    "objects": [
+        {
+            "id": "Default",
+            "name": "Default",
+            "schedule": { "ref": "ETLSchedule" },
+            "scheduleType": "cron",
+            "failureAndRerunMode": "CASCADE",
+            "resourceRole": "${resources.EC2.iam_instance_profile}",
+            "role": "${resources.DataPipeline.role}",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/",
+            "region": "${resources.VPC.region}",
+            "maximumRetries": "2"
+        },
+        {
+            "id": "ETLSchedule",
+            "name": "Run once on demand",
+            "type": "Schedule",
+            "period": "1 days",
+            "startDateTime": "#{myStartDateTime}",
+            "occurrences": "1"
+        },
+        {
+            "id": "SNSParent",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-status"
+        },
+        {
+            "id": "SuccessNotification",
+            "type": "SnsAlarm",
+            "parent": {"ref": "SNSParent"},
+            "subject": "ETL Rebuild Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
+        },
+        {
+            "id": "FailureNotification",
+            "type": "SnsAlarm",
+            "parent": {"ref": "SNSParent"},
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
+        },
+        {
+            "id": "ResourceParent",
+            "keyPair": "${resources.key_name}",
+            "subnetId": "${resources.VPC.public_subnet}",
+            "terminateAfter": "6 Hours"
+        },
+        {
+            "id": "ArthurDriverEC2Resource",
+            "type": "Ec2Resource",
+            "parent": { "ref": "ResourceParent" },
+            "actionOnTaskFailure": "terminate",
+            "actionOnResourceFailure": "retryAll",
+            "instanceType": "${resources.EC2.instance_type}",
+            "imageId": "${resources.EC2.image_id}",
+            "securityGroupIds": [
+                "${resources.EC2.public_security_group}",
+                "${resources.VPC.whitelist_security_group}"
+            ],
+            "associatePublicIpAddress": "true"
+        },
+        {
+            "id": "Ec2CommandGrandParent",
+            "runsOn": {"ref": "ArthurDriverEC2Resource"}
+        },
+        {
+            "id": "ShellCommandParent",
+            "parent": {"ref": "Ec2CommandGrandParent"}
+        },
+        {
+            "id": "ArthurCommandParent",
+            "parent": {"ref": "Ec2CommandGrandParent"},
+            "maximumRetries": "0"
+        },
+        {
+            "id": "CopyBootstrap",
+            "name": "Copy Bootstrap (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh /tmp/bootstrap.sh"
+        },
+        {
+            "id": "Bootstrap",
+            "name": "Bootstrap (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}",
+            "dependsOn": { "ref": "CopyBootstrap" }
+        },
+        {
+            "id": "ArthurUpgrade",
+            "name": "Arthur Upgrade (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --continue-from '#{mySelection}' --prolix --prefix ${object_store.s3.prefix}",
+            "dependsOn": { "ref": "Bootstrap" }
+        }
+    ],
+    "parameters": [
+        {
+            "id": "myStartDateTime",
+            "type": "String",
+            "optional": "false",
+            "description": "UTC ISO formatted string giving the datetime to start the pipeline",
+            "watermark": "2525-01-01T00:00:00",
+            "helpText": "When should the pipeline start?"
+        },
+        {
+            "id": "mySelection",
+            "type": "String",
+            "optional": "false",
+            "description": "Relation name to start upgrade at (or use '*' for all, ':transformations' to skip load",
+            "watermark": "*",
+            "helpText": "Which table should we continue from?"
+        }
+    ],
+    "values": {
+        "myStartDateTime": "2525-01-01T00:00:00",
+        "mySelection": "*"
+    }
+}

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -4,18 +4,20 @@ START_NOW=`date -u +"%Y-%m-%dT%H:%M:%S"`
 USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
-if [[ $# -gt 3 || "$1" = "-h" ]]; then
+if [[ $# -gt 2 || "$1" = "-h" ]]; then
 
     cat <<EOF
 
-Usage: `basename $0` [<environment> [<startdatetime> [<occurrences>]]]
+Single-shot upgrade pipeline. This will run without staging schemas and without alerting.
+
+Usage: `basename $0` [<environment> [<continue-from>]]
 
 The environment defaults to \"$DEFAULT_PREFIX\".
-Start time should take the ISO8601 format, defaults to \"$START_NOW\" (now).
-The number of occurrences defaults to 1.
+The upgrade will start from the "continue-from" relation if specified.
 
 EOF
     exit 0
+
 fi
 
 set -e -u
@@ -31,41 +33,30 @@ fi
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
 PROJ_ENVIRONMENT="${1:-$DEFAULT_PREFIX}"
 
-START_DATE_TIME="${2:-$START_NOW}"
-OCCURRENCES="${3:-1}"
+CONTINUE_FROM_RELATION="${2:-*}"
+START_DATE_TIME="$START_NOW"
 
-# Verify that this bucket/environment pair is set up on s3 with credentials
-VALIDATION_CREDENTIALS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/validation/config/credentials_validation.sh"
-if ! aws s3 ls "$VALIDATION_CREDENTIALS" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
-    echo "whether you have access to it, and whether credentials_validation.sh was copied into validation/config!"
+# Verify that this bucket/environment pair is set up on s3
+BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
+if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
+    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
     exit 1
 fi
 
 set -x
 
-# N.B. This assumes you are in the directory with your warehouse definition (schemas, config, ...)
-GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD 2>/dev/null || true)
-
-if [[ "$PROJ_ENVIRONMENT" =~ "production" ]]; then
-    PIPELINE_NAME="ETL Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
-elif [[ -n "$GIT_BRANCH" ]]; then
-    PIPELINE_NAME="Validation Pipeline ($DEFAULT_PREFIX:$GIT_BRANCH $PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
-else
-    PIPELINE_NAME="Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
-fi
-
 # Note: "key" and "value" are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
 
+PIPELINE_NAME="Upgrade Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
-arthur.py render_template --prefix "$PROJ_ENVIRONMENT" validation_pipeline > "$PIPELINE_DEFINITION_FILE"
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" upgrade_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 aws datapipeline create-pipeline \
-    --unique-id validation_pipeline \
+    --unique-id dw-etl-upgrade-pipeline \
     --name "$PIPELINE_NAME" \
     --tags $AWS_TAGS \
     | tee "$PIPELINE_ID_FILE"
@@ -82,7 +73,7 @@ aws datapipeline put-pipeline-definition \
     --pipeline-definition "file://$PIPELINE_DEFINITION_FILE" \
     --parameter-values \
         myStartDateTime="$START_DATE_TIME" \
-        myOccurrences="$OCCURRENCES" \
+        mySelection="$CONTINUE_FROM_RELATION" \
     --pipeline-id "$PIPELINE_ID"
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "python/scripts/install_pizza_load_pipeline.sh",
         "python/scripts/install_rebuild_pipeline.sh",
         "python/scripts/install_refresh_pipeline.sh",
+        "python/scripts/install_upgrade_pipeline.sh",
         "python/scripts/install_validation_pipeline.sh",
         "python/scripts/launch_ec2_instance.sh",
         "python/scripts/launch_emr_cluster.sh",


### PR DESCRIPTION
User visible changes:
* Try to load data for a CTAS once if there is an error due to S3 Query Exception (Fetch).
* Added settings to connections to aid with keeping them alive. Avoids:
> psycopg2.OperationalError: SSL SYSCALL error: EOF detected
* New pipeline to help with testing upgrades -- an upgrade will start from the specified relation
```
install_upgrade_pipeline.sh development "schema.table"
```

Developer changes:
* Bring back port 8086 for ETL progress monitor when running Arthur in Docker container.
    - Start a long-running operation, say `arthur.py load --dry-run`
    - Point browser to [http://localhost:8086/](http://localhost:8086/)
    - Watch the monitor page show the progress through the schemas and tables.
