### PR TITLE
Help with pgpass file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ echo \n\
 echo "Environment settings:"\n\
 arthur.py settings object_store.s3.* version' > /root/.bashrc
 
+# Create an empty .pgpass file to help with create_user and update_user commands.
+RUN echo '# Format to set password (used by create_user and update_user): *:5439:*:<user>:<password>' > /root/.pgpass \
+    && chmod go= /root/.pgpass
+
 # Whenever there is an ETL running, it offers progress information on port 8086.
 EXPOSE 8086
 

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -271,11 +271,12 @@ def initial_setup(config, with_user_creation=False, force=False, dry_run=False):
 def _create_or_update_user(user_name, group_name=None, add_user_schema=False, only_update=False, dry_run=False):
     """
     Add new user to cluster or update existing user.
+
     Either pick a group or accept the default group (from settings).
     If the group does not yet exist, then we create the user's group here.
 
-    If so advised, creates a schema for the user. (Making sure that the ETL user keeps read access via its group).
-    So this assumes that the connection string points to the ETL database, not 'dev'.
+    If so advised, creates a schema for the user, making sure that the ETL user keeps read access
+    via its group. So this assumes that the connection string points to the ETL database, not 'dev'.
     """
     config = etl.config.get_dw_config()
     # Find user in the list of pre-defined users or create new user instance with default settings


### PR DESCRIPTION
The use of `create_user` or `add_user` commands requires a `~/.pgpass` file (or whatever `$PGPASSFILE` points to). This can create some confusion and extra steps. So this PR makes first the error messages more information (and log lines also provide next steps)., then adds a default `.pgpass` file to show the expected format. Now the only exception message should be about a missing line, and that message is preceded by a line which can by added to `.pgpass` (along with a suitable and secure password!).