### PR TITLE
Add row count to output of "query_events"

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1053,14 +1053,16 @@ class QueryEventsCommand(SubCommand):
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["prefix"])
+        parser.add_argument("--columns", help="comma-separated list of output columns")
         parser.add_argument("etl_id", help="pick particular ETL from the past", nargs="?")
 
     def callback(self, args, config):
+        # TODO This is starting to become awkard: make finding latest ETL a separate command.
         if args.etl_id is None:
             # Going back two days should cover at least one complete and one running rebuild ETL.
             etl.monitor.query_for_etl_ids(days_ago=2)
         else:
-            etl.monitor.scan_etl_events(args.etl_id)
+            etl.monitor.scan_etl_events(args.etl_id, args.columns)
 
 
 class TailEventsCommand(SubCommand):


### PR DESCRIPTION
Goal is to be able to compare row counts of tables between separate ETL runs.

First, look up the ETLs in the current environment with:
```
arthur.py query_events -q
```
Let's say the output is:
```
etl_id           | step    | timestamp
-----------------+---------+--------------------
C92AC14C4AD8442C | upgrade | 2019-05-05T15:47:11
4EA4FC6494CE496B | upgrade | 2019-05-05T20:55:28
```

If we now fetch the event information, it would create false-positives in comparisons since the time information is included. Consider:
```
# arthur.py query_events -q C92AC14C4AD8442C
target                           | step    | event  | timestamp           | elapsed | rowcount
---------------------------------+---------+--------+---------------------+---------+---------
redshift_experiments.dimensions  | upgrade | finish | 2019-05-05T15:47:56 |  42.85  |  98765
redshift_experiments.facts       | upgrade | finish | 2019-05-05T15:48:43 |  46.80  |  7654321
(2 rows)
```

So compare two runs by selecting only `rowcount` in the output. For example:
```
# arthur.py query_events -q C92AC14C4AD8442C --column rowcount
target                          | event  | rowcount
--------------------------------+--------+---------
redshift_experiments.dimensions | finish | 98765
redshift_experiments.facts      | finish | 7654321
(2 rows)
# arthur.py query_events -q 4EA4FC6494CE496B --column rowcount
target                          | event  | rowcount
--------------------------------+--------+---------
redshift_experiments.dimensions | finish | 44765
redshift_experiments.facts      | finish | 7654321
(2 row2)
```
(In this case ... something changed in the second run with the dimensions ... go fix it :-) )

Overall, we'll always show the `target` and `event` columns.