### PR TITLE
Remove Spot bid prices from refresh pipelines

### DIFF
--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -58,10 +58,8 @@
             "parent": { "ref": "ResourceParent" },
             "releaseLabel": "${resources.EMR.release_label}",
             "masterInstanceType": "${resources.EMR.master.instance_type}",
-            "masterInstanceBidPrice": "${resources.EMR.master.bid_price}",
             "coreInstanceType": "${resources.EMR.core.instance_type}",
             "coreInstanceCount": "${resources.EMR.core.instance_count}",
-            "coreInstanceBidPrice": "${resources.EMR.core.bid_price}",
             "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
             "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
             "additionalMasterSecurityGroupIds": [


### PR DESCRIPTION
This will stop using spot instances for refresh ETLs. We'll have to rethink use of Spot instances in terms of Spot Fleet.

We see an error happening where:
* Update and extract start at the same time.
* Update starts waiting.
* The EMR cluster fails to come up for more than an hour since instances of the particular type are not available.
* Update gives up waiting and errors out.
* Oddly enough the EMR cluster does finally start and so doesn't show up as "failed" in the data pipeline. It just takes too long.