### PR TITLE
Add -y (assume yes) to upload script

### DIFF
--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -142,21 +142,25 @@ case "$action" in
             --env ARTHUR_DEFAULT_PREFIX="$target_env" \
             $profile_arg \
             "arthur:$tag" \
-            /bin/bash -c 'source /tmp/redshift_etl/venv/bin/activate && arthur.py sync --force --deploy'
+            /bin/bash -c \
+                'source /tmp/redshift_etl/venv/bin/activate && \
+                arthur.py sync --force --deploy'
         ;;
     upload)
         set -o xtrace
         bin/release_version.sh
         docker build --tag "arthur:$tag" .
-        # TODO(tom): This needs to be interactive because of the y/n-question from the upload script.
-        docker run --rm --interactive --tty \
+        docker run --rm --tty \
             --volume "$data_warehouse_path":/data-warehouse \
             --volume ~/.aws:/root/.aws \
             --env DATA_WAREHOUSE_CONFIG="/data-warehouse/$config_path" \
             --env ARTHUR_DEFAULT_PREFIX="$target_env" \
             $profile_arg \
             "arthur:$tag" \
-            /bin/bash -c 'source /tmp/redshift_etl/venv/bin/activate && cd /arthur-redshift-etl && ./bin/upload_env.sh'
+            /bin/bash -c \
+                'source /tmp/redshift_etl/venv/bin/activate && \
+                cd /arthur-redshift-etl && \
+                ./bin/upload_env.sh -y'
         ;;
     validate)
         set -o xtrace
@@ -167,7 +171,9 @@ case "$action" in
             --env ARTHUR_DEFAULT_PREFIX="$target_env" \
             $profile_arg \
             "arthur:$tag" \
-            /bin/bash -c 'source /tmp/redshift_etl/venv/bin/activate && install_validation_pipeline.sh'
+            /bin/bash -c \
+                'source /tmp/redshift_etl/venv/bin/activate \
+                && install_validation_pipeline.sh'
         ;;
     *)
         echo "Internal Error: unknown action '$action'!" >&2

--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -13,18 +13,59 @@ set -o errexit
 USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
-if [[ $# -gt 2 || "$1" = "-h" ]]; then
-    cat <<EOF
+show_usage_and_exit () {
+    cat <<USAGE
 
-Usage: `basename $0` [[<bucket_name>] <target_env>]
+Usage: `basename $0` [-y] [[<bucket_name>] <target_env>]
 
 This creates a new distribution and uploads it into S3.
 The <target_env> defaults to "$DEFAULT_PREFIX".
 The <bucket_name> defaults to your object store setting.
-If the bucket name is not specified, variable DATA_WAREHOUSE_CONFIG must be set.
+If the bucket name is not specified, the variable DATA_WAREHOUSE_CONFIG must be set.
 
-EOF
-    exit 0
+You can specify "-y" to skip the confirmation question.
+
+USAGE
+
+    exit ${1-0}
+}
+
+ask_to_confirm () {
+    while true; do
+        read -r -p "$1 (y/[n]) " ANSWER
+        case "$ANSWER" in
+            y|Y)
+                echo "Proceeding"
+                break
+                ;;
+            *)
+                echo "Bailing out"
+                exit 0
+                ;;
+        esac
+    done
+}
+
+assume_yes="NO"
+while getopts ":hq" opt; do
+    case "$opt" in
+      h)
+        show_usage_and_exit
+        ;;
+      y)
+        assume_yes="YES"
+        ;;
+      \?)
+        echo "Invalid option: -$OPTARG" >&2
+        show_usage_and_exit 1
+      ;;
+    esac
+done
+shift $((OPTIND -1))
+
+if [[ $# -gt 2 ]]; then
+    echo "Too many arguments"
+    show_usage_and_exit 1
 fi
 
 if [[ $# -lt 2 && -z "$DATA_WAREHOUSE_CONFIG" ]]; then
@@ -46,22 +87,6 @@ else
 fi
 
 set -o nounset
-
-ask_to_confirm () {
-    while true; do
-        read -r -p "$1 (y/[n]) " ANSWER
-        case "$ANSWER" in
-            y|Y)
-                echo "Proceeding"
-                break
-                ;;
-            *)
-                echo "Bailing out"
-                exit 0
-                ;;
-        esac
-    done
-}
 
 DIR_NAME=`dirname $0`
 BIN_PATH=$(\cd "$DIR_NAME" && \pwd)
@@ -92,7 +117,9 @@ if ! aws s3 ls "s3://$PROJ_BUCKET/" > /dev/null; then
     exit 2
 fi
 
-if aws s3 ls "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/jars" > /dev/null; then
+if [[ "$assume_yes" = "YES" ]]; then
+    true
+elif aws s3 ls "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/jars" > /dev/null; then
     ask_to_confirm "Are you sure you want to overwrite 's3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT'?"
 else
     ask_to_confirm "Are you sure you want to create 's3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT'?"
@@ -126,6 +153,10 @@ if [[ -d "jars" ]]; then
 fi
 
 set +o xtrace
-echo
-echo "# You should *now* sync your data warehouse::"
-echo "arthur.py sync --deploy --prefix \"$PROJ_TARGET_ENVIRONMENT\""
+
+# If you're confident enough to use "-y", you should know already about next steps.
+if [[ "$assume_yes" != "YES" ]]; then
+    echo
+    echo "# You should *now* sync your data warehouse::"
+    echo "arthur.py sync --deploy --prefix \"$PROJ_TARGET_ENVIRONMENT\""
+fi


### PR DESCRIPTION
When using the Arthur deploy script, which uploads the ETL distribution file to S3, inside another script, it's helpful to avoid the prompt from the deploy script. So this PR adds a `-y` option (similar to yum's "--assume-yes"). Note that this is now the default when deploying Arthur ETL using the Docker image with `bin/deploy_arthur.sh`.