### PR TITLE
Allow description for columns in VIEW relations

### DIFF
--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -125,7 +125,8 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "name": { "$ref": "#/definitions/identifier" }
+                            "name": { "$ref": "#/definitions/identifier" },
+                            "description": { "type": "string" }
                         },
                         "required": [ "name" ],
                         "additionalProperties": false


### PR DESCRIPTION
This PR allows to add a `description` on a column name when the relation is a VIEW just like we allow `description` on column in `CTAS` relations. There wasn't a particular good reason to not do this. Also, this is backwards compatible in that it allows a new field which won't affect current table design files.