### PR TITLE
Fix bootstrap_transformations

### DIFF
--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -461,8 +461,12 @@ def bootstrap_transformations(dsn_etl, schemas, local_dir, local_files, as_view,
     relations = [RelationDescription(file_set) for file_set in transforms]
     if update:
         logger.info("Loading existing table design file(s)")
-        # Unfortunately, this adds warnings about any of the upstream sources being unknown.
-        relations = etl.relation.order_by_dependencies(relations)
+        try:
+            # Unfortunately, this adds warnings about any of the upstream sources being unknown.
+            relations = etl.relation.order_by_dependencies(relations)
+        except ValueError as exc:
+            logger.error("Failed to load existing design file(s) before update: %s", exc)
+            raise
 
     if as_view:
         create_func = create_table_design_for_view
@@ -470,9 +474,8 @@ def bootstrap_transformations(dsn_etl, schemas, local_dir, local_files, as_view,
         create_func = create_table_design_for_ctas
 
     with closing(etl.db.connection(dsn_etl, autocommit=True)) as conn:
-        TableName.set_external_schemas(etl.db.get_external_schemas(conn))
         for relation in relations:
-            with relation.matching_temporary_view(conn) as tmp_view_name:
+            with relation.matching_temporary_view(conn, assume_external_schema=not update) as tmp_view_name:
                 table_design = create_func(conn, tmp_view_name, relation, update)
                 source_dir = os.path.join(local_dir, relation.source_name)
                 save_table_design(source_dir, relation.target_table_name, relation.target_table_name, table_design,

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -189,6 +189,8 @@ def create_partial_table_design(conn: connection, source_table_name: TableName, 
     default_attribute_type = type_maps["default_att_type"]  # default (fallback)
 
     source_attributes = fetch_attributes(conn, source_table_name)
+    if not source_attributes:
+        raise RuntimeError("failed to find attributes (check your query)")
     target_columns = [ColumnDefinition.from_attribute(attribute,
                                                       as_is_attribute_type,
                                                       cast_needed_attribute_type,

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -50,6 +50,8 @@ def load_table_design_from_localfile(local_filename, table_name):
     Load (and validate) table design file in local file system.
     """
     logger.debug("Loading local table design from '%s'", local_filename)
+    if local_filename is None:
+        raise ValueError("local filename is unknown")
     try:
         with open(local_filename) as f:
             table_design = load_table_design(f, table_name)

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -317,7 +317,7 @@ class RelationDescription:
         return None
 
     @contextmanager
-    def matching_temporary_view(self, conn):
+    def matching_temporary_view(self, conn, assume_external_schema=False):
         """
         Create a temporary view (with a name loosely based around the reference passed in).
 
@@ -327,7 +327,7 @@ class RelationDescription:
 
         with etl.db.log_error():
             ddl_stmt = """CREATE OR REPLACE VIEW {} AS\n{}""".format(temp_view, self.query_stmt)
-            if any(dep.is_external for dep in self.dependencies):
+            if assume_external_schema or any(dep.is_external for dep in self.dependencies):
                 ddl_stmt += "\nWITH NO SCHEMA BINDING"
                 temp_view.is_late_binding_view = True
 


### PR DESCRIPTION
Bug fix
* The workflow for creating an initial table design from a query has changed to accommodate working with external schemas.
    1. Write the query for a CTAS.
    2. Run `arthur.py bootstrap_transformations CTAS schema_name.table_name` (where the file `schemas/<schema_name>/<schema_name>-<table_name>.sql` must exist)
    3. Add dependencies to external dependencies. If there aren't any, run:
    4. Run `arthur.py bootstrap_transformations CTAS schema_name.table_name -u` (where the update adds dependencies automatically based on the query)