### PR TITLE
Have the validation pipeline create its own credentials

### DIFF
--- a/bin/create_validation_credentials
+++ b/bin/create_validation_credentials
@@ -1,0 +1,64 @@
+#! /bin/bash
+
+# Create a credentials file for the validation pipeline.
+
+set -o errexit -o nounset
+
+show_usage_and_exit() {
+  cat <<USAGE
+
+Usage: $(basename "$0") <bucket_name> <prefix>
+
+This will create an additional credentials file needed for the validation pipeline.
+By changing the target database from "database" to "validation_database", we can make sure that
+the validation pipeline runs on an empty and separate database.
+
+USAGE
+  exit "${1-0}"
+}
+
+case "${1-help}" in
+  -h|--help|help)
+    show_usage_and_exit
+    ;;
+esac
+
+if [[ $# -ne 2 ]]; then
+  echo 1>&2 "Wrong number of arguments."
+  show_usage_and_exit 1
+fi
+
+PROJ_BUCKET="$1"
+PROJ_ENVIRONMENT="$2"
+
+# Figure out the "safe" name that drops suspicious characters (replacing them with '_').
+SAFE_ENVIRONMENT="$(echo -n "$PROJ_ENVIRONMENT" | tr -cs '_a-zA-Z0-9' '_')"
+VALIDATION_DATABASE="validation_$SAFE_ENVIRONMENT"
+
+# Try first environment specific file, then general one.
+S3_SOURCE_CREDENTIALS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/config/credentials_$SAFE_ENVIRONMENT.sh"
+if ! aws s3 ls "$S3_SOURCE_CREDENTIALS" >/dev/null; then
+  S3_SOURCE_CREDENTIALS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/config/credentials.sh"
+  if ! aws s3 ls "$S3_SOURCE_CREDENTIALS" >/dev/null; then
+    echo "Check whether you have access to \"$S3_SOURCE_CREDENTIALS\"!"
+    exit 2
+  fi
+fi
+S3_TARGET_CREDENTIALS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/validation/config/credentials_validation.sh"
+
+echo "Using as source: $S3_SOURCE_CREDENTIALS"
+echo "Using as target: $S3_TARGET_CREDENTIALS"
+
+TMP_SOURCE_FILE="$(mktemp)"
+TMP_TARGET_FILE="$(mktemp)"
+# shellcheck disable=SC2064
+trap "rm -f \"$TMP_SOURCE_FILE\" \"$TMP_TARGET_FILE\"" EXIT
+set -o xtrace
+
+# Step 1: Download credentials
+aws s3 cp "$S3_SOURCE_CREDENTIALS" "$TMP_SOURCE_FILE"
+# Step 2: ???
+sed -ne "/^DATA_WAREHOUSE_ETL=/s,:5439/\([a-zA-Z0-9_]*\),:5439/$VALIDATION_DATABASE,p" \
+  <"$TMP_SOURCE_FILE" >"$TMP_TARGET_FILE"
+# Step 3: Profit
+aws s3 cp "$TMP_TARGET_FILE" "$S3_TARGET_CREDENTIALS"

--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -138,9 +138,9 @@ do
     aws s3 cp "$FILE" "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/jars/"
 done
 
-aws s3 sync --delete \
-    --exclude '*' --include bootstrap.sh --include send_health_check.sh --include sync_env.sh \
-    bin "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/bin"
+aws s3 sync --delete --exclude '*' \
+    --include bootstrap.sh --include create_validation_credentials --include send_health_check.sh --include sync_env.sh \
+    ./bin "s3://$PROJ_BUCKET/$PROJ_TARGET_ENVIRONMENT/bin"
 
 # Users who don't intend to use Spark may not have the jars directory.
 if [[ -d "jars" ]]; then

--- a/python/etl/templates/validation_pipeline.json
+++ b/python/etl/templates/validation_pipeline.json
@@ -83,23 +83,31 @@
             "name": "Copy Startup Scripts (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp --recursive --exclude '*' --include 'bootstrap.sh' --include 'sync_env.sh' s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin /tmp"
+            "command": "/usr/bin/aws s3 cp --recursive --exclude '*' --include 'bootstrap.sh' --include 'create_validation_credentials' --include 'sync_env.sh' s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin /tmp"
         },
         {
             "id": "SyncEnvironment",
             "name": "Sync environments (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "bash /tmp/sync_env.sh -y ${object_store.s3.bucket_name} ${object_store.s3.prefix} ${object_store.s3.prefix}/validation",
+            "command": "/bin/bash /tmp/sync_env.sh -y ${object_store.s3.bucket_name} ${object_store.s3.prefix} ${object_store.s3.prefix}/validation",
             "dependsOn": { "ref": "CopyStartupScripts" }
+        },
+        {
+            "id": "CreateValidationCredentials",
+            "name": "Create validation credentials (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "/bin/bash /tmp/create_validation_credentials ${object_store.s3.bucket_name} ${object_store.s3.prefix}",
+            "dependsOn": { "ref": "SyncEnvironment" }
         },
         {
             "id": "Bootstrap",
             "name": "Bootstrap (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
-            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}/validation",
-            "dependsOn": { "ref": "SyncEnvironment" }
+            "command": "/bin/bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}/validation",
+            "dependsOn": { "ref": "CreateValidationCredentials" }
         },
         {
             "id": "ArthurValidateUpstream",


### PR DESCRIPTION
# Description
One hiccup for adoption is usually that there are some strange instructions around setting up validation credentials. This PR simplifies the process so that a user can start a validation pipeline as soon as they have setup their access in general.

## Testing
Remove your `credentials_validation.sh` and then try the new setup:
```
bin/build_arthur.sh
bin/deploy_arthur.sh
bin/deploy_with_arthur.sh
bin/run_validation.sh
```
