### PR TITLE
Show pipeline state (to gauge when finished)

### DIFF
--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -35,6 +35,10 @@ class DataPipeline:
     def health_status(self):
         return self.fields.get('@healthStatus', '---')
 
+    @property
+    def state(self):
+        return self.fields.get('@pipelineState', '---')
+
 
 def list_pipelines(selection: List[str]) -> List[DataPipeline]:
     """
@@ -87,9 +91,9 @@ def show_pipelines(selection: List[str]) -> None:
         else:
             logger.info("Currently active pipelines: %s",
                         join_with_quotes(pipeline.pipeline_id for pipeline in pipelines))
-        print(etl.text.format_lines([(pipeline.pipeline_id, pipeline.name, pipeline.health_status)
+        print(etl.text.format_lines([(pipeline.pipeline_id, pipeline.name, pipeline.health_status, pipeline.state)
                                      for pipeline in pipelines],
-                                    header_row=["Pipeline ID", "Name", "Health"], max_column_width=80))
+                                    header_row=["Pipeline ID", "Name", "Health", "State"], max_column_width=80))
     if selection and len(pipelines) == 1:
         pipeline = pipelines[0]
         print()

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -80,3 +80,8 @@ aws datapipeline put-pipeline-definition \
     --pipeline-id "$PIPELINE_ID"
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
+
+set +x
+echo
+echo "You can check the status of this upgrade pipeline using:"
+echo "  arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -88,5 +88,6 @@ aws datapipeline put-pipeline-definition \
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
 set +x
+echo
 echo "You can check the status of this validation pipeline using:"
 echo "  arthur.py show_pipelines -q '$PIPELINE_ID'"


### PR DESCRIPTION
This adds the pipeline state to the pipeline health shown by the `show_pipelines` command.
It's now easy to run this command in the shell and monitor the progress of a pipeline.

Example output:
```
Pipeline ID             | Name                | Health  | State
------------------------+---------------------+---------+---------
df-098ABCDEFGHIJKL      | Validation Pipeline | HEALTHY | FINISHED
(1 row)

Key                      | Value
-------------------------+-----------------------------------------------------
@accountId               | 123456789
@creationTime            | 2019-05-06T14:42:59
@finishedTime            | 2019-05-06T15:03:09
@firstActivationTime     | 2019-05-06T14:43:02
@healthStatus            | HEALTHY
@healthStatusUpdatedTime | 2019-05-06T14:45:17
@id                      | df-098ABCDEFGHIJKL
@lastActivationTime	 | 2019-05-06T14:43:02
@latestRunTime           | 2019-05-06T14:42:56
@pipelineState           | FINISHED
@scheduledEndTime        | 2019-05-07T14:42:56
@scheduledPeriod         | 1 day
@scheduledStartTime	 | 2019-05-06T14:42:56
@sphere                  | PIPELINE
@userId                  | 987654321
@version                 | 1
name                     | Validation Pipeline
pipelineCreator          | SOMEBODY:botocore-session-12345
uniqueId                 | validation-pipeline
(19 rows)
```
Note how the state says `Finished` and the health status is `Healthy`.

To run this as a monitor, use the `watch` command, as in:
```
watch --interval 10  arthur.py show_pipelines -q 'df-098ABCDEFGHIJKL'
```