### PR TITLE
Release candidate for v1.8.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN echo $'source /tmp/redshift_etl/venv/bin/activate\n\
 source /tmp/redshift_etl/etc/arthur_completion.sh\n\
 PATH=$PATH:/tmp/redshift_etl/bin\n\
 cat /tmp/redshift_etl/etc/motd\n\
-echo "arthur.py settings object_store.s3.* version"\n\
+echo \n\
+echo "Environment settings:"\n\
 arthur.py settings object_store.s3.* version' > /root/.bashrc
 
 WORKDIR /data-warehouse

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1053,14 +1053,16 @@ class QueryEventsCommand(SubCommand):
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["prefix"])
+        parser.add_argument("--columns", help="comma-separated list of output columns")
         parser.add_argument("etl_id", help="pick particular ETL from the past", nargs="?")
 
     def callback(self, args, config):
+        # TODO This is starting to become awkard: make finding latest ETL a separate command.
         if args.etl_id is None:
             # Going back two days should cover at least one complete and one running rebuild ETL.
             etl.monitor.query_for_etl_ids(days_ago=2)
         else:
-            etl.monitor.scan_etl_events(args.etl_id)
+            etl.monitor.scan_etl_events(args.etl_id, args.columns)
 
 
 class TailEventsCommand(SubCommand):

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -36,7 +36,7 @@ import simplejson as json
 import etl.assets
 import etl.config
 import etl.text
-from etl.errors import ETLRuntimeError
+from etl.errors import ETLRuntimeError, InvalidArgumentError
 from etl.json_encoder import FancyJsonEncoder
 from etl.timer import utc_now, elapsed_seconds, Timer
 
@@ -543,14 +543,40 @@ def start_monitors(environment):
 
 
 def _format_output_column(key: str, value: str) -> str:
-    if key == "timestamp":
+    if value is None:
+        return '---'
+    elif key == "timestamp":
         # Make timestamp readable by turning epoch seconds into a date.
         return datetime.utcfromtimestamp(float(value)).replace(microsecond=0).isoformat()
     elif key == "elapsed":
         # Reduce number of decimals to 2.
         return '{:6.2f}'.format(float(value))
+    elif key == "rowcount":
+        return '{:9d}'.format(int(value))
     else:
         return value
+
+
+def _flatten_scan_result(result: dict) -> dict:
+    """Remove type annotation from a scan result.
+
+    Careful, this only works for a specific subset of types that DynamoDB may send back.
+
+    >>> result = _flatten_scan_result({'step': {'S': 'load'}, 'extra': {'M': {'rowcount': {'N': '100'}}}})
+    >>> sorted(result)
+    ['extra', 'step']
+    >>> result['extra']['rowcount']
+    '100'
+    """
+    flat = {}
+    for key, value in result.items():
+        if 'S' in value:
+            flat[key] = value['S']
+        elif 'N' in value:
+            flat[key] = value['N']
+        elif 'M' in value:
+            flat[key] = _flatten_scan_result(value['M'])
+    return flat
 
 
 def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
@@ -590,13 +616,24 @@ def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
     print(etl.text.format_lines(rows, header_row=keys))
 
 
-def scan_etl_events(etl_id) -> None:
-    """Scan for all events belonging to the specific ETL."""
+def scan_etl_events(etl_id, comma_separated_columns) -> None:
+    """Scan for all events belonging to a specific ETL."""
     ddb = DynamoDBStorage.factory()
     table = ddb.get_table(create_if_not_exists=False)
-    keys = ["target", "step", "event", "timestamp", "elapsed"]
+    all_keys = ["target", "step", "event", "timestamp", "elapsed", "rowcount"]
+    if comma_separated_columns:
+        selected_columns = comma_separated_columns.split(',')
+        invalid_columns = [key for key in selected_columns if key not in all_keys]
+        if invalid_columns:
+            raise InvalidArgumentError("invalid column(s): {}".format(','.join(invalid_columns)))
+        # We will always select "target" and "event" to have a meaningful output.
+        selected_columns = frozenset(selected_columns).union(["target", "event"])
+        keys = [key for key in all_keys if key in selected_columns]
+    else:
+        keys = all_keys
 
     # We need to scan here since the events are stored by "target" and not by "etl_id".
