### PR TITLE
Add condition to extract settings and allow to partition by timestamps

### DIFF
--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -205,6 +205,10 @@
         "extract_settings":  {
             "type": "object",
             "properties": {
+                "condition": {
+                    "$ref": "#/definitions/expression",
+                    "description": "Condition in SQL that will be part of the WHERE clause during extraction"
+                },
                 "split_by": { "$ref": "#/definitions/one_column_as_list" },
                 "num_partitions": {
                     "type": "integer",

--- a/python/etl/extract/database_extractor.py
+++ b/python/etl/extract/database_extractor.py
@@ -103,7 +103,7 @@ class DatabaseExtractor(Extractor):
         selected_columns = relation.get_columns_with_casts()
         statement = """SELECT {} FROM {}""".format(", ".join(selected_columns), relation.source_table_name)
         if add_sampling_on_column is None:
-            statement += " WHERE TRUE"
+            statement += """ WHERE ("created_at" >= '2019-02-28') """
         else:
             self.logger.info("Adding sampling on column '%s' while extracting '%s.%s'",
                              add_sampling_on_column, relation.source_name, relation.source_table_name.identifier)

--- a/python/etl/extract/database_extractor.py
+++ b/python/etl/extract/database_extractor.py
@@ -102,12 +102,16 @@ class DatabaseExtractor(Extractor):
         """
         selected_columns = relation.get_columns_with_casts()
         statement = """SELECT {} FROM {}""".format(", ".join(selected_columns), relation.source_table_name)
+
+        condition = relation.table_design.get("extract_settings", {}).get("condition", "TRUE")
+
         if add_sampling_on_column is None:
-            statement += """ WHERE ("created_at" >= '2019-02-28') """
+            statement += """ WHERE ({})""".format(condition)
         else:
             self.logger.info("Adding sampling on column '%s' while extracting '%s.%s'",
                              add_sampling_on_column, relation.source_name, relation.source_table_name.identifier)
-            statement += """ WHERE (("{}" % 10) = 1)""".format(add_sampling_on_column)
+            statement += """ WHERE (({}) AND ("{}" % 10) = 1)""".format(condition, add_sampling_on_column)
+
         return statement
 
     def fetch_source_table_size(self, dsn_dict: Dict[str, str], relation: RelationDescription) -> int:

--- a/python/etl/extract/sqoop.py
+++ b/python/etl/extract/sqoop.py
@@ -147,6 +147,8 @@ class SqoopExtractor(DatabaseExtractor):
         """
         Build the partitioning-related arguments for Sqoop.
         """
+        return ["--split-by", "CAST(TO_CHAR(created_at, 'YYYYMMDDHH24MISS') AS BIGINT)", "--num-mappers", str(16)]
+
         if partition_key:
             quoted_key_arg = '"{}"'.format(partition_key)
 


### PR DESCRIPTION
If you have an upstream (source) table that could be split by a date but has no other usable partition key, then use that date column.
If you need only portion of the source table, then specify a condition.

Example:
```
    "extract_settings": {
            "condition": "created_at >= '2019-01-01'",
            "split_by": [ "created_at" ]
    },
```

Also:
Closes #101