### PR TITLE
Use 8MB as max size for log files

### DIFF
--- a/python/etl/config/logging.json
+++ b/python/etl/config/logging.json
@@ -29,7 +29,7 @@
             "level": "DEBUG",
             "filename": "arthur.log",
             "mode": "a",
-            "maxBytes": 5000000,
+            "maxBytes": 8388608,
             "backupCount": 5,
             "filters": [ "insert_trace_key" ],
             "encoding": "UTF-8"


### PR DESCRIPTION
We have an increasing number of sources and transformations, which has led to an increasing size of our logfile. The consequence is that the logfile in production now gets rotated and our log is spread over two files, say `StdError.gz ` and `StdError@000000000000000-000000005308416.gz`. This PR increases the `maxBytes` setting from around 5MB to 8MB so that our log files won't get split up, which makes it easier to review an ELT run at once.

(Ideally, we move to structured logging and don't have to worry about lines that conceptionally belong together getting split. Alas that's for v2.)