### PR TITLE
Make window for cluster maintenance a parameter

### DIFF
--- a/cloudformation/dw_admin.yaml
+++ b/cloudformation/dw_admin.yaml
@@ -1,4 +1,4 @@
-Description: |
+Description: |-
     Create the admin role for users and add permission to assume this role to the given group.
 
 AWSTemplateFormatVersion: '2010-09-09'

--- a/cloudformation/dw_cluster.yaml
+++ b/cloudformation/dw_cluster.yaml
@@ -1,4 +1,4 @@
-Description: |
+Description: |-
     Create a Redshift cluster with its subnet group and parameter group.
 
 AWSTemplateFormatVersion: '2010-09-09'
@@ -74,6 +74,10 @@ Parameters:
         Type: String
         Default: ""
 
+    PreferredMaintenanceWindow:
+        Description: (optional) Preferred maintenance window for the Redshift cluster
+        Type: String
+        Default: "sun:18:30-sun:19:00"
 
 Conditions:
 
@@ -172,7 +176,7 @@ Resources:
             PubliclyAccessible:
                 true
             PreferredMaintenanceWindow:
-                "sun:18:30-sun:19:00"
+                !Ref PreferredMaintenanceWindow
             VpcSecurityGroupIds:
                 - Fn::ImportValue: !Sub "${VpcStackName}::redshift-public-sg"
             SnapshotIdentifier:


### PR DESCRIPTION
We've noticed that ETLs that follow a reset during maintenance take longer to complete. We assume that's a "cold start" effect. We'd like to move the maintenance window to Saturdays so that the ETL which will run longer after maintenance runs on Sunday morning when no business stakeholders are waiting for their data to arrive.
This PR makes the preferred maintenance window a parameter to the CloudFormation template so that it's easier to change the value as well as see what's currently set.