### PR TITLE
Add extraction pipeline script

### DIFF
--- a/python/etl/templates/extraction_pipeline.json
+++ b/python/etl/templates/extraction_pipeline.json
@@ -28,14 +28,14 @@
             "id": "SuccessNotification",
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
-            "subject": "ETL Upgrade Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "subject": "ETL Extraction Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
-            "subject": "ETL Upgrade Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "subject": "ETL Extraction Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
@@ -45,54 +45,31 @@
             "terminateAfter": "6 Hours"
         },
         {
-            "id": "ArthurDriverEC2Resource",
-            "type": "Ec2Resource",
+            "id": "ETLCluster",
+            "name": "ETL EMR Cluster",
+            "type": "EmrCluster",
             "parent": { "ref": "ResourceParent" },
-            "actionOnTaskFailure": "terminate",
-            "actionOnResourceFailure": "retryAll",
-            "instanceType": "${resources.EC2.instance_type}",
-            "imageId": "${resources.EC2.image_id}",
-            "securityGroupIds": [
+            "releaseLabel": "${resources.EMR.release_label}",
+            "masterInstanceType": "${resources.EMR.master.instance_type}",
+            "coreInstanceType": "${resources.EMR.core.instance_type}",
+            "coreInstanceCount": "${resources.EMR.core.instance_count}",
+            "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
+            "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
+            "additionalMasterSecurityGroupIds": [
                 "${resources.EC2.public_security_group}",
                 "${resources.VPC.whitelist_security_group}"
             ],
-            "associatePublicIpAddress": "true"
+            "bootstrapAction": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh,${object_store.s3.bucket_name},${object_store.s3.prefix}",
+            "applications": [ "Spark", "Ganglia", "Zeppelin", "Sqoop" ],
+            "configuration": []
         },
         {
-            "id": "Ec2CommandGrandParent",
-            "runsOn": { "ref": "ArthurDriverEC2Resource" }
-        },
-        {
-            "id": "ShellCommandParent",
-            "parent": { "ref": "Ec2CommandGrandParent" }
-        },
-        {
-            "id": "ArthurCommandParent",
-            "parent": { "ref": "Ec2CommandGrandParent" },
+            "id": "EmrActivityUpstreamExtract",
+            "name": "Arthur Extract (EMR Activity)",
+            "type": "EmrActivity",
+            "step": "/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar,/tmp/redshift_etl/venv/bin/arthur.py,--config,/tmp/redshift_etl/config/,extract,--keep-going,--prolix,--prefix,${object_store.s3.prefix},#{myExtractArguments}",
+            "runsOn": { "ref": "ETLCluster" },
             "maximumRetries": "0"
-        },
-        {
-            "id": "CopyBootstrap",
-            "name": "Copy Bootstrap (EC2)",
-            "type": "ShellCommandActivity",
-            "parent": { "ref": "ShellCommandParent" },
-            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh /tmp/bootstrap.sh"
-        },
-        {
-            "id": "Bootstrap",
-            "name": "Bootstrap (EC2)",
-            "type": "ShellCommandActivity",
-            "parent": { "ref": "ShellCommandParent" },
-            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}",
-            "dependsOn": { "ref": "CopyBootstrap" }
-        },
-        {
-            "id": "ArthurUpgrade",
-            "name": "Arthur Upgrade (EC2)",
-            "type": "ShellCommandActivity",
-            "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ upgrade --prolix --prefix ${object_store.s3.prefix} #{myUpgradeArguments}",
-            "dependsOn": { "ref": "Bootstrap" }
         }
     ],
     "parameters": [
@@ -105,16 +82,16 @@
             "helpText": "When should the pipeline start?"
         },
         {
-            "id": "myUpgradeArguments",
+            "id": "myExtractArguments",
             "type": "String",
             "optional": "false",
-            "description": "Arguments for the upgrade command, e.g. relations. Defaults to '--continue-from :transformations'",
+            "description": "Arguments for the extract command (must be comma separated)",
             "watermark": "*",
-            "helpText": "Which table should we continue from?"
+            "helpText": "Which tables should we extract?"
         }
     ],
     "values": {
         "myStartDateTime": "2525-01-01T00:00:00",
-        "myUpgradeArguments": "--continue-from :transformations"
+        "myExtractArguments": ""
     }
 }

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -28,21 +28,21 @@
             "id": "SuccessNotification",
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
-            "subject": "ETL Rebuild Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "subject": "ETL Rebuild Success (Pizza): ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
-            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "subject": "ETL Rebuild Failure (Pizza): ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
             "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
