### PR TITLE
Pin the mypy version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -rrequirements.txt
-mypy>=0.521
+mypy>=0.521,<=0.670
 # q>=2.6
 # ipython>=6.2


### PR DESCRIPTION
Leaving the mypy version to trail upstream causes some validation issues right now in the type checker. This pins the version to 0.670.