### PR TITLE
SQL for f_sha256

### DIFF
--- a/sql/000_ADMIN_grant_language.sql
+++ b/sql/000_ADMIN_grant_language.sql
@@ -1,0 +1,1 @@
+GRANT USAGE ON LANGUAGE plpythonu TO etl;

--- a/sql/001_ETL_create_f_sha256.sql
+++ b/sql/001_ETL_create_f_sha256.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION dw.f_sha256 (msg VARCHAR)
+        returns varchar
+STABLE
+AS $$
+        import hashlib
+        return hashlib.sha256(msg).hexdigest()
+$$ LANGUAGE plpythonu
+;
+
+/* TODO When loading functions, grant to the "default" group from the setup */
+GRANT EXECUTE ON FUNCTION dw.f_sha256(msg varchar) TO GROUP analyst_ro
+;

--- a/sql/001_ETL_create_f_sha256.sql
+++ b/sql/001_ETL_create_f_sha256.sql
@@ -1,3 +1,5 @@
+/* Naming here follows recommenation in https://docs.aws.amazon.com/redshift/latest/dg/udf-naming-udfs.html */
+/* See also: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_FUNCTION.html */
 CREATE OR REPLACE FUNCTION dw.f_sha256 (msg VARCHAR)
         returns varchar
 STABLE

--- a/sql/001_ETL_create_f_sha256.sql
+++ b/sql/001_ETL_create_f_sha256.sql
@@ -1,5 +1,6 @@
-/* Naming here follows recommenation in https://docs.aws.amazon.com/redshift/latest/dg/udf-naming-udfs.html */
+/* Naming here follows recommendation in https://docs.aws.amazon.com/redshift/latest/dg/udf-naming-udfs.html */
 /* See also: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_FUNCTION.html */
+
 CREATE OR REPLACE FUNCTION dw.f_sha256 (msg VARCHAR)
         returns varchar
 STABLE

--- a/sql/README.md
+++ b/sql/README.md
@@ -1,0 +1,5 @@
+For files named `<number>_<USER>_<description>.sql`:
+    * Run them in alpha-numeric sort order (which should sort by `number`)
+    * Execute them as the `ADMIN` or `ETL` user, depending on `USER`
+
+(And ideally, create a PR to have an Arthur step do that during `initialize`.)


### PR DESCRIPTION
Add file that needs to be run as admin to allow the `etl` user to define functions, then run as `etl` a SQL file to add a function to calculate SHA256 using a UDF.

This is just an example ... we don't have a way inside the tooling to pull in UDFs into a data warehouse.