### PR TITLE
Update CloudFormation based on alert experiences

### DIFF
--- a/cloudformation/dw_cluster.yaml
+++ b/cloudformation/dw_cluster.yaml
@@ -173,7 +173,7 @@ Resources:
             Namespace: AWS/Redshift
             Statistic: Minimum
             ComparisonOperator: LessThanThreshold
-            Threshold: 2
+            Threshold: 1
             Period: 60
             EvaluationPeriods: 3
             Dimensions:

--- a/cloudformation/dw_cluster.yaml
+++ b/cloudformation/dw_cluster.yaml
@@ -127,7 +127,7 @@ Resources:
             PubliclyAccessible:
                 true
             PreferredMaintenanceWindow:
-                "mon:14:10-mon:14:40"
+                "sun:18:30-sun:19:00"
             VpcSecurityGroupIds:
                 - Fn::ImportValue: !Sub "${VpcStackName}::redshift-public-sg"
             SnapshotIdentifier:
@@ -148,11 +148,13 @@ Resources:
             AlarmDescription: "Disk space usage too high"
             AlarmActions:
                 - !Ref ClusterAlertTopic
+            OKActions:
+                - !Ref ClusterAlertTopic
             MetricName: PercentageDiskSpaceUsed
             Namespace: AWS/Redshift
             Statistic: Average
             ComparisonOperator: GreaterThanThreshold
-            Threshold: 60
+            Threshold: 65
             Period: 300
             EvaluationPeriods: 3
             Dimensions:
@@ -165,11 +167,13 @@ Resources:
             AlarmDescription: "Cluster unhealthy"
             AlarmActions:
                 - !Ref ClusterAlertTopic
+            OKActions:
+                - !Ref ClusterAlertTopic
             MetricName: HealthStatus
             Namespace: AWS/Redshift
             Statistic: Minimum
             ComparisonOperator: LessThanThreshold
-            Threshold: 1
+            Threshold: 2
             Period: 60
             EvaluationPeriods: 3
             Dimensions:


### PR DESCRIPTION
Update Redshift clusters:
* Maintenance window moved to Sunday so as not to interfere with users's dashboards on Monday morning.
* Unhealthy alert needs two minutes two trigger which should cut down on any false positives. A reboot during maintenance will still trigger this.
* The disk space usage is bumped to 65% or about 2/3.
* Addition of "Ok" actions should help with auto-resolving alerts in PagerDuty.