### PR TITLE
Release candidate for v1.8.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ cat /tmp/redshift_etl/etc/motd' > /root/.bashrc
 
 WORKDIR /data-warehouse
 
-# Whenever there is an ETL running, it offerst progress information on port 8086.
+# Whenever there is an ETL running, it offers progress information on port 8086.
 EXPOSE 8086
 
 # From here, bind-mount your data warehouse code directory to /data-warehouse.

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,19 +32,18 @@ RUN virtualenv --python=python3 venv && \
 
 COPY . .
 
-RUN source venv/bin/activate && \
-    python3 setup.py develop && \
-    arthur.py --version >> /tmp/redshift_etl/etc/motd
-
 # Use the self tests to check if everything was installed properly
 RUN source venv/bin/activate && \
+    python3 setup.py develop && \
     run_tests.py
 
 # Ensure the venv is activated when running interactive shells
 RUN echo $'source /tmp/redshift_etl/venv/bin/activate\n\
 source /tmp/redshift_etl/etc/arthur_completion.sh\n\
 PATH=$PATH:/tmp/redshift_etl/bin\n\
-cat /tmp/redshift_etl/etc/motd' > /root/.bashrc
+cat /tmp/redshift_etl/etc/motd\n\
+echo "arthur.py settings object_store.s3.* version"\n\
+arthur.py settings object_store.s3.* version' > /root/.bashrc
 
 WORKDIR /data-warehouse
 

--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -19,7 +19,7 @@ if [[ $# -gt 2 || "$1" = "-h" ]]; then
 Usage: `basename $0` [[<bucket_name>] <target_env>]
 
 This creates a new distribution and uploads it into S3.
-The <target_env> defaults to \"$DEFAULT_PREFIX\".
+The <target_env> defaults to "$DEFAULT_PREFIX".
 The <bucket_name> defaults to your object store setting.
 If the bucket name is not specified, variable DATA_WAREHOUSE_CONFIG must be set.
 

--- a/etc/motd
+++ b/etc/motd
@@ -11,11 +11,9 @@ Here are some frequently-used commands to get started
 =====================================================
 
   arthur.py ping
-  arthur.py settings object_store.s3.*
 
   upload_env.sh
   arthur.py sync --deploy
-
   install_validation_pipeline.sh
 
 
@@ -41,5 +39,3 @@ Most likely command to run if a pipeline failed
 
   install_pizza_load_pipeline.sh development ":transformations"
 
-
-Installed:

--- a/etc/motd
+++ b/etc/motd
@@ -39,3 +39,4 @@ Most likely command to run if a pipeline failed
 
   install_pizza_load_pipeline.sh development ":transformations"
 
+---------------------------------------------------------------

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1022,7 +1022,7 @@ class ShowVarsCommand(SubCommand):
     def add_arguments(self, parser):
         parser.set_defaults(log_level="CRITICAL")
         add_standard_arguments(parser, ["prefix"])
-        parser.add_argument("name", nargs="?", help="print just the value for the chosen setting")
+        parser.add_argument("name", help="print just the value for the chosen setting", nargs="*")
 
     def callback(self, args, config):
         etl.render_template.show_vars(args.name)

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -308,15 +308,15 @@ def add_standard_arguments(parser, options):
                            action="store_const", const="s3", dest="scheme")
     if "max-concurrency" in options:
         parser.add_argument("-x", "--max-concurrency", metavar="N", type=int,
-                            help="set max number of parallel loads to N "
-                                 "(overrides 'resources.RedshiftCluster.max_concurrency')")
+                            help="set max number of parallel loads to N"
+                                 " (overrides 'resources.RedshiftCluster.max_concurrency')")
     if "wlm-query-slots" in options:
         parser.add_argument("-w", "--wlm-query-slots", metavar="N", type=int,
                             help="set the number of Redshift WLM query slots used for transformations"
-                                 "(overrides 'resources.RedshiftCluster.wlm_query_slots')")
+                                 " (overrides 'resources.RedshiftCluster.wlm_query_slots')")
     if "skip-copy" in options:
         parser.add_argument("-y", "--skip-copy",
-                            help="skip the COPY and INSERT commands (leaves tables empty, for debugging)",
+                            help="skip the COPY and INSERT commands (leaves tables empty, used for validation)",
                             action="store_true")
     if "continue-from" in options:
         parser.add_argument("--continue-from",

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1049,7 +1049,7 @@ class QueryEventsCommand(SubCommand):
                          "query the tables of ETL events",
                          "Query the table of events written during an ETL."
                          " When an ETL is specified, then it is used as a filter."
-                         " Otherwise ETLs from the last day are listed.")
+                         " Otherwise ETLs from the last 48 hours are listed.")
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["prefix"])
@@ -1057,7 +1057,8 @@ class QueryEventsCommand(SubCommand):
 
     def callback(self, args, config):
         if args.etl_id is None:
