### PR TITLE
Switch EMR nodes to spot instances instead of on-demand instances

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -39,9 +39,12 @@
         "EMR": {
             "core": {
                 "bid_price": 10.0
+            },
+            "master": {
+                "bid_price": 10.0
             }
         }
-    }
+    },
     # Type information from source (PostgreSQL) to target (Redshift)
     "type_maps": {
         # Types that may be used "as-is", see also

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -33,6 +33,15 @@
         "read_capacity": 3,
         "write_capacity": 3
     },
+    # Set a default value for spot instances that is high enough that engineers do not need
+    # to think about it for most use cases.
+    "resources": {
+        "EMR": {
+            "core": {
+                "bid_price": 10.0
+            }
+        }
+    }
     # Type information from source (PostgreSQL) to target (Redshift)
     "type_maps": {
         # Types that may be used "as-is", see also

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -119,6 +119,7 @@
                     "type": "integer",
                     "minimum": 1
                 },
+                "bid_price": { "type": "number" },
                 "managed_security_group": { "type": "string" }
             },
             "required": [ "instance_type", "managed_security_group" ],

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -119,7 +119,10 @@
                     "type": "integer",
                     "minimum": 1
                 },
-                "bid_price": { "type": "number" },
+                "bid_price": {
+                    "type": "number",
+                    "minimum": 0.01
+                },
                 "managed_security_group": { "type": "string" }
             },
             "required": [ "instance_type", "managed_security_group" ],

--- a/python/etl/templates/extraction_pipeline.json
+++ b/python/etl/templates/extraction_pipeline.json
@@ -51,8 +51,10 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
+            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
+            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [

--- a/python/etl/templates/instance_groups.json
+++ b/python/etl/templates/instance_groups.json
@@ -3,12 +3,14 @@
         "Name": "Master instance group - 1",
         "InstanceGroupType": "MASTER",
         "InstanceCount": ${resources.EMR.master.instance_count},
-        "InstanceType": "${resources.EMR.master.instance_type}"
+        "InstanceType": "${resources.EMR.master.instance_type}",
+        "BidPrice": "${resources.EMR.master.bid_price}"
     },
     {
         "Name": "Core instance group - 2",
         "InstanceGroupType": "CORE",
         "InstanceCount": ${resources.EMR.core.instance_count},
-        "InstanceType": "${resources.EMR.core.instance_type}"
+        "InstanceType": "${resources.EMR.core.instance_type}",
+        "BidPrice": "${resources.EMR.core.bid_price}"
     }
 ]

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -58,8 +58,10 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
+            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
+            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -58,8 +58,10 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
+            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
+            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [


### PR DESCRIPTION
Currently, EMR clusters in our pipelines utilize on-demand instances, by shifting to spot instances we can reduce node costs to below the reserved instance hourly rates while simultaneously avoiding their 24/7 requirement.

https://harrys.atlassian.net/browse/DOC-136
https://harrys.atlassian.net/browse/TECK-573

This change will break backwards compatibility with existing Arthur pipelines.  