### PR TITLE
Cleanup for listing pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ cat /tmp/redshift_etl/etc/motd' > /root/.bashrc
 
 WORKDIR /data-warehouse
 
-# Whenever there is an ETL running, it offerst progress information on port 8086.
+# Whenever there is an ETL running, it offers progress information on port 8086.
 EXPOSE 8086
 
 # From here, bind-mount your data warehouse code directory to /data-warehouse.

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -65,7 +65,7 @@ trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 arthur.py render_template --prefix "$PROJ_ENVIRONMENT" validation_pipeline > "$PIPELINE_DEFINITION_FILE"
 
 aws datapipeline create-pipeline \
-    --unique-id validation_pipeline \
+    --unique-id validation-pipeline \
     --name "$PIPELINE_NAME" \
     --tags $AWS_TAGS \
     | tee "$PIPELINE_ID_FILE"
@@ -86,3 +86,7 @@ aws datapipeline put-pipeline-definition \
     --pipeline-id "$PIPELINE_ID"
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
+
+set +x
+echo "You can check the status of this validation pipeline using:"
+echo "  arthur.py show_pipelines '$PIPELINE_ID'"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-simplejson~=3.8
-jsonschema~=2.5
-pyyaml>=4.2b1
 boto3~=1.4,>=1.4.7
 botocore~=1.7,>=1.7.17
+funcy~=1.11
 jmespath~=0.9
+jsonschema~=2.5
+pgpasslib~=1.1
 psycopg2-binary~=2.6
 pycodestyle>=2.5.0
-pgpasslib~=1.1
+pyyaml~=5.1
+simplejson~=3.8


### PR DESCRIPTION
User-visible changes:
* After installing a new validation pipeline, the next command for Arthur will be printed.
    * The `show_pipelines` command enables easy inspection of the status of validation (and other) pipelines.
```
arthur.py show_pipelines "df-<number>"
```

Developer notes:
* This adds a dependency on `funcy`.
* Some code was updated to take advantage of multi-select hashes.