-            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "subject": "ETL Rebuild Failure (Pizza): ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nSphere: #{node.@sphere}\\nCancellation reason: #{node.cancellationReason}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nError stacktrace: #{node.errorStackTrace}"
         },
         {

--- a/python/scripts/install_extraction_pipeline.sh
+++ b/python/scripts/install_extraction_pipeline.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+START_NOW=`date -u +"%Y-%m-%dT%H:%M:%S"`
+USER="${USER-nobody}"
+DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
+
+if [[ $# -lt 1 || "$1" = "-h" ]]; then
+
+    cat <<EOF
+
+Single-shot extraction pipeline. You get to pick the arguments to 'extract' command.
+
+Usage: `basename $0` extract_arg [extract_arg ...]
+
+The remaining arguments will be passed to 'extract'.
+The environment defaults to "$DEFAULT_PREFIX".
+
+Example: `basename $0` dw
+
+EOF
+    exit 0
+
+fi
+
+set -e -u
+
+# Verify that there is a local configuration directory
+DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
+if [[ ! -d "$DEFAULT_CONFIG" ]]; then
+    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
+    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+    exit 1
+fi
+
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_ENVIRONMENT="$DEFAULT_PREFIX"
+
+# The list of arguments must be comma-separated when passed to a step in an EMR cluster.
+EXTRACT_ARGUMENTS=$(join_by ',' "$@")
+
+START_DATE_TIME="$START_NOW"
+
+# Verify that this bucket/environment pair is set up on s3
+BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
+if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
+    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+    exit 1
+fi
+
+set -x
+
+# Note: "key" and "value" are lower-case keywords here.
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
+
+PIPELINE_NAME="Extraction Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
+PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
+PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
+
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" extraction_pipeline > "$PIPELINE_DEFINITION_FILE"
+
+aws datapipeline create-pipeline \
+    --unique-id dw-etl-extraction-pipeline \
+    --name "$PIPELINE_NAME" \
+    --tags $AWS_TAGS \
+    | tee "$PIPELINE_ID_FILE"
+
+PIPELINE_ID=`jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId'`
+
+if [[ -z "$PIPELINE_ID" ]]; then
+    set +x
+    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+    exit 1
+fi
+
+aws datapipeline put-pipeline-definition \
+    --pipeline-definition "file://$PIPELINE_DEFINITION_FILE" \
+    --parameter-values \
+        myStartDateTime="$START_DATE_TIME" \
+        myExtractArguments="$EXTRACT_ARGUMENTS" \
+    --pipeline-id "$PIPELINE_ID"
+
+aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
+
+set +x
+echo
+echo "You can monitor the status of this extraction pipeline using:"
+echo "  watch arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/launch_ec2_instance.sh
+++ b/python/scripts/launch_ec2_instance.sh
@@ -10,8 +10,13 @@ set -e -u
 # === Command line args ===
 
 show_usage_and_exit() {
-    echo "Usage: `basename $0` [<environment>]"
-    echo "The environment defaults to \"$DEFAULT_PREFIX\"."
+    cat <<USAGE
+
+Usage: `basename $0` [<environment>]
+
+The environment defaults to "$DEFAULT_PREFIX".
+
+USAGE
     exit ${1-0}
 }
 

--- a/python/scripts/launch_emr_cluster.sh
+++ b/python/scripts/launch_emr_cluster.sh
@@ -13,8 +13,13 @@ set -e -u
 # === Command line args ===
 
 show_usage_and_exit() {
-    echo "Usage: `basename $0` [<environment>]"
-    echo "The environment defaults to \"$DEFAULT_PREFIX\"."
+    cat <<USAGE
+
+Usage: `basename $0` [<environment>]
+
+The environment defaults to "$DEFAULT_PREFIX".
+
+USAGE
     exit ${1-0}
 }
 
@@ -126,5 +131,8 @@ cat <<EOF
 
   export CLUSTER_ID="$CLUSTER_ID"
 
-# * Do not forget to shutdown the cluster as soon as you no longer need it. *
+# *** Do not forget to shutdown the cluster as soon as you no longer need it. ***
+
+  terminate_emr_cluster.sh "$CLUSTER_ID"
+
 EOF

--- a/python/scripts/terminate_emr_cluster.sh
+++ b/python/scripts/terminate_emr_cluster.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Terminate an EMR cluster in AWS (or list all active ones to find the one to terminate).
+
+USER="${USER-nobody}"
+DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
+
+set -o errexit -o nounset
+
+# === Command line args ===
+
+show_usage_and_exit() {
+    cat <<USAGE
+
+Usage: `basename $0` [<cluster_id>]
+
+This will terminate the cluster with the given cluster ID.
+If no cluster ID is provided, all active clusters are listed.
+
+USAGE
+    exit ${1-0}
+}
+
+while getopts ":h" opt; do
+  case $opt in
+    h)
+      show_usage_and_exit
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ $# -gt 1 ]]; then
+    show_usage_and_exit 1
+elif [[ $# -eq 0 ]]; then
+    ACTIVE=$(
+        set -o xtrace
+        aws emr list-clusters --active |
+            jq --raw-output '.Clusters?[] | [.Id, .Name, .Status.State] | @tsv'
+    )
+    set +o xtrace
+    echo
+    if [[ -z "$ACTIVE" ]]; then
+        echo "No active clusters."
+    else
+        echo "Active clusters:"
+        echo "$ACTIVE"
+    fi
+else
+    set -o xtrace
+    CLUSTERID="$1"
+    # This will fail for us if the cluster ID is invalid.
+    aws emr modify-cluster-attributes --no-termination-protected --cluster-id "$CLUSTERID"
+    aws emr terminate-clusters --cluster-ids "$CLUSTERID"
+    aws emr list-clusters --active --query "Clusters[?Id=='$CLUSTERID']" |
+        jq --raw-output '.[] | [.Id, .Name, .Status.State] | @tsv'
+fi

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.11.0",
+    version="1.12.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.10.0",
+    version="1.11.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",
@@ -20,6 +20,7 @@ setup(
     },
     scripts=[
         "python/scripts/compare_events.py",
+        "python/scripts/install_extraction_pipeline.sh",
         "python/scripts/install_pizza_load_pipeline.sh",
         "python/scripts/install_rebuild_pipeline.sh",
         "python/scripts/install_refresh_pipeline.sh",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "etl": [
             "assets/*",
             "config/*",
-            "templates/*"
+            "templates/*",
         ]
     },
     scripts=[
@@ -30,13 +30,14 @@ setup(
         "python/scripts/launch_emr_cluster.sh",
         "python/scripts/re_run_partial_pipeline.py",
         "python/scripts/sns_subscribe.sh",
-        "python/scripts/submit_arthur.sh"
+        "python/scripts/submit_arthur.sh",
+        "python/scripts/terminate_emr_cluster.sh",
     ],
     entry_points={
         "console_scripts": [
             # NB The script must end in ".py" so that spark submit accepts it as a Python script.
             "arthur.py = etl.commands:run_arg_as_command",
-            "run_tests.py = etl.selftest:run_tests"
+            "run_tests.py = etl.selftest:run_tests",
         ]
     }
 )


### PR DESCRIPTION
We have currently no way of extraction upstream sources during development inside a pipeline. This leads to developers spinning up EMR clusters and then forgetting about them. Adding a script for this step allows us to have a consistent flow in simple cases and yet have access to all the individual steps if we needed to.
```
arthur.py sync --force upstream.source
install_extraction_pipeline.sh upstream.source
# Wait for its execution to finish
install_upgrade_pipeline.sh upstream_source
```

An alternative implementation would add an extract step to the upgrade pipeline which, however, might mean that we'll spin up an EMR cluster for nothing since there's no conditional on the resources when a step is empty.

Bonus feature:
```
terminate_emr_cluster.sh "j-3SVABCDSRYTZ"
```
If you don't provide a cluster ID to the `terminate_emr_cluster.sh` script, it will list all active clusters.