### PR TITLE
Add option to dump table designs into a single file

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
         black --config ./etc/pyproject.toml --check python/ setup.py
     - name: Lint with isort
       run: |-
-        isort --settings-path ./etc --check-only python/ setup.py
+        isort --settings-path ./etc --check-only --recursive python/ setup.py
     - name: Lint with flake8
       run: |-
         flake8 python setup.py

--- a/README.md
+++ b/README.md
@@ -351,14 +351,14 @@ pip3 install --requirement requirements-linters.txt
 
 ```bash
 black --config ./etc/pyproject.toml python/ setup.py
-isort --settings-path ./etc python/ setup.py
+isort --settings-path ./etc --recursive python/ setup.py
 ```
 
 #### Running linters locally
 
 ```bash
 black --config ./etc/pyproject.toml --check python/ setup.py
-isort --settings-path ./etc --check-only python/ setup.py
+isort --settings-path ./etc --check-only --recursive python/ setup.py
 flake8 python setup.py
 mypy python
 ```

--- a/python/etl/config/console.py
+++ b/python/etl/config/console.py
@@ -1,0 +1,20 @@
+import logging
+import time
+
+from termcolor import colored
+
+
+class ColorfulFormatter(logging.Formatter):
+    converter = time.gmtime
+
+    palette = {
+        logging.DEBUG: "blue",
+        logging.INFO: "white",
+        logging.WARNING: "cyan",
+        logging.ERROR: "red",
+        logging.CRITICAL: "magenta",
+    }
+
+    def format(self, record):
+        s = super().format(record)
+        return colored(s, color=self.palette.get(record.levelno))

--- a/python/etl/config/logging.json
+++ b/python/etl/config/logging.json
@@ -3,8 +3,9 @@
     "disable_existing_loggers": false,
     "formatters": {
         "console": {
-            "format": "%(asctime)s - %(levelname)s - %(message)s",
-            "datefmt": "%Y-%m-%d %H:%M:%S"
+            "class": "etl.config.console.ColorfulFormatter",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+            "format": "%(asctime)s - %(levelname)s - %(message)s"
         },
         "file": {
             "format": "%(asctime)s %(trace_key)s %(levelname)s %(name)s (%(threadName)s) [%(filename)s:%(lineno)d] %(message)s"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ pycodestyle==2.6.0
 PyYAML==5.3.1
 simplejson==3.17.2
 tabulate==0.8.7
+termcolor==1.1.0
 tqdm==4.48.2


### PR DESCRIPTION
To make processing of table designs easier, this PR enables to dump all or selected table designs into a single output. Patterns can be applied as usually.
```shell script
python3 -m etl.relation | tee designs.json
python3 -m etl.relation dw.* | tee dw_designs.json
```

Example use: Find all relations that are distributed to all nodes
```python
import json
designs = json.load(open("designs.json"))
on_all_nodes = [design["name"] for design in designs if design.get("attributes", {}).get("distribution") == "all"]
```

This PR also includes a fix for the `isort` commands, broken during a hasty upgrade from version 4 to version 5.