### PR TITLE
Add PagerNotification topic for Validation Pipeline on failure

### DIFF
--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -39,6 +39,13 @@
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
+            "id": "PagerNotification",
+            "type": "SnsAlarm",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-validation-page",
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
+        },
+        {
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
@@ -126,7 +133,11 @@
             "parent": { "ref": "ArthurCommandParent" },
             "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ validate --prolix --remote-files --prefix ${object_store.s3.prefix}/validation --keep-going --skip-sources-check",
             "dependsOn": { "ref": "ArthurLoad" },
-            "onSuccess": {"ref": "SuccessNotification"}
+            "onSuccess": {"ref": "SuccessNotification"},
+            "onFail": [
+                { "ref": "FailureNotification" },
+                { "ref": "PagerNotification" }
+            ]
         }
     ],
     "parameters": [

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -42,7 +42,7 @@
             "id": "PagerNotification",
             "type": "SnsAlarm",
             "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-validation-page",
-            "subject": "ETL Validation Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "subject": "ETL Validation Failure: ${object_store.s3.prefix}/validation at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -42,7 +42,7 @@
             "id": "PagerNotification",
             "type": "SnsAlarm",
             "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-validation-page",
-            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "subject": "ETL Validation Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
@@ -67,7 +67,6 @@
         },
         {
             "id": "Ec2CommandGrandParent",
-            "onFail": {"ref": "FailureNotification"},
             "runsOn": {"ref": "ArthurDriverEC2Resource"}
         },
         {

--- a/python/scripts/sns_subscribe.sh
+++ b/python/scripts/sns_subscribe.sh
@@ -45,13 +45,14 @@ ENV_PREFIX=$( arthur.py show_value resource_prefix --prefix "$PROJ_ENVIRONMENT" 
 STATUS_NAME="$ENV_PREFIX-status"
 PAGE_NAME="$ENV_PREFIX-page"
 VALIDATION_NAME="$ENV_PREFIX-validation"
+VALIDATION_PAGE_NAME="$ENV_PREFIX-validation-page"
 
 # ===  Create topic and subscription ===
 
 TOPIC_ARN_FILE="/tmp/topic_arn_${USER}$$.json"
 trap "rm -f \"$TOPIC_ARN_FILE\"" EXIT
 
-for TOPIC in "$STATUS_NAME" "$PAGE_NAME" "$VALIDATION_NAME"; do
+for TOPIC in "$STATUS_NAME" "$PAGE_NAME" "$VALIDATION_NAME" "$VALIDATION_PAGE_NAME"; do
     aws sns create-topic --name "$TOPIC" | tee "$TOPIC_ARN_FILE"
     TOPIC_ARN=`jq --raw-output < "$TOPIC_ARN_FILE" '.TopicArn'`
     if [[ -z "$TOPIC_ARN" ]]; then


### PR DESCRIPTION
Made changes to create a "validation-page" topic.
In validation pipeline template, added onFail block that will send a message to this topic.

Once this topic is created in production, will add a subscription that pings PagerDuty.