### PR TITLE
Treat JSON files like YAML files (4 spaces)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ indent_style = space
 tab_width = 4
 trim_trailing_whitespace = true
 
-[*.{yaml,yml}]
+[*.{json,yaml,yml}]
 indent_size = 4
 indent_style = space
 tab_width = 4


### PR DESCRIPTION
This repo (and its buddy, [arthur-tools](https://github.com/harrystech/arthur-tools)) uses configuration files in JSON and YAML format that are indented by 4 spaces because Python code is indented 4 spaces.