### PR TITLE
Prettier query events output

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1049,7 +1049,7 @@ class QueryEventsCommand(SubCommand):
                          "query the tables of ETL events",
                          "Query the table of events written during an ETL."
                          " When an ETL is specified, then it is used as a filter."
-                         " Otherwise ETLs from the last day are listed.")
+                         " Otherwise ETLs from the last 48 hours are listed.")
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["prefix"])
@@ -1057,7 +1057,8 @@ class QueryEventsCommand(SubCommand):
 
     def callback(self, args, config):
         if args.etl_id is None:
-            etl.monitor.query_for_etl_ids(days_ago=1)
+            # Going back two days should cover at least one complete and one running rebuild ETL.
+            etl.monitor.query_for_etl_ids(days_ago=2)
         else:
             etl.monitor.scan_etl_events(args.etl_id)
 

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -591,7 +591,7 @@ def scan_etl_events(etl_id) -> None:
     table = ddb.get_table(create_if_not_exists=False)
     keys = ["target", "step", "event", "timestamp", "elapsed"]
 
-    # The paginator operates on the client not resource. So open a client and start iterating.
+    # We need to scan here since the events are stored by "target" and not by "etl_id".
     client = boto3.client('dynamodb')
     paginator = client.get_paginator('scan')
     response_iterator = paginator.paginate(

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -537,7 +537,19 @@ def start_monitors(environment):
         logger.warning("Writing events to a DynamoDB table is disabled in settings.")
 
 
+def _format_output_column(key: str, value: str) -> str:
+    if key == "timestamp":
+        # Make timestamp readable by turning epoch seconds into a date.
+        return datetime.utcfromtimestamp(float(value)).replace(microsecond=0).isoformat()
+    elif key == "elapsed":
+        # Reduce number of decimals to 2.
+        return '{:6.2f}'.format(float(value))
+    else:
+        return value
+
+
 def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
+    """Search for ETLs by looking for the "marker" event at the start of an ETL command."""
     start_time = datetime.utcnow() - timedelta(days=days_ago, hours=hours_ago)
     epoch_seconds = timegm(start_time.utctimetuple())
     ddb = DynamoDBStorage.factory()
@@ -565,9 +577,7 @@ def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
                 response['Count'], response['ScannedCount'], response['ConsumedCapacity']['CapacityUnits'])
     rows = [
         [
-            # Make timestamp readable by turning epoch seconds into a date.
-            item[key] if key != "timestamp" else datetime.utcfromtimestamp(item[key]).isoformat()
-            for key in keys
+            _format_output_column(key, item[key]) for key in keys
         ]
         for item in response['Items']
     ]
@@ -576,6 +586,7 @@ def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
 
 
 def scan_etl_events(etl_id) -> None:
+    """Scan for all events belonging to the specific ETL."""
     ddb = DynamoDBStorage.factory()
     table = ddb.get_table(create_if_not_exists=False)
     keys = ["target", "step", "event", "timestamp", "elapsed"]
@@ -601,6 +612,7 @@ def scan_etl_events(etl_id) -> None:
         #     "PageSize": 100
         # }
     )
+    logger.info("Scanning events table for elapsed times")
     consumed_capacity = .0
     scanned_count = 0
     rows = []
@@ -609,7 +621,7 @@ def scan_etl_events(etl_id) -> None:
         scanned_count += response['ScannedCount']
         rows.extend([
             [
-                item[key].get('S', item[key].get('N')) for key in keys
+                _format_output_column(key, item[key].get('S', item[key].get('N'))) for key in keys
             ]
             for item in response['Items']
         ])


### PR DESCRIPTION
User-visible changes:
* When checking for recent ETLs or their events, the output now shows timestamp as, well, timestamps instead of seconds since whatever epoch.
```
$ arthur.py query_events -p development -q
etl_id           | step    | timestamp
-----------------+---------+--------------------
5BB41C69A80A4787 | load    | 2019-04-06T22:03:31

$ arthur.py query_events -p development -q 5BB41C69A80A4787
target                                                               | step | event  | timestamp           | elapsed
---------------------------------------------------------------------+------+--------+---------------------+--------
schema.table                                                         | load | finish | 2019-04-06T22:10:04 |   5.97
```

Implementation notes:
* This "query" is actually a table scan since we're missing an index. We could query on all relations and then filter on the ETL instead.