### PR TITLE
More fixes to deal with tighter rules from flake8

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -1,10 +1,10 @@
 """
+This module provides global access to settings.  Always treat them nicely and read-only.
+
 We use the term "config" files to refer to all files that may reside in the "config" directory:
 * "Settings" files (ending in '.yaml') which drive the data warehouse or resource settings
 * Environment files (with variables used in connections)
 * Other files (like release notes)
-
-This module provides global access to settings.  Always treat them nicely and read-only.
 """
 
 import datetime
@@ -139,7 +139,7 @@ def etl_tmp_dir(path: str) -> str:
 
 def configure_logging(full_format: bool = False, log_level: str = None) -> None:
     """
-    Setup logging to go to console and application log file.
+    Set up logging to go to console and application log file.
 
     If full_format is True, then use the terribly verbose format of
     the application log file also for the console.  And log at the DEBUG level.

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -134,10 +134,10 @@ class LoadableRelation:
         >>> fs = etl.file_sets.RelationFileSet(TableName("a", "b"), TableName("c", "b"), None)
         >>> relation = LoadableRelation(RelationDescription(fs), {}, skip_copy=True)
         >>> "As delimited identifier: {:s}, as string: {:x}".format(relation, relation)
-        'As delimited identifier: "c"."b", as string: \\'c.b\\''
+        'As delimited identifier: "c"."b", as string: \'c.b\''
         >>> relation_with_staging = LoadableRelation(RelationDescription(fs), {}, use_staging=True, skip_copy=True)
         >>> "As delimited identifier: {:s}, as string: {:x}".format(relation_with_staging, relation_with_staging)
-        'As delimited identifier: "etl_staging$c"."b", as string: \\'c.b\\' (in staging)'
+        'As delimited identifier: "etl_staging$c"."b", as string: \'c.b\' (in staging)'
         """
         if (not code) or (code == "s"):
             return str(self)

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -119,7 +119,7 @@ class LoadableRelation:
     __str__ = RelationDescription.__str__  # type: ignore
 
     def __format__(self, code):
-        """
+        r"""
         Format target table as delimited identifier (by default, or 's') or just as identifier (using 'x').
 
         Compared to RelationDescription, we have the additional complexity of dealing with

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -278,7 +278,7 @@ class TableName:
 
 
 class TempTableName(TableName):
-    """
+    r"""
     Class to deal with names of temporary relations.
 
     Note that temporary views or tables do not have a schema (*) and have a name starting with '#'.

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -290,7 +290,7 @@ class TempTableName(TableName):
     >>> temp.identifier
     '#hello'
     >>> "For SQL: {:s}, for logging: {:x}".format(temp, temp)
-    'For SQL: "#hello", for logging: \\'#hello\\''
+    'For SQL: "#hello", for logging: \'#hello\''
 
     Schema and name comparison in SQL continues to work if you use LIKE for schema names:
     >>> temp.schema

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -102,7 +102,7 @@ class RelationDescription:
         return "{}({}:{})".format(self.__class__.__name__, self.identifier, self.source_path_name)
 
     def __format__(self, code):
-        """
+        r"""
         Format target table as delimited identifier (by default, or 's') or just as identifier (using 'x').
 
         >>> fs = etl.file_sets.RelationFileSet(TableName("a", "b"), TableName("c", "b"), None)
@@ -211,7 +211,7 @@ class RelationDescription:
         return dw_config.schema_lookup(self.source_name)
 
     def data_directory(self, from_prefix=None):
-        """"Full path to data files (in the schema's data format)."""
+        """Full path to data files (in the schema's data format)."""
         # TODO(tom): Split between source data and static data
         # Either somewhere in S3 for static sources, in S3 for extracted sources or locally.
         return os.path.join(

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -108,7 +108,7 @@ class RelationDescription:
         >>> fs = etl.file_sets.RelationFileSet(TableName("a", "b"), TableName("c", "b"), None)
         >>> relation = RelationDescription(fs)
         >>> "As delimited identifier: {:s}, as loggable string: {:x}".format(relation, relation)
-        'As delimited identifier: "c"."b", as loggable string: \\'c.b\\''
+        'As delimited identifier: "c"."b", as loggable string: \'c.b\''
         """
         if (not code) or (code == "s"):
             return str(self.target_table_name)


### PR DESCRIPTION
Fixes all D300, D301 errors (using `r""""` when needed, removing extra quote from `""""`) and fixes most
violations in data_warehouse.py, config/__init__.py and config/dw.py