### PR TITLE
Show rowcount for a relation

### DIFF
--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -255,7 +255,7 @@ def query_load_summary(conn: connection, table_name: TableName, dry_run=False) -
         [row] = etl.db.query(conn, stmt, (copy_id,))
         logger.info(
             (
-                "Copied {copy_count:d} rows into {table_name:x} "
+                "Copied {copy_count:d} row(s) into {table_name:x} "
                 "(files: {file_count:d}, slices: {slice_count:d}, nodes: {node_count:d}, slots: {slot_count:d}, "
                 "elapsed: {elapsed}s ({elapsed_queued}s queued), size: {total_mb}MB)"
             ).format(copy_count=copy_count, table_name=table_name, **row)

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -664,7 +664,8 @@ def build_one_relation(conn: connection, relation: LoadableRelation, dry_run=Fal
         if not (relation.in_transaction or relation.is_view_relation or relation.failed):
             rows = etl.db.run(
                 conn,
-                "Calculating row count for {:x}".format(relation),
+                # TODO(tom): This should be logged at the DEBUG level.
+                "(Calculating row count for {:x})".format(relation),
                 "SELECT COUNT(*) AS rowcount FROM {}".format(relation),
                 return_result=True,
                 dry_run=dry_run,

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -664,13 +664,15 @@ def build_one_relation(conn: connection, relation: LoadableRelation, dry_run=Fal
         if not (relation.in_transaction or relation.is_view_relation or relation.failed):
             rows = etl.db.run(
                 conn,
-                "Calculating row count",
+                "Calculating row count for {:x}".format(relation),
                 "SELECT COUNT(*) AS rowcount FROM {}".format(relation),
                 return_result=True,
                 dry_run=dry_run,
             )
             if rows:
-                monitor.add_extra("rowcount", rows[0]["rowcount"])
+                rowcount = rows[0]["rowcount"]
+                logger.info("Found {:d} row(s) in {:x}".format(rowcount, relation))
+                monitor.add_extra("rowcount", rowcount)
 
 
 def build_one_relation_using_pool(pool, relation: LoadableRelation, dry_run=False) -> None:


### PR DESCRIPTION
The log lines right now are just a tease -- we show that the query is about to run but then don't show the result. This PR adds the missing info, the rowcount of a table that just got loaded.

```
2020-04-10 17:09:25 - INFO - (Calculating row count for 'dw.orders')
2020-04-10 17:09:25 - INFO - Found 100 row(s) in 'dw.orders'
```
