### PR TITLE
Add command 'delete_finished_pipelines'

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -300,6 +300,7 @@ def build_full_parser(prog_name):
         ShowValueCommand,
         ShowVarsCommand,
         ShowPipelinesCommand,
+        DeleteFinishedPipelinesCommand,
         QueryEventsCommand,
         SummarizeEventsCommand,
         TailEventsCommand,
@@ -1268,10 +1269,26 @@ class ShowPipelinesCommand(SubCommand):
         )
 
     def add_arguments(self, parser):
-        parser.add_argument("selection", help="pick pipelines to show", nargs="*")
+        parser.add_argument("selection", help="pick pipelines to show more details for", nargs="*")
 
     def callback(self, args, config):
         etl.pipeline.show_pipelines(args.selection)
+
+
+class DeleteFinishedPipelinesCommand(SubCommand):
+    def __init__(self):
+        super().__init__(
+            "delete_finished_pipelines",
+            "delete pipelines that finished yesterday or before",
+            "Delete pipelines if they are finished and they finished more than 24 hours ago.",
+        )
+
+    def add_arguments(self, parser):
+        add_standard_arguments(parser, ["dry-run"])
+        parser.add_argument("selection", help="pick specific pipelines", nargs="*")
+
+    def callback(self, args, config):
+        etl.pipeline.delete_finished_pipelines(args.selection, dry_run=args.dry_run)
 
 
 class QueryEventsCommand(SubCommand):

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -20,7 +20,6 @@ from etl.errors import ETLSystemError, TransientETLError
 from etl.names import TableName
 from etl.text import join_column_list
 
-
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 

--- a/python/etl/s3.py
+++ b/python/etl/s3.py
@@ -222,6 +222,7 @@ def test_object_creation(bucket_name: str, prefix: str) -> None:
 
 if __name__ == "__main__":
     import sys
+
     import etl.config
 
     if len(sys.argv) != 3:


### PR DESCRIPTION
This PR adds the `delete_finished_pipelines` command so that we can reap finished pipelines that we no longer need or should pay for.

The code here was formatted with a max line length of 100.