### PR TITLE
Make timeout for rebuild pipeline configurable

### DIFF
--- a/python/etl/templates/extraction_pipeline.json
+++ b/python/etl/templates/extraction_pipeline.json
@@ -42,7 +42,7 @@
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
-            "terminateAfter": "6 Hours"
+            "terminateAfter": "#{myTimeout} Hours"
         },
         {
             "id": "ETLCluster",
@@ -88,10 +88,20 @@
             "description": "Arguments for the extract command (must be comma separated)",
             "watermark": "*",
             "helpText": "Which tables should we extract?"
+        },
+        {
+            "id": "myTimeout",
+            "type": "Integer",
+            "optional": "true",
+            "description": "How many hours to allow the pipeline to run before terminating it",
+            "watermark": "6",
+            "default": "6",
+            "helpText": "How long can the pipeline run?"
         }
     ],
     "values": {
         "myStartDateTime": "2525-01-01T00:00:00",
-        "myExtractArguments": ""
+        "myExtractArguments": "",
+        "myTimeout": "6"
     }
 }

--- a/python/etl/templates/pizza_load_pipeline.json
+++ b/python/etl/templates/pizza_load_pipeline.json
@@ -49,7 +49,7 @@
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
-            "terminateAfter": "6 Hours"
+            "terminateAfter": "#{myTimeout} Hours"
         },
         {
             "id": "ArthurDriverEC2Resource",
@@ -166,10 +166,20 @@
             "description": "Relation name to continue from (or *) (for ArthurUpgrade)",
             "watermark": "*",
             "helpText": "Which table should we continue from?"
+        },
+        {
+            "id": "myTimeout",
+            "type": "Integer",
+            "optional": "true",
+            "description": "How many hours to allow the pipeline to run before terminating it",
+            "watermark": "6",
+            "default": "6",
+            "helpText": "How long can the pipeline run?"
         }
     ],
     "values": {
         "myStartDateTime": "2525-01-01T00:00:00",
-        "mySelection": "*"
+        "mySelection": "*",
+        "myTimeout": "6"
     }
 }

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -49,7 +49,7 @@
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
-            "terminateAfter": "8 Hours"
+            "terminateAfter": "#{myTimeout} Hours"
         },
         {
             "id": "ETLCluster",
@@ -193,10 +193,20 @@
             "description": "Number of occurrences for this pipeline",
             "watermark": "1000",
             "helpText": "How often should the pipeline schedule be repeated?"
+        },
+        {
+            "id": "myTimeout",
+            "type": "Integer",
+            "optional": "true",
+            "description": "How many hours to allow the pipeline to run before terminating it",
+            "watermark": "8",
+            "default": "8",
+            "helpText": "How long can the pipeline run?"
         }
     ],
     "values": {
         "myStartDateTime": "2525-01-01T00:00:00",
-        "myOccurrences": "1000"
+        "myOccurrences": "1000",
+        "myTimeout": "8"
     }
 }

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -49,7 +49,7 @@
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
-            "terminateAfter": "6 Hours"
+            "terminateAfter": "#{myTimeout} Hours"
         },
         {
             "id": "ETLCluster",
@@ -184,12 +184,22 @@
             "description": "Comma separated list of arthur pattern globs (for ArthurExtract)",
             "watermark": "*",
             "helpText": "Which tables should be refreshed?"
+        },
+        {
+            "id": "myTimeout",
+            "type": "Integer",
+            "optional": "true",
+            "description": "How many hours to allow the pipeline to run before terminating it",
+            "watermark": "6",
+            "default": "6",
+            "helpText": "How long can the pipeline run?"
         }
     ],
     "values": {
         "myStartDateTime": "2525-01-01T00:00:00",
         "myOccurrences": "1000",
         "mySelection": "",
-        "myCommaSeparatedSelection": ""
+        "myCommaSeparatedSelection": "",
+        "myTimeout": "6"
     }
 }

--- a/python/etl/templates/upgrade_pipeline.json
+++ b/python/etl/templates/upgrade_pipeline.json
@@ -42,7 +42,7 @@
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
-            "terminateAfter": "6 Hours"
+            "terminateAfter": "#{myTimeout} Hours"
         },
         {
             "id": "ArthurDriverEC2Resource",
@@ -111,10 +111,20 @@
             "description": "Arguments for the upgrade command, e.g. relations. Defaults to '--continue-from :transformations'",
             "watermark": "*",
             "helpText": "Which table should we continue from?"
+        },
+        {
+            "id": "myTimeout",
+            "type": "Integer",
+            "optional": "true",
+            "description": "How many hours to allow the pipeline to run before terminating it",
+            "watermark": "6",
+            "default": "6",
+            "helpText": "How long can the pipeline run?"
         }
     ],
     "values": {
         "myStartDateTime": "2525-01-01T00:00:00",
-        "myUpgradeArguments": "--continue-from :transformations"
+        "myUpgradeArguments": "--continue-from :transformations",
+        "myTimeout": "6"
     }
 }

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -49,7 +49,7 @@
             "id": "ResourceParent",
             "keyPair": "${resources.key_name}",
             "subnetId": "${resources.VPC.public_subnet}",
-            "terminateAfter": "2 Hours"
+            "terminateAfter": "#{myTimeout} Hours"
         },
         {
             "id": "ArthurDriverEC2Resource",
@@ -155,10 +155,20 @@
             "description": "Number of occurrences for this pipeline",
             "watermark": "1000",
             "helpText": "How often should the pipeline schedule be repeated?"
+        },
+        {
+            "id": "myTimeout",
+            "type": "Integer",
+            "optional": "true",
+            "description": "How many hours to allow the pipeline to run before terminating it",
+            "watermark": "6",
+            "default": "6",
+            "helpText": "How long can the pipeline run?"
         }
     ],
     "values": {
         "myStartDateTime": "2525-01-01T00:00:00",
-        "myOccurrences": "1000"
+        "myOccurrences": "1000",
+        "myTimeout": "2"
     }
 }

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -161,8 +161,8 @@
             "type": "Integer",
             "optional": "true",
             "description": "How many hours to allow the pipeline to run before terminating it",
-            "watermark": "6",
-            "default": "6",
+            "watermark": "2",
+            "default": "2",
             "helpText": "How long can the pipeline run?"
         }
     ],

--- a/python/scripts/install_rebuild_pipeline.sh
+++ b/python/scripts/install_rebuild_pipeline.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-if [[ $# -lt 3 || "$1" = "-h" ]]; then
+if [[ $# -lt 3 || $# -gt 4 || "$1" = "-h" ]]; then
     echo "Usage: `basename $0` <environment> <startdatetime> <occurrences> [timeout]"
     echo "      Start time should be 'now' or take the ISO8601 format like: `date -u +"%Y-%m-%dT%H:%M:%S"`"
-    echo "      Optional timeout should be the number of hours it's allowed to run. Defaults to 8"
+    echo "      Optional timeout should be the number of hours pipeline is allowed to run. Defaults to 8."
     exit 0
 fi
 
-# Optional timeout parameter. Default value set in pipeline template, not here
+# Optional timeout parameter. Default value set in pipeline template, not here.
 TIMEOUT="$4"
 
 set -e -u

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.14.0",
+    version="1.15.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.15.0",
+    version="1.14.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
Updated all of the pipeline templates so that the timeout is now a parameter instead of being hard-coded. The parameters simply default to the previously hard-coded values.

Only the `install_rebuild_pipeline.sh` script was updated to allow the user to set the timeout parameter however; that's the only one we need right now, and it was much simpler to add the extra parameter to that script than several of the others.

Depends on #156 