### PR TITLE
Add "validation" to log path

### DIFF
--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -8,7 +8,7 @@
             "failureAndRerunMode": "CASCADE",
             "resourceRole": "${resources.EC2.iam_instance_profile}",
             "role": "${resources.DataPipeline.role}",
-            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/validation/",
             "region": "${resources.VPC.region}",
             "maximumRetries": "2"
         },

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -122,7 +122,7 @@ def validate_dependencies(conn: connection, relation: RelationDescription, tmp_v
         logger.error("Mismatch in dependencies of '{}': {}".format(relation.identifier, difference))
         raise TableDesignValidationError("mismatched dependencies in '%s'" % relation.identifier)
     else:
-        logger.info('Dependencies listing in design file matches SQL')
+        logger.info("Dependencies listing in design file for '%s' matches SQL", relation.identifier)
 
 
 def validate_column_ordering(conn: connection, relation: RelationDescription, tmp_view_name: TempTableName) -> None:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.10.0",
+    version="1.11.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
We derive the "environment" from the path of the log file when processing logs. This is broken when the path doesn't contain the full environment name. So my logs for a validation pipeline currently show up as "environment:tom" in Kibana and not "environment:tom/validation".

There is also a cosmetic change included in that the log lines for checking dependencies now includes the name of the relation. This way the log lines still make sense after filtering in Kibana.