### PR TITLE
Add auto option for distribution style in H-D-W schemas

### DIFF
--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -190,8 +190,7 @@
             "properties": {
                 "distribution": {
                     "oneOf": [
-                        { "enum": [ "all" ] },
-                        { "enum": [ "even" ] },
+                        { "enum": [ "all", "even", "auto" ] },
                         { "$ref": "#/definitions/one_column_as_list" }
                     ]
                 },

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -113,10 +113,8 @@ def build_table_attributes(table_design: dict) -> List[str]:
         if isinstance(distribution, list):
             ddl_attributes.append("DISTSTYLE KEY")
             ddl_attributes.append("DISTKEY ( {} )".format(join_column_list(distribution)))
-        elif distribution == "all":
-            ddl_attributes.append("DISTSTYLE ALL")
-        elif distribution == "even":
-            ddl_attributes.append("DISTSTYLE EVEN")
+        else:
+            ddl_attributes.append("DISTSTYLE {}".format(distribution.upper()))
     if compound_sort:
         ddl_attributes.append("COMPOUND SORTKEY ( {} )".format(join_column_list(compound_sort)))
     elif interleaved_sort:


### PR DESCRIPTION
## Description of changes

* For the schemas in H-D-W, it is now possible to set the distribution field to "auto", which is one of the distribution style permitted. This will tell Redshift  to automatically choose a distribution style for that table.

## Impacted areas

I identified two impacted areas:
  * Validation of the schemas against the table design.
  * Formatting the SQL query for the create table statement.

## Testing

* I ran a validation with arthur to check the scemas, skipping the dependencies and upstream check.
* I did not test the create table part.

## Risks

* The generation for create table statement was not tested.