### PR TITLE
Add AZ64 as supported column encoding

### DIFF
--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -53,6 +53,7 @@
             "description": "Encoding types for columns in Redshift tables, see http://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html",
             "enum": [
                 "raw",
+                "az64",
                 "bytedict",
                 "delta",
                 "delta32k",


### PR DESCRIPTION
Update per https://docs.amazonaws.cn/en_us/redshift/latest/dg/az64-encoding.html