### PR TITLE
Build Arthur so that latest version is used for deployment

### DIFF
--- a/bin/build_arthur.sh
+++ b/bin/build_arthur.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset
 show_usage_and_exit () {
     cat <<EOF
 
-Usage: `basename $0` [-t tag_name]
+Usage: `basename $0` [-t image_tag]
 
 This builds the Docker image to run Arthur locally. Docker itself must already be installed.
 The script 'bin/release_version.sh' is run to update version information for the build.

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -13,7 +13,7 @@ case "$0" in
         ;;
     *docker_upload.sh|*deploy_arthur.sh)
         action="upload"
-        action_description="upload your ELT code from a shell"
+        action_description="upload your ELT code from a shell (after building the image)"
         ;;
     *run_validation.sh)
         action="validate"
@@ -141,6 +141,9 @@ case "$action" in
         ;;
     upload)
         set -o xtrace
+        bin/release_version.sh
+        docker build --tag "arthur:$tag" .
+        # TODO(tom): This needs to be interactive because of the y/n-question from the upload script.
         docker run --rm --interactive --tty \
             --volume "$data_warehouse_path":/data-warehouse \
             --volume ~/.aws:/root/.aws \

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -29,7 +29,7 @@ esac
 show_usage_and_exit () {
     cat <<EOF
 
-Usage: `basename $0` [-p aws_profile] [-t tag] [<config_dir> [<target_env>]]
+Usage: `basename $0` [-p aws_profile] [-t image_tag] [<config_dir> [<target_env>]]
 
 This will $action_description inside a Docker container with Arthur installed and
 configured to use <config_dir>.


### PR DESCRIPTION
When deploying arthur, it was assumed that the latest version had been built. This now simply builds arthur before deploying it so that the release info and build image are up to date.