### PR TITLE
Sample only above 100MB

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -735,7 +735,7 @@ class ExtractToS3Command(MonitoredSubCommand):
         )
         parser.add_argument(
             "--use-sampling",
-            help="use only 10%% of rows in extracted tables that are larger than 1MB",
+            help="use only 10%% of rows in extracted tables that are larger than 100MB",
             default=False,
             action="store_true",
         )

--- a/python/etl/extract/database_extractor.py
+++ b/python/etl/extract/database_extractor.py
@@ -37,9 +37,9 @@ class DatabaseExtractor(Extractor):
 
     def use_sampling_with_table(self, size: int) -> bool:
         """
-        Return True iff option `--use-sampling` appeared and table is large enough (> 1MB).
+        Return True iff option `--use-sampling` appeared and table is large enough (> 100MB).
         """
-        return self.use_sampling and (size > 1024 ** 2)
+        return self.use_sampling and (size > 100 * 1024 ** 2)
 
     def select_min_partition_size(self, size: int) -> int:
         """


### PR DESCRIPTION
Raise the limit when "sampling" of a table kicks in. This tries to avoid "sampling" small tables that are actually needed in full (stuff that ends up in dimension tables) while still turning on 10% sampling for very large tables. The limit goes from 1MB to 100MB.