-            etl.monitor.query_for_etl_ids(days_ago=1)
+            # Going back two days should cover at least one complete and one running rebuild ETL.
+            etl.monitor.query_for_etl_ids(days_ago=2)
         else:
             etl.monitor.scan_etl_events(args.etl_id)
 

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -260,6 +260,8 @@ def load_config(config_files: Sequence[str], default_file: str="default_settings
     global _dw_config
     _dw_config = etl.config.dw.DataWarehouseConfig(settings)
 
+    set_config_value("version", package_version())
+
 
 def validate_with_schema(obj: dict, schema_name: str) -> None:
     """

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -5,7 +5,7 @@
         # retry the extract at most this many times. Zero disables retries.
         "extract_retries": 1,
         "copy_data_retries": 3,
-        "insert_data_retries": 1
+        "insert_data_retries": 3
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -50,6 +50,8 @@ def load_table_design_from_localfile(local_filename, table_name):
     Load (and validate) table design file in local file system.
     """
     logger.debug("Loading local table design from '%s'", local_filename)
+    if local_filename is None:
+        raise ValueError("local filename is unknown")
     try:
         with open(local_filename) as f:
             table_design = load_table_design(f, table_name)

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -168,14 +168,11 @@ def log_load_error(cx):
         raise
 
 
-def copy_from_uri(conn: connection, table_name: TableName, column_list: List[str], s3_uri: str, aws_iam_role: str,
-                  need_compupdate=False, dry_run=False) -> None:
-    """
-    Load data into table in the data warehouse using the COPY command.
-    """
+def copy_using_manifest(conn: connection, table_name: TableName, column_list: List[str], s3_uri: str,
+                        aws_iam_role: str, need_compupdate=False, dry_run=False) -> None:
     credentials = "aws_iam_role={}".format(aws_iam_role)
 
-    stmt = """
+    copy_stmt = """
         COPY {table} (
             {columns}
         )
@@ -189,20 +186,71 @@ def copy_from_uri(conn: connection, table_name: TableName, column_list: List[str
         """.format(table=table_name, columns=join_column_list(column_list),
                    compupdate="ON" if need_compupdate else "OFF")
     if dry_run:
-        logger.info("Dry-run: Skipping copying data into '%s' from '%s'", table_name.identifier, s3_uri)
-        etl.db.skip_query(conn, stmt, (s3_uri, credentials))
+        logger.info("Dry-run: Skipping copying data into '%s' using '%s'", table_name.identifier, s3_uri)
+        etl.db.skip_query(conn, copy_stmt, (s3_uri, credentials))
     else:
-        logger.info("Copying data into '%s' from '%s'", table_name.identifier, s3_uri)
+        logger.info("Copying data into '%s' using '%s'", table_name.identifier, s3_uri)
         try:
             with log_load_error(conn):
-                etl.db.execute(conn, stmt, (s3_uri, credentials))
-            row_count = etl.db.query(conn, "SELECT pg_last_copy_count()")
-            logger.info("Copied %d rows into '%s'", row_count[0][0], table_name.identifier)
+                etl.db.execute(conn, copy_stmt, (s3_uri, credentials))
         except psycopg2.InternalError as exc:
             raise TransientETLError(exc) from exc
 
-# Find files that were just copied in:
-# select query, trim(filename) as file, curtime as updated from stl_load_commits where query = pg_last_copy_id();
+
+def query_load_commits(conn: connection, table_name: TableName, s3_uri: str, dry_run=False) -> None:
+    stmt = """
+        SELECT TRIM(filename) AS filename
+             , lines_scanned
+          FROM stl_load_commits
+         WHERE query = pg_last_copy_id()
+         ORDER BY TRIM(filename)
+        """
+    if dry_run:
+        etl.db.skip_query(conn, stmt)
+    else:
+        rows = etl.db.query(conn, stmt)
+        summary = '    ' + '\n    '.join("'{filename}' ({lines_scanned} line(s))".format(**row) for row in rows)
+        logger.debug("Copied %d file(s) into '%s' using manifest '%s':\n%s",
+                     len(rows), table_name.identifier, s3_uri, summary)
+
+
+def query_load_summary(conn: connection, table_name: TableName, dry_run=False) -> None:
+    # This query is not guarded by "dry_run" so that we have a copy_id for the other query.
+    [[copy_count, copy_id]] = etl.db.query(conn, "SELECT pg_last_copy_count(), pg_last_copy_id()")
+
+    stmt = """
+        SELECT COUNT(s3.key) AS file_count
+             , COUNT(DISTINCT s.slice) AS slice_count
+             , COUNT(DISTINCT s.node) AS node_count
+             , MAX(wq.slot_count) AS slot_count
+             , ROUND(MAX(wq.total_queue_time/1000000.0), 2) AS elapsed_queued
+             , ROUND(MAX(wq.total_exec_time/1000000.0), 2) AS elapsed
+             , ROUND(SUM(s3.transfer_size)/(1024.0*1024.0), 2) AS total_mb
+          FROM stl_wlm_query wq
+          JOIN stl_s3client s3 USING (query)
+          JOIN stv_slices s USING (slice)
+         WHERE wq.query = %s
+        """
+    if dry_run:
+        etl.db.skip_query(conn, stmt, (copy_id,))
+    else:
+        [row] = etl.db.query(conn, stmt, (copy_id,))
+        logger.info(
+            (
+                'Copied {copy_count:d} rows into {table_name:x} '
+                '(files: {file_count:d}, slices: {slice_count:d}, nodes: {node_count:d}, slots: {slot_count:d}, '
+                'elapsed: {elapsed}s ({elapsed_queued}s queued), size: {total_mb}MB)'
+            ).format(copy_count=copy_count, table_name=table_name, **row))
+
+
+def copy_from_uri(conn: connection, table_name: TableName, column_list: List[str], s3_uri: str, aws_iam_role: str,
+                  need_compupdate=False, dry_run=False) -> None:
+    """
+    Load data into table in the data warehouse using the COPY command.
+    """
+    copy_using_manifest(conn, table_name, column_list, s3_uri, aws_iam_role, need_compupdate, dry_run)
+    query_load_commits(conn, table_name, s3_uri, dry_run)
+    query_load_summary(conn, table_name, dry_run)
 
 
 def insert_from_query(conn: connection, table_name: TableName, column_list: List[str], query_stmt: str,

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -537,7 +537,19 @@ def start_monitors(environment):
         logger.warning("Writing events to a DynamoDB table is disabled in settings.")
 
 
+def _format_output_column(key: str, value: str) -> str:
+    if key == "timestamp":
+        # Make timestamp readable by turning epoch seconds into a date.
+        return datetime.utcfromtimestamp(float(value)).replace(microsecond=0).isoformat()
+    elif key == "elapsed":
+        # Reduce number of decimals to 2.
+        return '{:6.2f}'.format(float(value))
+    else:
+        return value
+
+
 def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
+    """Search for ETLs by looking for the "marker" event at the start of an ETL command."""
     start_time = datetime.utcnow() - timedelta(days=days_ago, hours=hours_ago)
     epoch_seconds = timegm(start_time.utctimetuple())
     ddb = DynamoDBStorage.factory()
@@ -565,9 +577,7 @@ def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
                 response['Count'], response['ScannedCount'], response['ConsumedCapacity']['CapacityUnits'])
     rows = [
         [
-            # Make timestamp readable by turning epoch seconds into a date.
-            item[key] if key != "timestamp" else datetime.utcfromtimestamp(item[key]).isoformat()
-            for key in keys
+            _format_output_column(key, item[key]) for key in keys
         ]
         for item in response['Items']
     ]
@@ -576,11 +586,12 @@ def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
 
 
 def scan_etl_events(etl_id) -> None:
+    """Scan for all events belonging to the specific ETL."""
     ddb = DynamoDBStorage.factory()
     table = ddb.get_table(create_if_not_exists=False)
     keys = ["target", "step", "event", "timestamp", "elapsed"]
 
-    # The paginator operates on the client not resource. So open a client and start iterating.
+    # We need to scan here since the events are stored by "target" and not by "etl_id".
     client = boto3.client('dynamodb')
     paginator = client.get_paginator('scan')
     response_iterator = paginator.paginate(
@@ -601,6 +612,7 @@ def scan_etl_events(etl_id) -> None:
         #     "PageSize": 100
         # }
     )
+    logger.info("Scanning events table for elapsed times")
     consumed_capacity = .0
     scanned_count = 0
     rows = []
@@ -609,7 +621,7 @@ def scan_etl_events(etl_id) -> None:
         scanned_count += response['ScannedCount']
         rows.extend([
             [
-                item[key].get('S', item[key].get('N')) for key in keys
+                _format_output_column(key, item[key].get('S', item[key].get('N'))) for key in keys
             ]
             for item in response['Items']
         ])

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -217,6 +217,11 @@ class Monitor(metaclass=MetaMonitor):
         payload = MonitorPayload(self, event, self._end_time, elapsed=seconds, errors=errors, extra=self._extra)
         payload.emit(dry_run=self._dry_run)
 
+    def add_extra(self, key, value):
+        if key in self._extra:
+            raise KeyError("duplicate key in 'extra' payload")
+        self._extra[key] = value
+
     @classmethod
     def marker_payload(cls, step: str):
         monitor = cls(_DUMMY_TARGET, step)

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -317,7 +317,7 @@ class RelationDescription:
         return None
 
     @contextmanager
-    def matching_temporary_view(self, conn):
+    def matching_temporary_view(self, conn, assume_external_schema=False):
         """
         Create a temporary view (with a name loosely based around the reference passed in).
 
@@ -327,7 +327,7 @@ class RelationDescription:
 
         with etl.db.log_error():
             ddl_stmt = """CREATE OR REPLACE VIEW {} AS\n{}""".format(temp_view, self.query_stmt)
-            if any(dep.is_external for dep in self.dependencies):
+            if assume_external_schema or any(dep.is_external for dep in self.dependencies):
                 ddl_stmt += "\nWITH NO SCHEMA BINDING"
                 temp_view.is_late_binding_view = True
 

--- a/python/etl/render_template.py
+++ b/python/etl/render_template.py
@@ -107,14 +107,16 @@ def show_vars(names: List[str]) -> None:
     List all known configuration settings as "variables" with their values or just the variables that are selected.
     """
     config_mapping = etl.config.get_config_map()
+    all_keys = sorted(config_mapping)
     if not names:
-        keys = list(config_mapping)
+        keys = all_keys
     else:
-        keys = []
+        selected_keys = set()
         for name in names:
-            selected_keys = [key for key in sorted(config_mapping) if fnmatch.fnmatch(key, name)]
-            if not selected_keys:
+            matching_keys = [key for key in all_keys if fnmatch.fnmatch(key, name)]
+            if not matching_keys:
                 raise InvalidArgumentError("no matching setting for '{}'".format(name))
-            keys.extend(selected_keys)
-    values = [config_mapping[key] for key in sorted(keys)]
+            selected_keys.update(matching_keys)
+        keys = sorted(selected_keys)
+    values = [config_mapping[key] for key in keys]
     print(etl.text.format_lines(zip(keys, values), header_row=["Name", "Value"]))

--- a/python/etl/render_template.py
+++ b/python/etl/render_template.py
@@ -3,7 +3,7 @@ import logging
 import os.path
 import string
 from collections import OrderedDict
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import pkg_resources
 import simplejson
@@ -102,17 +102,19 @@ def show_value(name: str, default: Optional[str]) -> None:
     print(value)
 
 
-def show_vars(name: Optional[str]) -> None:
+def show_vars(names: List[str]) -> None:
     """
-    List all the known configuration settings as "variables" with their values or
-    just for the variable that's selected.
+    List all known configuration settings as "variables" with their values or just the variables that are selected.
     """
     config_mapping = etl.config.get_config_map()
-    if name is None:
-        keys = sorted(config_mapping)
+    if not names:
+        keys = list(config_mapping)
     else:
-        keys = [key for key in sorted(config_mapping) if fnmatch.fnmatch(key, name)]
-        if not keys:
-            raise InvalidArgumentError("no matching setting for '{}'".format(name))
-    values = [config_mapping[key] for key in keys]
+        keys = []
+        for name in names:
+            selected_keys = [key for key in sorted(config_mapping) if fnmatch.fnmatch(key, name)]
+            if not selected_keys:
+                raise InvalidArgumentError("no matching setting for '{}'".format(name))
+            keys.extend(selected_keys)
+    values = [config_mapping[key] for key in sorted(keys)]
     print(etl.text.format_lines(zip(keys, values), header_row=["Name", "Value"]))

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -27,14 +27,14 @@
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Rebuild Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
@@ -67,15 +67,15 @@
         },
         {
             "id": "Ec2CommandGrandParent",
-            "runsOn": {"ref": "ArthurDriverEC2Resource"}
+            "runsOn": { "ref": "ArthurDriverEC2Resource" }
         },
         {
             "id": "ShellCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"}
+            "parent": { "ref": "Ec2CommandGrandParent" }
         },
         {
             "id": "ArthurCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"},
+            "parent": { "ref": "Ec2CommandGrandParent" },
             "maximumRetries": "0"
         },
         {
@@ -121,7 +121,7 @@
             "id": "PublishAndBackup",
             "name": "Publish and Backup (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ShellCommandParent"},
+            "parent": { "ref": "ShellCommandParent" },
             "command": "bash /tmp/redshift_etl/bin/sync_env.sh -y ${object_store.s3.bucket_name} ${object_store.s3.prefix} ${object_store.s3.prefix}/current",
             "dependsOn": { "ref": "ArthurPromote" }
         },
@@ -129,9 +129,9 @@
             "id": "ArthurUnload",
             "name": "Arthur Unload (EC2)",
             "type": "ShellCommandActivity",
-            "parent": {"ref": "ArthurCommandParent"},
+            "parent": { "ref": "ArthurCommandParent" },
             "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ unload --keep-going --prolix --prefix ${object_store.s3.prefix}",
-            "dependsOn": {"ref": "ArthurPromote"}
+            "dependsOn": { "ref": "ArthurPromote" }
         },
         {
             "id": "PingCronutAfterEtl",

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -27,14 +27,14 @@
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Rebuild Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
@@ -86,15 +86,15 @@
         },
         {
             "id": "Ec2CommandGrandParent",
-            "runsOn": {"ref": "ArthurDriverEC2Resource"}
+            "runsOn": { "ref": "ArthurDriverEC2Resource" }
         },
         {
             "id": "ShellCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"}
+            "parent": { "ref": "Ec2CommandGrandParent" }
         },
         {
             "id": "ArthurCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"},
+            "parent": { "ref": "Ec2CommandGrandParent" },
             "maximumRetries": "0"
         },
         {

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -27,14 +27,14 @@
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Refresh Success: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
@@ -86,15 +86,15 @@
         },
         {
             "id": "Ec2CommandGrandParent",
-            "runsOn": {"ref": "ArthurDriverEC2Resource"}
+            "runsOn": { "ref": "ArthurDriverEC2Resource" }
         },
         {
             "id": "ShellCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"}
+            "parent": { "ref": "Ec2CommandGrandParent" }
         },
         {
             "id": "ArthurCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"},
+            "parent": { "ref": "Ec2CommandGrandParent" },
             "maximumRetries": "0"
         },
         {

--- a/python/etl/templates/upgrade_pipeline.json
+++ b/python/etl/templates/upgrade_pipeline.json
@@ -27,14 +27,14 @@
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Rebuild Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
@@ -60,15 +60,15 @@
         },
         {
             "id": "Ec2CommandGrandParent",
-            "runsOn": {"ref": "ArthurDriverEC2Resource"}
+            "runsOn": { "ref": "ArthurDriverEC2Resource" }
         },
         {
             "id": "ShellCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"}
+            "parent": { "ref": "Ec2CommandGrandParent" }
         },
         {
             "id": "ArthurCommandParent",
-            "parent": {"ref": "Ec2CommandGrandParent"},
+            "parent": { "ref": "Ec2CommandGrandParent" },
             "maximumRetries": "0"
         },
         {

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -27,14 +27,14 @@
         {
             "id": "SuccessNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Validation Success: ${object_store.s3.prefix}/validation at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
-            "parent": {"ref": "SNSParent"},
+            "parent": { "ref": "SNSParent" },
             "subject": "ETL Validation Failure: ${object_store.s3.prefix}/validation at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
@@ -67,7 +67,7 @@
         },
         {
             "id": "Ec2CommandGrandParent",
-            "runsOn": {"ref": "ArthurDriverEC2Resource"}
+            "runsOn": { "ref": "ArthurDriverEC2Resource" }
         },
         {
             "id": "ShellCommandParent",

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -39,6 +39,13 @@
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
+            "id": "PagerNotification",
+            "type": "SnsAlarm",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-validation-page",
+            "subject": "ETL Validation Failure: ${object_store.s3.prefix}/validation at #{node.@scheduledStartTime}",
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
+        },
+        {
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
@@ -60,7 +67,6 @@
         },
         {
             "id": "Ec2CommandGrandParent",
-            "onFail": {"ref": "FailureNotification"},
             "runsOn": {"ref": "ArthurDriverEC2Resource"}
         },
         {
@@ -126,7 +132,11 @@
             "parent": { "ref": "ArthurCommandParent" },
             "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ validate --prolix --remote-files --prefix ${object_store.s3.prefix}/validation --keep-going --skip-sources-check",
             "dependsOn": { "ref": "ArthurLoad" },
-            "onSuccess": {"ref": "SuccessNotification"}
+            "onSuccess": {"ref": "SuccessNotification"},
+            "onFail": [
+                { "ref": "FailureNotification" },
+                { "ref": "PagerNotification" }
+            ]
         }
     ],
     "parameters": [

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -65,7 +65,7 @@ trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 arthur.py render_template --prefix "$PROJ_ENVIRONMENT" validation_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 aws datapipeline create-pipeline \
-    --unique-id validation_pipeline \
+    --unique-id validation-pipeline \
     --name "$PIPELINE_NAME" \
     --tags $AWS_TAGS \
     | tee "$PIPELINE_ID_FILE"
@@ -86,3 +86,7 @@ aws datapipeline put-pipeline-definition \
     --pipeline-id "$PIPELINE_ID"
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
+
+set +x
+echo "You can check the status of this validation pipeline using:"
+echo "  arthur.py show_pipelines '$PIPELINE_ID'"

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -89,4 +89,4 @@ aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
 set +x
 echo "You can check the status of this validation pipeline using:"
-echo "  arthur.py show_pipelines '$PIPELINE_ID'"
+echo "  arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -45,13 +45,14 @@ ENV_PREFIX=$( arthur.py show_value resource_prefix --prefix "$PROJ_ENVIRONMENT" 
 STATUS_NAME="$ENV_PREFIX-status"
 PAGE_NAME="$ENV_PREFIX-page"
 VALIDATION_NAME="$ENV_PREFIX-validation"
+VALIDATION_PAGE_NAME="$ENV_PREFIX-validation-page"
 
 # ===  Create topic and subscription ===
 
 TOPIC_ARN_FILE="/tmp/topic_arn_${USER}$$.json"
 trap "rm -f \"$TOPIC_ARN_FILE\"" EXIT
 
-for TOPIC in "$STATUS_NAME" "$PAGE_NAME" "$VALIDATION_NAME"; do
+for TOPIC in "$STATUS_NAME" "$PAGE_NAME" "$VALIDATION_NAME" "$VALIDATION_PAGE_NAME"; do
     aws sns create-topic --name "$TOPIC" | tee "$TOPIC_ARN_FILE"
     TOPIC_ARN=`jq --raw-output < "$TOPIC_ARN_FILE" '.TopicArn'`
     if [[ -z "$TOPIC_ARN" ]]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-simplejson~=3.8
-jsonschema~=2.5
-pyyaml>=4.2b1
 boto3~=1.4,>=1.4.7
 botocore~=1.7,>=1.7.17
+funcy~=1.11
 jmespath~=0.9
+jsonschema~=2.5
+pgpasslib~=1.1
 psycopg2-binary~=2.6
 pycodestyle>=2.5.0
-pgpasslib~=1.1
+pyyaml~=5.1
+simplejson~=3.8

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.8.5",
+    version="1.8.6",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
Bug fixes
* The workflow for creating an initial table design from a query has changed to accommodate working with external schemas.
    1. Write the query for a CTAS.
    2. Run `arthur.py bootstrap_transformations CTAS schema_name.table_name` (where the file `schemas/<schema_name>/<schema_name>-<table_name>.sql` must exist)
    3. Add dependencies to external dependencies. If there aren't any, run:
    4. Run `arthur.py bootstrap_transformations CTAS schema_name.table_name -u` (where the update adds dependencies automatically based on the query)
* Bug fix for cases where keys were repeated or worse, the values didn't line up with the keys in the settings command.

User-visible changes:
* A new topic "validation-page" for the validation pipeline allows sending a message to another subscription than the success/failure "validation" topic, e.g. to raise a page.
* When checking for recent ETLs or their events, the output now shows timestamp as, well, timestamps instead of seconds since whatever epoch.
```
$ arthur.py query_events -p development -q
etl_id           | step    | timestamp
-----------------+---------+--------------------
5BB41C69A80A4787 | load    | 2019-04-06T22:03:31

$ arthur.py query_events -p development -q 5BB41C69A80A4787
target                                                               | step | event  | timestamp           | elapsed
---------------------------------------------------------------------+------+--------+---------------------+--------
schema.table                                                         | load | finish | 2019-04-06T22:10:04 |   5.97
```
* After installing a new validation pipeline, the next command for Arthur will be printed.
    * The `show_pipelines` command enables easy inspection of the status of validation (and other) pipelines.
```
arthur.py show_pipelines "df-<number>"
```
* Add the setting "version", see `arthur.py show_vars version`.
* Automatically show most important settings (object lake, version) when logging into Docker container.
* List all files that were part of a COPY (in the log file).
* Add summary after a COPY to check how many files, slices, nodes, slots were involved.
* Add `rowcount` as a new key in the monitor payload.

Implementation notes:
* This "query" is actually a table scan since we're missing an index. We could query on all relations and then filter on the ETL instead.

Developer notes:
* This adds a dependency on `funcy`.
* Some code was updated to take advantage of multi-select hashes.