+    # TODO Try to find all the "known" relations and query on them with a filter on the etl_id.
     client = boto3.client('dynamodb')
     paginator = client.get_paginator('scan')
     response_iterator = paginator.paginate(
@@ -611,7 +648,7 @@ def scan_etl_events(etl_id) -> None:
             ":start_event": {"S": STEP_START}
         },
         FilterExpression="etl_id = :etl_id and target <> :marker and event <> :start_event",
-        ProjectionExpression="target, step, event, #timestamp, elapsed",
+        ProjectionExpression="target, step, event, #timestamp, elapsed, extra.rowcount",
         ReturnConsumedCapacity="TOTAL",
         # PaginationConfig={
         #     "PageSize": 100
@@ -620,18 +657,22 @@ def scan_etl_events(etl_id) -> None:
     logger.info("Scanning events table for elapsed times")
     consumed_capacity = .0
     scanned_count = 0
-    rows = []
+    rows = []  # type: List[List[str]]
     for response in response_iterator:
         consumed_capacity += response['ConsumedCapacity']['CapacityUnits']
         scanned_count += response['ScannedCount']
-        rows.extend([
-            [
-                _format_output_column(key, item[key].get('S', item[key].get('N'))) for key in keys
-            ]
-            for item in response['Items']
-        ])
+        items = [_flatten_scan_result(item) for item in response['Items']]
+        # Backwards compatibility kludge: Be careful picking out the rowcount which may not be present in older tables.
+        items = [
+            {key: item.get('extra', {'rowcount': None})['rowcount'] if key == 'rowcount' else item[key] for key in keys}
+            for item in items
+        ]
+        rows.extend([_format_output_column(key, item[key]) for key in keys] for item in items)
     logger.info("Scan result: scanned count = %d, consumed capacity = %f", scanned_count, consumed_capacity)
-    rows.sort(key=itemgetter(keys.index("timestamp")))
+    if "timestamp" in keys:
+        rows.sort(key=itemgetter(keys.index("timestamp")))
+    else:
+        rows.sort(key=itemgetter(keys.index("target")))
     print(etl.text.format_lines(rows, header_row=keys))
 
 

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -35,6 +35,10 @@ class DataPipeline:
     def health_status(self):
         return self.fields.get('@healthStatus', '---')
 
+    @property
+    def state(self):
+        return self.fields.get('@pipelineState', '---')
+
 
 def list_pipelines(selection: List[str]) -> List[DataPipeline]:
     """
@@ -87,9 +91,9 @@ def show_pipelines(selection: List[str]) -> None:
         else:
             logger.info("Currently active pipelines: %s",
                         join_with_quotes(pipeline.pipeline_id for pipeline in pipelines))
-        print(etl.text.format_lines([(pipeline.pipeline_id, pipeline.name, pipeline.health_status)
+        print(etl.text.format_lines([(pipeline.pipeline_id, pipeline.name, pipeline.health_status, pipeline.state)
                                      for pipeline in pipelines],
-                                    header_row=["Pipeline ID", "Name", "Health"], max_column_width=80))
+                                    header_row=["Pipeline ID", "Name", "Health", "State"], max_column_width=80))
     if selection and len(pipelines) == 1:
         pipeline = pipelines[0]
         print()

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -80,3 +80,8 @@ aws datapipeline put-pipeline-definition \
     --pipeline-id "$PIPELINE_ID"
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
+
+set +x
+echo
+echo "You can check the status of this upgrade pipeline using:"
+echo "  arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -88,5 +88,6 @@ aws datapipeline put-pipeline-definition \
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
 set +x
+echo
 echo "You can check the status of this validation pipeline using:"
 echo "  arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.8.6",
+    version="1.8.7",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
User-facing changes
* The row count of a data or CTAS relation can now be shown as part of `query_events`.
* It is possible to select a subset of output columns for the `query_events` command.
    - The expected use case is to retrieve a list of tables and their row count from two different ETLs, say one in production and one from a release candidate, and compare their counts so as to make sure that the release candidate makes no changes, at least not to the row count.
* The pipeline scheduled state is shown in addition to the health status.
    - The expected use case is to look up a pipeline state and demonstrate that a validation or upgrade pipeline completed successfully.
    - The install scripts for validation and update pipeline will advise users how to run the command to show the pipeline state.
    - Example output:
```
Pipeline ID             | Name                | Health  | State
------------------------+---------------------+---------+---------
df-098ABCDEFGHIJKL      | Validation Pipeline | HEALTHY | FINISHED
(1 row)
```

Other updates
* Logging noise around loading files from S3 has been drastically reduced making it easier to find the beginning of the actual ETL work.