### PR TITLE
Cast pgcode to str, not int

### DIFF
--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -155,7 +155,7 @@
                     "minimum": 0
                 },
                 "retriable_error_codes": {
-                    "description": "Comma-separated list of pgcodes which can be safely retried",
+                    "description": "Comma-separated list of pgcode values which can be safely retried",
                     "type": "string"
                 }
             },

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -349,5 +349,5 @@ def insert_from_query(
             if exc.pgcode in retriable_error_codes:
                 raise TransientETLError(exc) from exc
             else:
-                logger.warning("Unretriable SQL Error: pgcode=%d, pgerror=%s", exc.pgcode, exc.pgerror)
+                logger.warning("Unretriable SQL Error: pgcode=%s, pgerror=%s", exc.pgcode, exc.pgerror)
                 raise


### PR DESCRIPTION
Small bugfix: we cast `pgcode` to an int inside a log message but `pgcode` can be any numeric-looking string, like "XX000", "15000", "80XX",  etc.

```
Message: 'Unretriable SQL Error: pgcode=%d, pgerror=%s'
Arguments: ('XX000', 'ERROR:  AwsClientException: Table [some external table in AWS Glue] not found.\n')
```