### PR TITLE
Add docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,11 +52,13 @@ echo \n\
 echo "Environment settings:"\n\
 arthur.py settings object_store.s3.* version' > /root/.bashrc
 
-WORKDIR /data-warehouse
-
 # Whenever there is an ETL running, it offers progress information on port 8086.
 EXPOSE 8086
 
+WORKDIR /data-warehouse
 # From here, bind-mount your data warehouse code directory to /data-warehouse.
 # All of the normal Arthur configuration for accessing and managing the data
 # warehouse is assumed to have already been set up in that directory.
+
+ENTRYPOINT ["/arthur-redshift-etl/bin/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+# Entrypoint script for Docker image to adjust for mounting the source directory.
+# 1. If we are using the python code that was copied into the image, then there's
+#    nothing else to do. The package information is correct (and static).
+#    That said, it won't hurt to update the package info.
+# 2. If we are mounting the local source into the image, then we may either find
+#    no package information or that the package information is out of date.
+#    In this case, we need to make sure that the virtual environment can find
+#    the up-to-date package information.
+# 3. Finally it's easy to forget to update package information when changing
+#    one of the scripts but then their old version will continue to be used.
+# Side-effect: You will find a python/redshift_etl.egg-info directory locally.
+# (This also means that we cannot mount the source read-only.)
+
+set -o errexit
+
+(
+    cd /arthur-redshift-etl &&
+    python setup.py develop
+)
+
+exec "$@"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -3,15 +3,15 @@
 # Entrypoint script for Docker image to adjust for mounting the source directory.
 # 1. If we are using the python code that was copied into the image, then there's
 #    nothing else to do. The package information is correct (and static).
-#    That said, it won't hurt to update the package info.
 # 2. If we are mounting the local source into the image, then we may either find
 #    no package information or that the package information is out of date.
 #    In this case, we need to make sure that the virtual environment can find
 #    the up-to-date package information.
 # 3. Finally it's easy to forget to update package information when changing
 #    one of the scripts but then their old version will continue to be used.
+# Bottom line: We'll always run "python setup.py develop" when starting up.
 # Side-effect: You will find a python/redshift_etl.egg-info directory locally.
-# (This also means that we cannot mount the source read-only.)
+#              (This also means that we cannot mount the source read-only.)
 
 set -o errexit
 

--- a/readme_release.md
+++ b/readme_release.md
@@ -1,7 +1,7 @@
 # Release of ETL code as open-source project
 
 Some files crept into the private repo that had some of our AWS setup hard-coded,
-like account number of security groups.
+like account number or security groups.
 Although these settings should not be useful for folks outside our organization,
 we still dropped all files related to AWS settings.
 This file outlines the steps taken from our private repo to a public repo.


### PR DESCRIPTION
This is a fix to enable developing on the ELT inside a Docker container. What I had missed the first time around is that there's an interaction with the local file system. The command `python setup.py develop` creates `python/redshift_etl.egg-info`. And having that command only run while the local file is NOT mounted, means that that info file isn't updated. This PR makes sure that we run `python setup.py develop` every time.