### PR TITLE
Retry loads related to CTAS when a failure is related to S3

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -1,9 +1,11 @@
 {
     # General settings controlling how Arthur itself behaves
     "arthur_settings": {
-        # If an extract from an upstream source or copy from S3 files fails due to some transient error, retry the extract at most this many times. Zero disables retries
+        # If an extract from an upstream source or copy from S3 files fails due to some transient error,
+        # retry the extract at most this many times. Zero disables retries.
         "extract_retries": 1,
-        "copy_data_retries": 3
+        "copy_data_retries": 3,
+        "load_data_retries": 1
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -5,7 +5,7 @@
         # retry the extract at most this many times. Zero disables retries.
         "extract_retries": 1,
         "copy_data_retries": 3,
-        "load_data_retries": 1
+        "insert_data_retries": 1
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -126,7 +126,7 @@
                     "type": "integer",
                     "minimum": 0
                 },
-                "load_data_retries": {
+                "insert_data_retries": {
                     "description": "If an INSERT command fails to load data with an error pointing to S3 fetch, retry the INSERT at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -125,6 +125,11 @@
                     "description": "If a COPY command fails with a database internal error (which we optimistically hope are transient), retry the COPY at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0
+                },
+                "load_data_retries": {
+                    "description": "If an INSERT command fails to load data with an error pointing to S3 fetch, retry the INSERT at most this many times. Zero disables retries",
+                    "type": "integer",
+                    "minimum": 0
                 }
             },
             "required": [ "extract_retries", "copy_data_retries" ],

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -232,6 +232,7 @@ class RetriesExhaustedError(ETLRuntimeError):
 def retry(max_retries: int, func: partial, logger):
     """
     Retry a function a maximum number of times and return its results.
+
     The function should be a functools.partial called with no arguments.
     Sleeps for 5 ^ attempt_number seconds if there are remaining retry attempts.
 
@@ -244,14 +245,14 @@ def retry(max_retries: int, func: partial, logger):
     for attempt in range(max_retries + 1):
         try:
             successful_result = func()
-        except TransientETLError as e:
+        except TransientETLError as exc:
             # Only retry transient errors
-            failure_reason = e
+            failure_reason = exc
             remaining_attempts = max_retries - attempt
             if remaining_attempts:
                 sleep_time = 5 ** (attempt + 1)
-                logger.warning("Encountered the following error (retrying %s more times after %s second sleep): %s",
-                               remaining_attempts, sleep_time, str(e))
+                logger.warning("Encountered the following error (retrying %s more time(s) after %s second sleep): %s",
+                               remaining_attempts, sleep_time, str(exc))
                 time.sleep(sleep_time)
             continue
         except Exception:
@@ -260,6 +261,6 @@ def retry(max_retries: int, func: partial, logger):
         else:
             break
     else:
-        raise RetriesExhaustedError("reached max number of retries (={:d})".format(max_retries)) from failure_reason
+        raise RetriesExhaustedError("reached max number of retries ({:d})".format(max_retries)) from failure_reason
 
     return successful_result

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -396,7 +396,7 @@ def insert_from_query(conn: connection, relation: LoadableRelation,
     if relation.in_transaction:
         insert_func()
     else:
-        retry(etl.config.get_config_int("arthur_settings.load_data_retries"), insert_func, logger)
+        retry(etl.config.get_config_int("arthur_settings.insert_data_retries"), insert_func, logger)
 
 
 def load_ctas_directly(conn: connection, relation: LoadableRelation, dry_run=False) -> None:

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -602,7 +602,7 @@ def build_one_relation(conn: connection, relation: LoadableRelation, dry_run=Fal
         if relation.is_view_relation:
             pass
         elif relation.skip_copy:
-            logger.info("Skipping loading data into {:x}".format(relation))
+            logger.info("Skipping loading data into {:x} (skip copy is active)".format(relation))
         elif relation.failed:
             logger.info("Bypassing already failed relation {:x}".format(relation))
         else:


### PR DESCRIPTION
By default this will now reload once if there is an error due to `S3 Query Exception (Fetch)`.

This adds a new `insert_data_retries` setting which allows to specify how often `INSERT ... FROM ` statements should be retried when CTAS relations are built. The  insert operation may fail if an underlying table isn't ready in S3 (so if Redshift Spectrum is having problems fetching some data).

