### PR TITLE
Hotfix revert spot instances

### DIFF
--- a/python/etl/templates/extraction_pipeline.json
+++ b/python/etl/templates/extraction_pipeline.json
@@ -51,10 +51,8 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
-            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
-            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [

--- a/python/etl/templates/instance_groups.json
+++ b/python/etl/templates/instance_groups.json
@@ -3,14 +3,12 @@
         "Name": "Master instance group - 1",
         "InstanceGroupType": "MASTER",
         "InstanceCount": ${resources.EMR.master.instance_count},
-        "InstanceType": "${resources.EMR.master.instance_type}",
-        "BidPrice": "${resources.EMR.master.bid_price}"
+        "InstanceType": "${resources.EMR.master.instance_type}"
     },
     {
         "Name": "Core instance group - 2",
         "InstanceGroupType": "CORE",
         "InstanceCount": ${resources.EMR.core.instance_count},
-        "InstanceType": "${resources.EMR.core.instance_type}",
-        "BidPrice": "${resources.EMR.core.bid_price}"
+        "InstanceType": "${resources.EMR.core.instance_type}"
     }
 ]

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -58,10 +58,8 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
-            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
-            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -58,10 +58,8 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
-            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
-            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.22.0",
+    version="1.22.1",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
The change to use spot instances for EMR clusters didn't include creation or permission to create the service linked role: `AWSServiceRoleForEC2Spot`.
This PR reverts using spot instances. We'll create a new PR to revert to using spot instances and also creating the role as needed.