### PR TITLE
Fixes for mypy 0.740

### DIFF
--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -103,7 +103,8 @@ class LoadableRelation:
             return getattr(self._relation_description, name)
         raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, name))
 
-    __str__ = RelationDescription.__str__
+    # This works although __str__ will get passed a 'LoadableRelation' object instead of a 'RelationDescription' object.
+    __str__ = RelationDescription.__str__  # type: ignore
 
     def __format__(self, code):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -rrequirements.txt
-mypy>=0.521,<=0.670
+mypy==0.740
 # q>=2.6
 # ipython>=6.2


### PR DESCRIPTION
This bumps the version of mypy to 0.740 and adds fixes to deal with errors that pop up with that version, e.g.
```
python/etl/extract/sqoop.py:64: error: Argument "dir" to "NamedTemporaryFile" has incompatible type "str"; expected "None"
python/etl/load.py:106: error: Incompatible types in assignment (expression has type "Callable[[RelationDescription], Any]", base class "object" defined the type as "Callable[[object], str]")
```
where the first is more of a bug with the standard library and the second is due to careful recklessness.