### PR TITLE
Expect the unexpected S3Query Exception

### DIFF
--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -273,7 +273,7 @@ def insert_from_query(conn: connection, table_name: TableName, column_list: List
         try:
             etl.db.execute(conn, stmt)
         except psycopg2.InternalError as exc:
-            if "S3 Query Exception (" in exc.pgerror:
+            if "S3 Query Exception" in exc.pgerror or "S3Query Exception" in exc.pgerror:
                 # If this error was caused by a table in S3 (see Redshift Spectrum) then we might be able to try again.
                 raise TransientETLError(exc) from exc
             else:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.8.8",
+    version="1.8.9",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
We received a new kind of error from Redshift running into troubles:
```
psycopg2.errors.InternalError_: S3Query Exception Connection failed, retries exceeded.
DETAIL:  
  -----------------------------------------------
  error:  S3Query Exception Connection failed, retries exceeded.
  code:      15005
  context:   
  query:     15067689
  location:  dory_util.cpp:844
  process:   query1_555_15067689 [pid=42951]
  -----------------------------------------------
```

This PR updates the strings we're looking for to detect spectrum errors with problems connecting to S3.