### PR TITLE
Retry s3 execute fails

### DIFF
--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -273,7 +273,7 @@ def insert_from_query(conn: connection, table_name: TableName, column_list: List
         try:
             etl.db.execute(conn, stmt)
         except psycopg2.InternalError as exc:
-            if "S3 Query Exception (Fetch)" in exc.pgerror:
+            if "S3 Query Exception (" in exc.pgerror:
                 # If this error was caused by a table in S3 (see Redshift Spectrum) then we might be able to try again.
                 raise TransientETLError(exc) from exc
             else:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.8.7",
+    version="1.8.8",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
In addition to `S3 Query Exception (Fetch)` we're also seeing `S3 Query Exception (Execute)` errors occurring when queries are hitting S3. This change will make any error related to `S3 Query Exception` retry-able.