### PR TITLE
Add bin/docker_upload.sh to simplify Arthur deploys

### DIFF
--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -11,6 +11,10 @@ case "$0" in
         action="deploy"
         action_description="deploy your data warehouse from a shell"
         ;;
+    *docker_upload.sh)
+        action="upload"
+        action_description="upload your ELT code from a shell"
+        ;;
     *)
         echo "Internal Error: unknown script name!" >&2
         exit 1
@@ -98,7 +102,7 @@ fi
 # The commands below bind the following directories
 #   - the "data warehouse" directory which is the parent of the chosen configuration directory
 #   - the '~/.aws' directory which contains the config and credentials needed
-#   - the '~/.ssh' directory which contains the keys to login into EMR and EC2 hosts
+#   - the '~/.ssh' directory which contains the keys to login into EMR and EC2 hosts (for interactive shells)
 # The commands below set these environment variables
 #   - DATA_WAREHOUSE_CONFIG so that Arthur finds the configuration files
 #   - ARTHUR_DEFAULT_PREFIX to pick the default "environment" (same as S3 prefix)
@@ -123,12 +127,22 @@ case "$action" in
         docker run --rm --tty \
             --volume "$data_warehouse_path":/data-warehouse \
             --volume ~/.aws:/root/.aws \
-            --volume ~/.ssh:/root/.ssh \
             -e DATA_WAREHOUSE_CONFIG="/data-warehouse/$config_path" \
             -e ARTHUR_DEFAULT_PREFIX="$target_env" \
             $profile_arg \
             "arthur:$tag" \
             /bin/bash -c 'source /tmp/redshift_etl/venv/bin/activate && arthur.py sync --force --deploy'
+        ;;
+    upload)
+        set -o xtrace
+        docker run --rm --interactive --tty \
+            --volume "$data_warehouse_path":/data-warehouse \
+            --volume ~/.aws:/root/.aws \
+            -e DATA_WAREHOUSE_CONFIG="/data-warehouse/$config_path" \
+            -e ARTHUR_DEFAULT_PREFIX="$target_env" \
+            $profile_arg \
+            "arthur:$tag" \
+            /bin/bash -c 'source /tmp/redshift_etl/venv/bin/activate && /tmp/redshift_etl/bin/upload_env.sh'
         ;;
     *)
         echo "Internal Error: unknown action '$action'!" >&2

--- a/bin/docker_upload.sh
+++ b/bin/docker_upload.sh
@@ -1,0 +1,1 @@
+docker_run.sh

--- a/bin/sync_env.sh
+++ b/bin/sync_env.sh
@@ -2,7 +2,7 @@
 
 # Sync (meaning: overwrite) one environment with another.
 
-set -eu
+set -o errexit -o nounset
 
 show_usage_and_exit () {
     cat <<EOF
@@ -70,7 +70,7 @@ if [[ "$CONFIRMED_YES" != "yes" ]]; then
     ask_to_confirm "Are you sure you want to overwrite '$CLUSTER_TARGET_ENVIRONMENT'?"
 fi
 
-set -x
+set -o xtrace
 
 for FOLDER in bin config jars schemas data; do
     aws s3 sync --delete --exclude 'credentials*.sh' \
@@ -84,6 +84,6 @@ if ! aws s3 sync --exclude '*' --include 'credentials*.sh' \
         "s3://$CLUSTER_BUCKET/$CLUSTER_SOURCE_ENVIRONMENT/config" \
         "s3://$CLUSTER_BUCKET/$CLUSTER_TARGET_ENVIRONMENT/config"
 then
-    set +x
+    set +o xtrace
     echo "You will have to copy your credentials manually!"
 fi

--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -8,7 +8,7 @@
 # Example:
 #   AWS_PROFILE=my-prof bin/upload_env.sh my-warehouse-bucket my-env
 
-set -e
+set -o errexit
 
 USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
@@ -45,7 +45,7 @@ else
     PROJ_TARGET_ENVIRONMENT=$( arthur.py show_value --prefix "$DEFAULT_PREFIX" object_store.s3.prefix )
 fi
 
-set -u
+set -o nounset
 
 ask_to_confirm () {
     while true; do
@@ -94,7 +94,7 @@ bin/release_version.sh || echo "File with release information was not updated!"
 
 echo "Creating Python dist file, then uploading files (including configuration, excluding credentials) to S3"
 
-set -x
+set -o xtrace
 
 python3 setup.py sdist
 LATEST_TAR_FILE=`ls -1t dist/redshift_etl*tar.gz | head -1`
@@ -116,7 +116,7 @@ if [[ -d "jars" ]]; then
         jars "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/jars"
 fi
 
-set +x
+set +o xtrace
 echo
 echo "# You should *now* sync your data warehouse::"
 echo "arthur.py sync --deploy --prefix \"$PROJ_TARGET_ENVIRONMENT\""


### PR DESCRIPTION
Simply call one script in the local environment that deploys the latest Arthur code.

New deployment step to upload Arthur code:
```
bin/docker_upload.sh -p data-profile ../your-data-warehouse/config_directory
```

This combines the two-step dance of
```
# First create container:
bin/docker_run.sh -p data-profile ../your-data-warehouse/config_directory
# Then inside the container, run:
upload_env.sh
```