### PR TITLE
DOC-210 Spectrum retries via pgcode list

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -78,11 +78,11 @@ def get_config_int(name: str, default: Optional[int] = None) -> int:
         return int(value)
 
 
-def get_config_list(name: str) -> List:
+def get_config_list(name: str) -> List[int]:
     """
-        Lookup a configuration value that is a List.
+    Lookup a configuration value that is a List.
     """
-    return _mapped_config.get(name)
+    return list(map(int, get_config_value(name).split(",")))
 
 
 def set_config_value(name: str, value: str) -> None:

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -82,7 +82,7 @@ def get_config_list(name: str) -> List:
     """
         Lookup a configuration value that is a List.
     """
-    return []
+    return _mapped_config.get(name)
 
 
 def set_config_value(name: str, value: str) -> None:

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -77,6 +77,9 @@ def get_config_int(name: str, default: Optional[int] = None) -> int:
     else:
         return int(value)
 
+def get_config_list(name: str) -> List:
+    return []
+
 
 def set_config_value(name: str, value: str) -> None:
     """

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -74,15 +74,17 @@ def get_config_int(name: str, default: Optional[int] = None) -> int:
         value = get_config_value(name, str(default))
     if value is None:
         raise InvalidArgumentError("missing config for {}".format(name))
-    else:
-        return int(value)
+    return int(value)
 
 
 def get_config_list(name: str) -> List[int]:
     """
     Lookup a configuration value that is a List.
     """
-    return list(map(int, get_config_value(name).split(",")))
+    value = get_config_value(name)
+    if value is None:
+        raise InvalidArgumentError("missing config for {}".format(name))
+    return list(map(int, value.split(",")))
 
 
 def set_config_value(name: str, value: str) -> None:

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -77,7 +77,11 @@ def get_config_int(name: str, default: Optional[int] = None) -> int:
     else:
         return int(value)
 
+
 def get_config_list(name: str) -> List:
+    """
+        Lookup a configuration value that is a List.
+    """
     return []
 
 

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -6,7 +6,7 @@
         "extract_retries": 1,
         "copy_data_retries": 3,
         "insert_data_retries": 3,
-        "retriable_error_codes": [15001]
+        "retriable_error_codes": "8001,15001,15005"
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -5,7 +5,8 @@
         # retry the extract at most this many times. Zero disables retries.
         "extract_retries": 1,
         "copy_data_retries": 3,
-        "insert_data_retries": 3
+        "insert_data_retries": 3,
+        "retriable_error_codes": [1,2,3,4]
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -6,7 +6,7 @@
         "extract_retries": 1,
         "copy_data_retries": 3,
         "insert_data_retries": 3,
-        "retriable_error_codes": [1,2,3,4]
+        "retriable_error_codes": [15001]
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -155,8 +155,8 @@
                     "minimum": 0
                 },
                 "retriable_error_codes": {
-                    "description": "known spectrum pgcodes - safe to retry",
-                    "type": "array"
+                    "description": "Comma-separated list of pgcodes which can be safely retried",
+                    "type": "string"
                 }
             },
             "required": [ "extract_retries", "copy_data_retries" ],

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -153,6 +153,10 @@
                     "description": "If an INSERT command fails to load data with an error pointing to S3 fetch, retry the INSERT at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0
+                },
+                "retriable_error_codes": {
+                    "description": "known spectrum pgcodes - safe to retry",
+                    "type": "array"
                 }
             },
             "required": [ "extract_retries", "copy_data_retries" ],

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -346,10 +346,8 @@ def insert_from_query(
         try:
             etl.db.execute(conn, stmt)
         except psycopg2.InternalError as exc:
-            #if "S3 Query Exception" in exc.pgerror or "S3Query Exception" in exc.pgerror:
             if exc.pgcode in retriable_error_codes:
-                # If this error was caused by a table in S3 (see Redshift Spectrum) then we might be able to try again.
                 raise TransientETLError(exc) from exc
             else:
-                logger.warning("SQL Error is not S3 Query Exception, cannot retry: %s", exc.pgerror)
+                logger.warning("SQL Error Code is unexpected, cannot retry: %s", exc.pgcode)
                 raise

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -14,7 +14,7 @@ import psycopg2
 import psycopg2.extensions
 from psycopg2.extensions import connection  # only for type annotation
 
-from etl.config import get_config_list
+import etl.config
 import etl.db
 from etl.errors import ETLSystemError, TransientETLError
 from etl.names import TableName
@@ -328,7 +328,7 @@ def insert_from_query(
     """
     Load data into table in the data warehouse using the INSERT INTO command.
     """
-    retriable_error_codes = get_config_list("arthur_settings.retriable_error_codes")
+    retriable_error_codes = etl.config.get_config_list("arthur_settings.retriable_error_codes")
     stmt = """
         INSERT INTO {table} (
             {columns}

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -349,5 +349,5 @@ def insert_from_query(
             if exc.pgcode in retriable_error_codes:
                 raise TransientETLError(exc) from exc
             else:
-                logger.warning("SQL Error Code is unexpected, cannot retry: %s", exc.pgcode)
+                logger.warning("SQL Error Code is unexpected, cannot retry: pgcode=%d", exc.pgcode)
                 raise

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -349,5 +349,5 @@ def insert_from_query(
             if exc.pgcode in retriable_error_codes:
                 raise TransientETLError(exc) from exc
             else:
-                logger.warning("SQL Error Code is unexpected, cannot retry: pgcode=%d", exc.pgcode)
+                logger.warning("Unretriable SQL Error: pgcode=%d, pgerror=%s", exc.pgcode, exc.pgerror)
                 raise

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="redshift_etl",
-    version="1.24.0",
+    version="1.24.1",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
     license="MIT",


### PR DESCRIPTION
For [Spectrum scan errors](https://docs.aws.amazon.com/redshift/latest/dg/c-spectrum-troubleshooting.html#spectrum-troubleshooting-retries-exceeded) caused by too many small files, we setup Arthur to retry if the PGCODE is a known value.

Previously, we have used the the PGERROR name, which has proved to be unreliable.

NOTE: The current Spectrum Scan Error `PGCODE=15001` is not even listed in the official [AWS List of Known Load Errors](https://docs.aws.amazon.com/redshift/latest/dg/r_Load_Error_Reference.html). We need to identify more Spectrum/S3 timeout PGCODE errors and add them to the list.

Testing inside Docker container:
```
$ python3
>>> etl.config.load_config(['... add path to config file ...'])
>>> etl.config.get_config_list('arthur_settings.retriable_error_codes')
```

Closes #164