### PR TITLE
Stable docker build

### DIFF
--- a/bin/release_version.sh
+++ b/bin/release_version.sh
@@ -9,7 +9,7 @@ if [[ $# -gt 0 ]]; then
 
 Usage: `basename $0`
 
-This will write current version information to '$RELEASE_PATH'.
+This will update current version information in '$RELEASE_PATH'.
 
 EOF
     exit 0
@@ -33,5 +33,13 @@ elif GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD); then
 else
     echo "commit=$GIT_COMMIT_HASH" >> "$RELEASE_FILE"
 fi
+# TODO This should be the date of the latest commit to have a stable build.
 echo "date=`date '+%Y-%m-%d %H:%M:%S%z'`" >> "$RELEASE_FILE"
-cat "$RELEASE_FILE" | tee "python/etl/config/release.txt"
+
+if cmp "$RELEASE_FILE" "$RELEASE_PATH" >/dev/null; then
+    echo "Release information is unchanged."
+else
+    echo "Updating release information in $RELEASE_PATH"
+    cp "$RELEASE_FILE" "$RELEASE_PATH"
+fi
+cat "$RELEASE_FILE"

--- a/bin/release_version.sh
+++ b/bin/release_version.sh
@@ -20,11 +20,17 @@ if ! type -a git >/dev/null 2>&1 ; then
     exit 1
 fi
 
+# We add the latest commit hash to the release file which is misleading if we're pulling in modified files.
+if git status --porcelain 2>/dev/null | egrep '^ M|^M' >/dev/null; then
+    echo "Warning: Not all of your changes have been committed!" >&2
+fi
+
 RELEASE_FILE="/tmp/upload_env_release_${USER-nobody}$$.txt"
 > "$RELEASE_FILE"
 trap "rm \"$RELEASE_FILE\"" EXIT
 
 echo "toplevel=`git rev-parse --show-toplevel`" >> "$RELEASE_FILE"
+
 GIT_COMMIT_HASH=$(git rev-parse HEAD)
 if GIT_LATEST_TAG=$(git describe --exact-match --tags HEAD 2>/dev/null); then
     echo "commit=$GIT_COMMIT_HASH ($GIT_LATEST_TAG)" >> "$RELEASE_FILE"
@@ -33,8 +39,8 @@ elif GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD); then
 else
     echo "commit=$GIT_COMMIT_HASH" >> "$RELEASE_FILE"
 fi
-# TODO This should be the date of the latest commit to have a stable build.
-echo "date=`date '+%Y-%m-%d %H:%M:%S%z'`" >> "$RELEASE_FILE"
+
+echo "date=`git log -1 --format='%ai' HEAD`" >> "$RELEASE_FILE"
 
 if cmp "$RELEASE_FILE" "$RELEASE_PATH" >/dev/null; then
     echo "Release information is unchanged."


### PR DESCRIPTION
Tweak to the release file which now uses the latest date (along with the latest commit, as before). Since the "release file" stays the same when nothing new gets committed, the docker build doesn't just re-run every time like it did before. The Docker build will trigger a rebuild when there are changes to files or when a new commit is done.