### PR TITLE
Use default of max 32 partitions

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -741,7 +741,7 @@ class ExtractToS3Command(MonitoredSubCommand):
         )
 
     def callback(self, args, config):
-        max_partitions = args.max_partitions or etl.config.get_config_int("resources.EMR.max_partitions", 16)
+        max_partitions = args.max_partitions or etl.config.get_config_int("resources.EMR.max_partitions")
         if max_partitions < 1:
             raise InvalidArgumentError("Option for max partitions must be >= 1")
         if args.extractor not in ("sqoop", "spark", "manifest-only"):

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -43,7 +43,8 @@
             },
             "master": {
                 "bid_price": 10.0
-            }
+            },
+            "max_partitions": 32
         }
     },
     # Type information from source (PostgreSQL) to target (Redshift)


### PR DESCRIPTION
This changes the default from a max of 16 to max of 32 partitions when extracting tables from upstream data sources. This is better for larger clusters (with more slices) and to avoid single files blocking progress (while other slices sit idle).

Also, this moves the default out of code into the default settings file.