### PR TITLE
Move .bashrc into etc/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,14 +43,8 @@ RUN source /tmp/redshift_etl/venv/bin/activate && \
     python3 setup.py develop && \
     run_tests.py
 
-# Ensure the venv is activated when running interactive shells
-RUN echo $'source /tmp/redshift_etl/venv/bin/activate\n\
-source /arthur-redshift-etl/etc/arthur_completion.sh\n\
-PATH=$PATH:/tmp/redshift_etl/bin\n\
-cat /arthur-redshift-etl/etc/motd\n\
-echo \n\
-echo "Environment settings:"\n\
-arthur.py settings object_store.s3.* version' > /root/.bashrc
+# The .bashrc will ensure the venv is activated when running interactive shells.
+RUN cat /arthur-redshift-etl/etc/default.bashrc > /root/.bashrc
 
 # Create an empty .pgpass file to help with create_user and update_user commands.
 RUN echo '# Format to set password (used by create_user and update_user): *:5439:*:<user>:<password>' > /root/.pgpass \

--- a/etc/default.bashrc
+++ b/etc/default.bashrc
@@ -1,0 +1,17 @@
+# This is the default .bashrc file inside a container.
+
+PS1='(aws:$AWS_PROFILE, prefix=$ARTHUR_DEFAULT_PREFIX) \$ '
+
+source /tmp/redshift_etl/venv/bin/activate
+PATH=$PATH:/tmp/redshift_etl/bin
+
+# Useful when developing Arthur
+alias develop="( \cd /arthur-redshift-etl && python setup.py develop )"
+
+source /arthur-redshift-etl/etc/arthur_completion.sh
+
+# TODO(tom): This should be in a .bash_profile?
+cat /arthur-redshift-etl/etc/motd
+echo -e "\nEnvironment settings:\n"
+arthur.py settings object_store.s3.* version
+echo


### PR DESCRIPTION
The motivation here is to have the command line prompt to show the "prefix" (which is usually the user's name or the environment, such as `tom` or `production`) -- reduces second guessing whether you're in the right environment.

This PR also adds an alias `develop` to make developing inside the Docker container easier when one is working on scripts or the like and a `python setup.py develop` in the correct directory is required.

Since there continues to be stuff added to the `.bashrc` file, this is now broken out of the `Dockerfile` into the `etc` directory.

Example:
```
bin/run_arthur.sh
...
(venv) (aws:data-dev, prefix=tom) # 
```