### PR TITLE
Make 8086 available when using Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ cat /tmp/redshift_etl/etc/motd' > /root/.bashrc
 
 WORKDIR /data-warehouse
 
+# Whenever there is an ETL running, it offerst progress information on port 8086.
+EXPOSE 8086
+
 # From here, bind-mount your data warehouse code directory to /data-warehouse.
 # All of the normal Arthur configuration for accessing and managing the data
 # warehouse is assumed to have already been set up in that directory.

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -88,7 +88,7 @@ fi
 #   - ARTHUR_DEFAULT_PREFIX to pick the default "environment" (same as S3 prefix)
 #   - AWS_PROFILE to pick the right user or role with access to ETL admin privileges
 set -x
-docker run --rm -it \
+docker run --rm -it --publish 8086:8086/tcp \
     --volume "$data_warehouse_path":/data-warehouse \
     --volume ~/.aws:/root/.aws \
     --volume ~/.ssh:/root/.ssh \


### PR DESCRIPTION
To test, build & run Docker, then point browser to [http://localhost:8086/](http://localhost:8086/).
Start a long-running operation, say `arthur.py load --dry-run`. Then watch the monitor page show
the progress through the schemas and tables.