### PR TITLE
Support external schemas

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -18,6 +18,7 @@ _arthur_completion()
                 bootstrap_sources
                 bootstrap_transformations
                 check_constraints
+                create_external_schemas
                 create_groups
                 create_index
                 create_schemas

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -48,6 +48,7 @@
             "pattern": "^(([a-zA-Z0-9._$-]+/?)|(\\${[.\\w]+})/?)+$"
         },
         "upstream_database": {
+            "description": "Description of an upstream database with access, tables and permissions for the copy",
             "type": "object",
             "properties": {
                 "name": { "$ref": "#/definitions/identifier" },
@@ -62,6 +63,7 @@
             "additionalProperties": false
         },
         "upstream_static": {
+            "description": "Description of an upstream source consisting of files in S3, may also be an unload target",
             "type": "object",
             "properties": {
                 "name": { "$ref": "#/definitions/identifier" },
@@ -84,12 +86,17 @@
             "additionalProperties": false
         },
         "upstream_external": {
+            "description": "Description of an external schema in AWS Redshift (listed in an AWS Glue Data Catalog)",
             "type": "object",
             "properties": {
                 "name": { "$ref": "#/definitions/identifier" },
                 "description": { "type": "string" },
-                "external": { "enum": [ true ] }
+                "external": { "enum": [ true ] },
+                "groups": { "$ref": "#/definitions/identifier_list" },
+                "database": { "$ref": "#/definitions/identifier" },
+                "iam_role": { "$ref": "#/definitions/aws_arn" }
             },
+            "required": [ "name", "external" ],
             "additionalProperties": false
         },
         "s3_data_format": {
@@ -275,34 +282,39 @@
             "description": "Location and attributes for shared storage, e.g. for unloads",
             "type": "object",
             "properties": {
+                "iam_role": {
+                    "description": "DEPRECATED Use the more specific IAM role for S3",
+                    "$ref": "#/definitions/aws_arn"
+                },
                 "s3": {
                     "type": "object",
                     "properties": {
-                        "bucket_name": { "$ref": "#/definitions/identifier" }
+                        "bucket_name": { "$ref": "#/definitions/identifier" },
+                        "iam_role": { "$ref": "#/definitions/aws_arn" }
                     },
                     "required": [ "bucket_name" ],
                     "additionalProperties": false
-                },
-                "iam_role": { "$ref": "#/definitions/aws_arn" }
+                }
             },
-            "required": [ "s3", "iam_role" ],
+            "required": [ "s3" ],
             "additionalProperties": false
         },
         "object_store": {
-            "description": "Location and attributes for (temporary) storage",
+            "description": "Location and attributes for (temporary) storage for code and extracted data",
             "type": "object",
             "properties": {
+                "iam_role": { "$ref": "#/definitions/aws_arn" },
                 "s3": {
                     "type": "object",
                     "properties": {
-                        "bucket_name": { "$ref": "#/definitions/identifier" }
+                        "bucket_name": { "$ref": "#/definitions/identifier" },
+                        "iam_role": { "$ref": "#/definitions/aws_arn" }
                     },
                     "required": [ "bucket_name" ],
                     "additionalProperties": false
-                },
-                "iam_role": { "$ref": "#/definitions/aws_arn" }
+                }
             },
-            "required": [ "s3", "iam_role" ],
+            "required": [ "s3" ],
             "additionalProperties": false
         },
         "resources": {

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -272,7 +272,7 @@ class LoadableRelation:
 
             target = relation.target_table_name
             source = {"bucket_name": relation.bucket_name}
-            if relation.is_view_relation or relation.is_ctas_relation:
+            if relation.is_transformation:
                 source["object_key"] = relation.sql_file_name
             else:
                 source["object_key"] = relation.manifest_file_name
@@ -1445,7 +1445,7 @@ def show_downstream_dependents(
     width_dep = max(len(identifier) for identifier in current_level)
     line_template = (
         "{relation.identifier:{width}s}"
-        " # kind={relation.kind} index={index:4d} level={level:3d}"
+        " # {relation.source_type} index={index:4d} level={level:3d}"
         " flag={flag:9s}"
         " is_required={relation.is_required}"
     )
@@ -1502,7 +1502,7 @@ def show_upstream_dependencies(relations: Sequence[RelationDescription], selecto
 
     max_len = max(len(identifier) for identifier in dependencies)
     line_template = (
-        "{relation.identifier:{width}s} # kind={relation.kind} index={index:4d}"
+        "{relation.identifier:{width}s} # {relation.source_type} index={index:4d}"
         " is_required={relation.is_required}"
     )
     for i, relation in enumerate(execution_order):

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -126,9 +126,10 @@ class TableName:
         """List external schemas that are not managed by us and may not exist during validation."""
         if self._external_schemas is None:
             try:
-                self._external_schemas = frozenset(etl.config.get_dw_config().external_schema_names)
+                schemas = etl.config.get_dw_config().external_schemas
             except AttributeError:
                 raise ETLSystemError("dw_config has not been set!")
+            self._external_schemas = frozenset(schema.name for schema in schemas)
         return self._external_schemas
 
     def to_tuple(self):


### PR DESCRIPTION
# Changes
* Allow to specify "database" for external schemas
* Allow to specify "groups" for external schemas so that permissions can be set
* Allow to specify IAM role for external schemas

These changes enable us to move the following code into the Arthur ETL code:
```
DROP SCHEMA IF EXISTS external_schema
;
CREATE EXTERNAL SCHEMA IF NOT EXISTS external_schema
FROM DATA CATALOG
DATABASE 'some_database'
IAM_ROLE 'arn:aws:iam::123456789:role/redshift-spectrum-acccess-to-aws-glue'
;
GRANT USAGE ON SCHEMA external_schema TO GROUP etl
;
```
provided there's a configuration for the external schema like this:
```
    {
        "name": "external_schema",
        "external": true,
        "database": "some_database",
        "iam_role": "arn:aws:iam::123456789:role/redshift-spectrum-acccess-to-aws-glue",
        "groups": ["etl"]
    }
```

This PR enables the changes in the schema file and adds the `create_external_schemas` command.

# Testing

Add the additional fields to an existing schema. Here's an example that you can use in a `sources` item:
```yaml
        {
            "name": "external__example",
            "description": "Database in Glue Catalog for event data from Braze Currents",
            "external": true,
            "database": "gcdb__examples__dev",
            "iam_role": "arn:aws:iam::123456789123:role/redshift-spectrum-glue-dev",
            "groups": ["etl_ro"]
        },
```

Then run:
```shell
arthur.py create_external_schemas external__example --dry-run --verbose
```

Then you will find this in the output:
```text
2021-07-13 06:20:41 - INFO - Dry-run: Skipping creating external schema 'external__example'
2021-07-13 06:20:41 - DEBUG - Skipped QUERY:
DROP SCHEMA IF EXISTS "external__example"
;
2021-07-13 06:20:41 - DEBUG - Skipped QUERY:
-- arthur.ddl: external__example
CREATE EXTERNAL SCHEMA IF NOT EXISTS "external__example"
FROM DATA CATALOG
DATABASE 'gcdb__examples__dev'
IAM_ROLE 'arn:aws:iam::123456789123:role/redshift-spectrum-glue-dev'
;
2021-07-13 06:20:41 - INFO - Dry-run: Skipping granting access for 'external__example' to 'etl_ro'
```