### PR TITLE
Show table execution level

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ running code in development cluster first should go through a release candidate.
 
 ### Releasing code to master branch
 
-Once code is considered ready for production:
+Once code is considered ready for production (and you've made sure there's an **updated** version number in `setup.py`):
 * Merge `next` into `master`
 ```
 git checkout master

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -10,12 +10,12 @@ Usage: `basename $0` [-p aws_profile] [-t tag] [<config_dir> [<target_env>]]
 This will drop you into a shell in a Docker container with Arthur installed and
 configured to use <config_dir>.
 
-The <config_dir> default to \$DATA_WAREHOUSE_CONFIG.
+The <config_dir> defaults to \$DATA_WAREHOUSE_CONFIG.
 The <target_env> defaults to \$ARTHUR_DEFAULT_PREFIX (or \$USER if not set).
 The optional -p flag lets you use the given profile from your AWS CLI config
 within the container. If \$AWS_PROFILE is set, it will be used as a default.
 
-You must build the Docker image with docker_build.sh before using this script.
+You must have built the Docker image with docker_build.sh before using this script.
 
 EOF
     exit ${1-0}

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -944,12 +944,16 @@ class ShowDownstreamDependentsCommand(SubCommand):
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern", "prefix", "scheme", "continue-from"])
+        parser.add_argument("--list-dependencies", help="show list of dependencies after every relation",
+                            action="store_true")
 
     def callback(self, args, config):
         relations = self.find_relation_descriptions(args,
                                                     required_relation_selector=config.required_in_full_load_selector,
                                                     return_all=True)
-        etl.load.show_downstream_dependents(relations, args.pattern, continue_from=args.continue_from)
+        etl.load.show_downstream_dependents(relations, args.pattern,
+                                            continue_from=args.continue_from,
+                                            list_dependencies=args.list_dependencies)
 
 
 class ShowUpstreamDependenciesCommand(SubCommand):

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1084,7 +1084,7 @@ def show_downstream_dependents(relations: List[RelationDescription], selector: T
                      " flag={flag:9s}"
                      " is_required={relation.is_required}")
 
-    back_reference = {}  # type: Dict[TableName, RelationDescription]
+    relation_map = {relation.target_table_name: relation for relation in selected_relations}
     for i, relation in enumerate(selected_relations):
         if relation.identifier in selected:
             flag = "selected"
@@ -1095,13 +1095,12 @@ def show_downstream_dependents(relations: List[RelationDescription], selector: T
         print(line_template.format(index=i + 1, relation=relation, width=max_len, flag=flag))
         if list_dependencies:
             for dependency in relation.dependencies:
-                if dependency in back_reference:
+                if dependency in relation_map:
                     print("  #> {relation.identifier:{width}s} # level={relation.level:3d}".format(
-                        relation=back_reference[dependency], width=max_len))
+                        relation=relation_map[dependency], width=max_len))
                 else:
                     # Dependencies that are not described as relations are "external" and thus at level = 1.
                     print("  #> {relation.identifier:{width}s} # level=1".format(relation=dependency, width=max_len))
-        back_reference[relation.target_table_name] = relation
 
 
 def show_upstream_dependencies(relations: List[RelationDescription], selector: TableSelector):

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1064,6 +1064,7 @@ def show_downstream_dependents(relations: List[RelationDescription], selector: T
     part of the propagation of new data.
     They are also marked whether they'd lead to a fatal error since they're required for full load.
     """
+    relation_map = {relation.target_table_name: relation for relation in relations}
     selected_relations = etl.relation.select_in_execution_order(relations, selector,
                                                                 include_dependents=True, continue_from=continue_from)
     if not selected_relations:
@@ -1084,7 +1085,6 @@ def show_downstream_dependents(relations: List[RelationDescription], selector: T
                      " flag={flag:9s}"
                      " is_required={relation.is_required}")
 
-    relation_map = {relation.target_table_name: relation for relation in selected_relations}
     for i, relation in enumerate(selected_relations):
         if relation.identifier in selected:
             flag = "selected"
@@ -1094,13 +1094,13 @@ def show_downstream_dependents(relations: List[RelationDescription], selector: T
             flag = "dependent"
         print(line_template.format(index=i + 1, relation=relation, width=max_len, flag=flag))
         if list_dependencies:
-            for dependency in relation.dependencies:
+            for dependency in sorted(relation.dependencies):
                 if dependency in relation_map:
                     print("  #> {relation.identifier:{width}s} # level={relation.level:3d}".format(
                         relation=relation_map[dependency], width=max_len))
                 else:
-                    # Dependencies that are not described as relations are "external" and thus at level = 1.
-                    print("  #> {relation.identifier:{width}s} # level=1".format(relation=dependency, width=max_len))
+                    # Dependencies that are not described as relations are "external".
+                    print("  #> {relation.identifier:{width}s} # level=  0".format(relation=dependency, width=max_len))
 
 
 def show_upstream_dependencies(relations: List[RelationDescription], selector: TableSelector):

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -469,6 +469,8 @@ def set_required_relations(relations: List[RelationDescription], required_select
     """
     Set the required property of the relations if they are directly or indirectly feeding
     into relations selected by the :required_selector.
+
+    Side-effect: relations are sorted to determine dependencies and their order and level is set.
     """
     logger.info("Loading table design for %d relation(s) to mark required relations", len(relations))
     ordered_descriptions = order_by_dependencies(relations)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.9.2",
+    version="1.9.3",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.9.3",
+    version="1.10.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
The output for `show_downstream_dependents` now also shows the "execution level" which starts from 1 for sources (or independent views and tables) and from then on is the max of any level of dependencies plus 1. All tables with the same execution level could be executed in parallel and all would work out in the right order.

The implementation is slightly ugly in that the level is annotated in the original relation description. That's a (design) problem for another day. (On the bright side, I did some code-cleanup around ordering relations in execution order.)