### PR TITLE
Change order of sections in table design files

### DIFF
--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -332,7 +332,7 @@ def make_item_sorter():
     """
     preferred_order = [
         "name", "description",  # always (tables, columns, etc.)
-        "source_name", "unload_target", "depends_on", "columns", "constraints", "attributes",  # only tables
+        "source_name", "unload_target", "depends_on", "constraints", "attributes", "columns",  # only tables
         "sql_type", "type", "expression", "source_sql_type", "not_null", "identity"  # only columns
     ]
     order_lookup = {key: (i, key) for i, key in enumerate(preferred_order)}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.10.0",
+    version="1.11.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
We usually care much more about learning the constraints and attributes of a table when checking table design files than seeing the list of columns. The list of columns is automatically created and we'll probably only go back to add an `encoding`. On the other hand, many constraints and all attributes are manually added.
We've been manually hoisting the constraints and attributes sections in table design files -- this makes that the "official" order.

To take advantage of this new order, update existing table design files, e.g.
```
arthur.py bootstrap_transformations -u CTAS dw.fact_order
```