### PR TITLE
Use Spot instances for EMR cluster (take 2)

### DIFF
--- a/cloudformation/do_cloudformation.sh
+++ b/cloudformation/do_cloudformation.sh
@@ -91,6 +91,18 @@ case "$DW_VERB" in
             "Key=user:stack-env-name,Value=$ENV_NAME"
     ;;
 
+  create-change-set)
+    aws cloudformation create-change-set \
+        --stack-name "$STACK_NAME" \
+        --change-set-name "DW-$(date -u '+%Y-%m-%d-%H-%M-%S')" \
+        --template-body "$TEMPLATE_URI" \
+        --capabilities CAPABILITY_NAMED_IAM \
+        --parameters $STACK_PARAMETERS \
+        --tags \
+            "Key=user:project,Value=data-warehouse" \
+            "Key=user:stack-env-name,Value=$ENV_NAME"
+    ;;
+
   update)
 
     aws cloudformation update-stack \

--- a/cloudformation/dw_vpc.yaml
+++ b/cloudformation/dw_vpc.yaml
@@ -1,4 +1,4 @@
-Description: |
+Description: |-
     Create the VPC for the Redshift data warehouse and its ETL.
 
 #    We use one public and one private subnet, an Internet Gateway, a service
@@ -690,6 +690,21 @@ Resources:
                                 - "sqs:PurgeQueue"
                                 - "sqs:ReceiveMessage"
                             Resource: "*"
+                - PolicyName: "service-role-for-spot"
+                  PolicyDocument:
+                      Version: "2012-10-17"
+                      Statement:
+                          - Effect: "Allow"
+                            Action: "iam:CreateServiceLinkedRole"
+                            Resource: "arn:aws:iam::*:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot"
+                            Condition:
+                                StringLike:
+                                    "iam:AWSServiceName": "spot.amazonaws.com"
+                          - Effect: "Allow"
+                            Action:
+                              - "iam:AttachRolePolicy"
+                              - "iam:PutRolePolicy"
+                            Resource: "arn:aws:iam::*:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot"
 
     # This starts from the default EMR instance profile role plus the Data Pipeline default resource role.
     # (NB We need allow ec2:CreateTags here so that bootstrap can update the tags of the instance.)

--- a/python/etl/templates/extraction_pipeline.json
+++ b/python/etl/templates/extraction_pipeline.json
@@ -51,8 +51,10 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
+            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
+            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [

--- a/python/etl/templates/instance_groups.json
+++ b/python/etl/templates/instance_groups.json
@@ -3,12 +3,14 @@
         "Name": "Master instance group - 1",
         "InstanceGroupType": "MASTER",
         "InstanceCount": ${resources.EMR.master.instance_count},
-        "InstanceType": "${resources.EMR.master.instance_type}"
+        "InstanceType": "${resources.EMR.master.instance_type}",
+        "BidPrice": "${resources.EMR.master.bid_price}"
     },
     {
         "Name": "Core instance group - 2",
         "InstanceGroupType": "CORE",
         "InstanceCount": ${resources.EMR.core.instance_count},
-        "InstanceType": "${resources.EMR.core.instance_type}"
+        "InstanceType": "${resources.EMR.core.instance_type}",
+        "BidPrice": "${resources.EMR.core.bid_price}"
     }
 ]

--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -58,8 +58,10 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
+            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
+            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -58,8 +58,10 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
+            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
+            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [


### PR DESCRIPTION
We reverted using spot instances for the EMR cluster since a necessary role not automatically created. This is the second attempt to get this feature out. The role for the Data Pipeline and EMR cluster will now create the service-linked role.

See:
* Switch EMR nodes to spot instances instead of on-demand instances #181
* Hotfix revert spot instances #189