### PR TITLE
Add comprehensive summary after COPY, add rowcount to monitor payload

### DIFF
--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -209,7 +209,7 @@ def query_load_commits(conn: connection, table_name: TableName, s3_uri: str, dry
         etl.db.skip_query(conn, stmt)
     else:
         rows = etl.db.query(conn, stmt)
-        summary = '  ' + '  \n'.join("'{filename}' ({lines_scanned} line(s))".format(**row) for row in rows)
+        summary = '    ' + '\n    '.join("'{filename}' ({lines_scanned} line(s))".format(**row) for row in rows)
         logger.debug("Copied %d file(s) into '%s' using manifest '%s':\n%s",
                      len(rows), table_name.identifier, s3_uri, summary)
 

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -217,6 +217,11 @@ class Monitor(metaclass=MetaMonitor):
         payload = MonitorPayload(self, event, self._end_time, elapsed=seconds, errors=errors, extra=self._extra)
         payload.emit(dry_run=self._dry_run)
 
+    def add_extra(self, key, value):
+        if key in self._extra:
+            raise KeyError("duplicate key in 'extra' payload")
+        self._extra[key] = value
+
     @classmethod
     def marker_payload(cls, step: str):
         monitor = cls(_DUMMY_TARGET, step)


### PR DESCRIPTION
User-visible changes
* List all files that were part of a COPY (in the log file).
* Add summary after a COPY to check how many files, slices, nodes, slots were involved.
* Add `rowcount` as a new key in the monitor payload.