### PR TITLE
Update VPC and CopyRole to allow unloading to any bucket

### DIFF
--- a/cloudformation/dw_vpc.yaml
+++ b/cloudformation/dw_vpc.yaml
@@ -240,7 +240,7 @@ Resources:
                             "s3:PutObject*"
                         ],
                         "Resource": [
-                            !Sub "arn:aws:s3:${AWS::Region}:${AWS::AccountId}:*"
+                            !Sub "arn:aws:s3::${AWS::AccountId}:*"
                         ]
                     }
                 ]
@@ -836,9 +836,7 @@ Resources:
                                 - "s3:DeleteObject"
                                 - "s3:PutObject"
                             Resource:
-                                - !Sub "arn:aws:s3:::${ObjectStore}/*"
-                                - !Sub "arn:aws:s3:::${DataLake}/*"
-                                - !If [ "ValidNotEmptySecondaryDataLake",  !Sub "arn:aws:s3:::${SecondaryDataLake}/*",  !Ref "AWS::NoValue" ]
+                                - !Sub "arn:aws:s3:::*"
                           - Sid: "EventAccess"
                             Effect: "Allow"
                             Action:

--- a/cloudformation/dw_vpc.yaml
+++ b/cloudformation/dw_vpc.yaml
@@ -232,16 +232,14 @@ Resources:
                         "Resource": "*"
                     },
                     {
-                        "Sid": "WriteIntoAccountOnly",
+                        "Sid": "WriteOnlyWIP",
                         "Effect": "Allow",
                         "Principal": "*",
                         "Action": [
                             "s3:DeleteObject*",
                             "s3:PutObject*"
                         ],
-                        "Resource": [
-                            !Sub "arn:aws:s3:::*"
-                        ]
+                        "Resource": "*"
                     }
                 ]
             }
@@ -794,8 +792,7 @@ Resources:
                             Action:
                                 - "s3:DeleteObject"
                                 - "s3:PutObject"
-                            Resource:
-                                - !Sub "arn:aws:s3:::*"
+                            Resource: "arn:aws:s3:::*/*"
                           - Sid: "EventAccess"
                             Effect: "Allow"
                             Action:
@@ -833,8 +830,7 @@ Resources:
                             Action:
                                 - "s3:DeleteObject"
                                 - "s3:PutObject"
-                            Resource:
-                                - !Sub "arn:aws:s3:::*"
+                            Resource: "arn:aws:s3:::*/*"
                           - Sid: "EventAccess"
                             Effect: "Allow"
                             Action:

--- a/cloudformation/dw_vpc.yaml
+++ b/cloudformation/dw_vpc.yaml
@@ -240,7 +240,7 @@ Resources:
                             "s3:PutObject*"
                         ],
                         "Resource": [
-                            !Sub "arn:aws:s3::${AWS::AccountId}:*"
+                            !Sub "arn:aws:s3:::*"
                         ]
                     }
                 ]
@@ -795,9 +795,7 @@ Resources:
                                 - "s3:DeleteObject"
                                 - "s3:PutObject"
                             Resource:
-                                - !Sub "arn:aws:s3:::${ObjectStore}/*"
-                                - !Sub "arn:aws:s3:::${DataLake}/*"
-                                - !If [ "ValidNotEmptySecondaryDataLake",  !Sub "arn:aws:s3:::${SecondaryDataLake}/*", !Ref "AWS::NoValue" ]
+                                - !Sub "arn:aws:s3:::*"
                           - Sid: "EventAccess"
                             Effect: "Allow"
                             Action:

--- a/cloudformation/dw_vpc.yaml
+++ b/cloudformation/dw_vpc.yaml
@@ -232,7 +232,7 @@ Resources:
                         "Resource": "*"
                     },
                     {
-                        "Sid": "WriteSelective",
+                        "Sid": "WriteIntoAccountOnly",
                         "Effect": "Allow",
                         "Principal": "*",
                         "Action": [
@@ -240,9 +240,7 @@ Resources:
                             "s3:PutObject*"
                         ],
                         "Resource": [
-                            !Sub "arn:aws:s3:::${ObjectStore}/*" ,
-                            !Sub "arn:aws:s3:::${DataLake}/*" ,
-                            !If [ "ValidNotEmptySecondaryDataLake",  !Sub "arn:aws:s3:::${SecondaryDataLake}/*", !Ref "AWS::NoValue" ]
+                            !Sub "arn:aws:s3:${AWS::Region}:${AWS::AccountId}:*"
                         ]
                     }
                 ]


### PR DESCRIPTION
- Like it says on the tin.

Why: we're unloading to a new bucket in development. We don't want to catalog all the allowed buckets.

Consequences: The cluster (using CopyRole) will be able to unload warehouse data to any bucket in S3, including public buckets that permits writes.