### PR TITLE
Use epoch time (seconds) instead of decimal date

### DIFF
--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -211,17 +211,12 @@ def validate_semantics_of_table(table_design):
     if split_by_name:
         split_by_column = fy.first(fy.where(table_design["columns"], name=split_by_name))
         if split_by_column.get("skipped", False):
-            raise TableDesignSemanticError("Split-by column type must not be skipped")
+            raise TableDesignSemanticError("split-by column must not be skipped")
         if not split_by_column.get("not_null", False):
-            raise TableDesignSemanticError("Split-by column type must have not-null constraint")
-        if split_by_column["type"] == "string":
-            if split_by_column["sql_type"].lower() not in ("timestamp", "timestamp without time zone"):
-                raise TableDesignSemanticError(
-                    "Split-by column must be a timestamp when not numeric, not '{}'".format(split_by_column["sql_type"])
-                )
-        elif split_by_column["type"] not in ("int", "long"):
+            raise TableDesignSemanticError("split-by column must have not-null constraint")
+        if split_by_column["type"] not in ("int", "long", "date", "timestamp"):
             raise TableDesignSemanticError(
-                "Split-by column type must be int or long when numeric, not '{}'".format(split_by_column["type"])
+                "type of split-by column must be int, long, date or timestamp, not '{}'".format(split_by_column["type"])
             )
 
 

--- a/python/etl/extract/sqoop.py
+++ b/python/etl/extract/sqoop.py
@@ -181,8 +181,8 @@ class SqoopExtractor(DatabaseExtractor):
         """
         if partition_key:
             column = fy.first(fy.where(relation.table_design["columns"], name=partition_key))
-            if column["sql_type"] in ("timestamp", "timestamp without time zone"):
-                quoted_key_arg = """CAST(TO_CHAR("{}", 'YYYYMMDDHH24MISS') AS BIGINT)""".format(partition_key)
+            if column["type"] in ("date", "timestamp"):
+                quoted_key_arg = """CAST(DATE_PART('epoch', "{}") AS BIGINT)""".format(partition_key)
             else:
                 quoted_key_arg = '"{}"'.format(partition_key)
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -463,7 +463,6 @@ def create_missing_dimension_row(columns: List[dict]) -> List[str]:
         elif column.get("identity", False):
             na_values_row.append("0")
         else:
-            # Use NULL for all null-able columns:
             if not column.get("not_null", False):
                 # Use NULL for any nullable column and use type cast (for UNION ALL to succeed)
                 na_values_row.append("NULL::{}".format(column["sql_type"]))

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -330,17 +330,13 @@ class RelationDescription:
 
         column = fy.first(fy.where(self.table_design["columns"], name=partition_key))
 
-        # We check here the "generic" type which abstracts the SQL types like smallint, int4, bigint, ...
-        if column["type"] in ("int", "long"):
-            logger.debug("Partition key for table '%s' is '%s'", self.identifier, partition_key)
-            return partition_key
-        # We check the specific case of a timestamp here.
-        if column["type"] == "string" and column["sql_type"] in ("timestamp", "timestamp without time zone"):
+        # We check here the "generic" type which abstracts the SQL types like smallint, int4, etc.
+        if column["type"] in ("int", "long", "date", "timestamp"):
             logger.debug("Partition key for table '%s' is '%s'", self.identifier, partition_key)
             return partition_key
 
         logger.warning(
-            "Column '%s' is not a number or timestamp and is not usable as a partition key for '%s'",
+            "Column '%s' is not int, long, date or timestamp so is not usable as a partition key for '%s'",
             partition_key,
             self.identifier,
         )


### PR DESCRIPTION
This solidifies partitioning tables during the extract step when we want to partition by a timestamp or date. The current code unfortunately leads to skewed files since the partition key is computed as a numeric interpretation of the date (`20200529184819`) instead of seconds (1590778099).
A second update here makes sure to test on the column types in their generic form (`date`, `timestamp`) instead of their SQL types (same/similar for dates and timestamps but varying for int, long, float, etc.)

Changes required:
* For any table with a partition key that's a date or timestamp, make sure that the generic `type` info reflects that it's a date or timestamp. A `string` value will no longer be supported as the partition key. This change can be made ahead of deploying this version.