### PR TITLE
Stop using spot instances for rebuild

### DIFF
--- a/python/etl/templates/rebuild_pipeline.json
+++ b/python/etl/templates/rebuild_pipeline.json
@@ -58,10 +58,8 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
-            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
-            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [


### PR DESCRIPTION
We've had a couple issues with rebuilds stopping because the EMR cluster loses its spot instances before extraction is done.

This PR (temporarily) reverts using spot instances for rebuilds until we can switch to using a spot fleet.