### PR TITLE
Pass all args of install command to upgrade

### DIFF
--- a/python/etl/templates/upgrade_pipeline.json
+++ b/python/etl/templates/upgrade_pipeline.json
@@ -91,7 +91,7 @@
             "name": "Arthur Upgrade (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --continue-from '#{mySelection}' --prolix --prefix ${object_store.s3.prefix}",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --prolix --prefix ${object_store.s3.prefix} #{myUpgradeArguments}",
             "dependsOn": { "ref": "Bootstrap" }
         }
     ],
@@ -105,16 +105,16 @@
             "helpText": "When should the pipeline start?"
         },
         {
-            "id": "mySelection",
+            "id": "myUpgradeArguments",
             "type": "String",
             "optional": "false",
-            "description": "Relation name to start upgrade at (or use '*' for all, ':transformations' to skip load",
+            "description": "Arguments for the upgrade command, e.g. relations. Defaults to '--continue-from :transformations'",
             "watermark": "*",
             "helpText": "Which table should we continue from?"
         }
     ],
     "values": {
         "myStartDateTime": "2525-01-01T00:00:00",
-        "mySelection": "*"
+        "myUpgradeArguments": "--continue-from :transformations"
     }
 }

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -10,8 +10,8 @@ if [[ $# -gt 3 || "$1" = "-h" ]]; then
 
 Usage: `basename $0` [<environment> [<startdatetime> [<occurrences>]]]
 
-The environment defaults to \"$DEFAULT_PREFIX\".
-Start time should take the ISO8601 format, defaults to \"$START_NOW\" (now).
+The environment defaults to "$DEFAULT_PREFIX".
+Start time should take the ISO8601 format, defaults to "$START_NOW" (now).
 The number of occurrences defaults to 1.
 
 EOF


### PR DESCRIPTION
User visible changes:
* This allows sending an `arthur.py upgrade` into a data pipeline and will now use the remaining command line args for the `upgrade` command.
```
install_upgrade_pipeline.sh my_schema.my_table --only-selected
```