### PR TITLE
Better copy for copy errors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,8 +5,9 @@ name: Lint Python code
 on:
   push:
     paths:
-    - "python"
     - ".github/workflows/lint.yaml"
+    - "python/**"
+    - "setup.py"
 
 jobs:
   lint:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -5,8 +5,9 @@ name: Unit Tests
 on:
   push:
     paths:
-    - "python"
     - ".github/workflows/unittest.yaml"
+    - "python/**"
+    - "setup.py"
 
 jobs:
   unittest:

--- a/python/etl/design/redshift.py
+++ b/python/etl/design/redshift.py
@@ -29,9 +29,13 @@ def build_column_description(column: Dict[str, str], skip_identity=False, skip_r
     Return the description of a table column suitable for a table creation.
     See build_columns.
 
-    >>> build_column_description({"name": "key", "sql_type": "int", "not_null": True, "encoding": "raw"})
+    >>> build_column_description(
+    ...     {"name": "key", "sql_type": "int", "not_null": True, "encoding": "raw"}
+    ... )
     '"key" int ENCODE raw NOT NULL'
-    >>> build_column_description({"name": "my_key", "sql_type": "int", "references": ["sch.ble", ["key"]]})
+    >>> build_column_description(
+    ...     {"name": "my_key", "sql_type": "int", "references": ["sch.ble", ["key"]]}
+    ... )
     '"my_key" int REFERENCES "sch"."ble" ( "key" )'
     """
     column_ddl = '"{name}" {sql_type}'.format(**column)
@@ -70,11 +74,13 @@ def build_columns(columns: List[dict], is_temp=False) -> List[str]:
 
 def build_table_constraints(table_design: dict) -> List[str]:
     """
-    Return the constraints from the table design so that they can be inserted into a SQL DDL statement.
+    Return the constraints from the table design, ready to be inserted into a SQL DDL statement.
 
     >>> build_table_constraints({})  # no-op
     []
-    >>> build_table_constraints({"constraints": [{"primary_key": ["id"]}, {"unique": ["name", "email"]}]})
+    >>> build_table_constraints(
+    ...     {"constraints": [{"primary_key": ["id"]}, {"unique": ["name", "email"]}]}
+    ... )
     ['PRIMARY KEY ( "id" )', 'UNIQUE ( "name", "email" )']
     """
     table_constraints = table_design.get("constraints", [])
@@ -95,7 +101,7 @@ def build_table_constraints(table_design: dict) -> List[str]:
 
 def build_table_attributes(table_design: dict) -> List[str]:
     """
-    Return the attributes from the table design so that they can be inserted into a SQL DDL statement.
+    Return the attributes from the table design, ready to be inserted into a SQL DDL statement.
 
     >>> build_table_attributes({})  # no-op
     []
@@ -339,10 +345,10 @@ def insert_from_query(
     """
     retriable_error_codes = etl.config.get_config_list("arthur_settings.retriable_error_codes")
     stmt = """
-        INSERT INTO {table} (
-            {columns}
-        )
-        {query}
+INSERT INTO {table} (
+    {columns}
+)
+{query}
         """.format(
         table=table_name, columns=join_column_list(column_list), query=query_stmt
     )

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,24 @@
 from setuptools import find_packages, setup
 
+ARTHUR_VERSION = "1.27.1"
+
 
 setup(
-    name="redshift_etl",
-    version="1.27.0",
     author="Harry's Data Engineering and Analytics Engineering",
     description="ETL code to ferry data from PostgreSQL databases or S3 files to Redshift clusters",
-    license="MIT",
-    keywords="redshift postgresql ETL ELT extract transform load",
-    url="https://github.com/harrystech/arthur-redshift-etl",
-    package_dir={"": "python"},
-    packages=find_packages("python"),
-    package_data={
-        "etl": [
-            "assets/*",
-            "config/*",
-            "templates/*",
+    entry_points={
+        "console_scripts": [
+            # NB The script must end in ".py" so that spark submit accepts it as a Python script.
+            "arthur.py = etl.commands:run_arg_as_command",
+            "run_tests.py = etl.selftest:run_tests",
         ]
     },
+    keywords="redshift postgresql ETL ELT extract transform load",
+    license="MIT",
+    name="redshift_etl",
+    package_dir={"": "python"},
+    packages=find_packages("python"),
+    package_data={"etl": ["assets/*", "config/*", "templates/*"]},
     scripts=[
         "python/scripts/compare_events.py",
         "python/scripts/install_extraction_pipeline.sh",
@@ -33,11 +34,6 @@ setup(
         "python/scripts/submit_arthur.sh",
         "python/scripts/terminate_emr_cluster.sh",
     ],
-    entry_points={
-        "console_scripts": [
-            # NB The script must end in ".py" so that spark submit accepts it as a Python script.
-            "arthur.py = etl.commands:run_arg_as_command",
-            "run_tests.py = etl.selftest:run_tests",
-        ]
-    }
+    url="https://github.com/harrystech/arthur-redshift-etl",
+    version=ARTHUR_VERSION,
 )


### PR DESCRIPTION
Two changes here based on a production issue:
* Skip retries for `XX000` -- once Redshift has given up on a load (e.g. bad format in CSV)
* Always show `pgcode` and `pgerror` ahead of rows from `stl_load_errors`.