### PR TITLE
Improve templates to get started quickly

### DIFF
--- a/bin/release_version.sh
+++ b/bin/release_version.sh
@@ -21,7 +21,7 @@ if ! type -a git >/dev/null 2>&1 ; then
     exit 1
 fi
 
-> "$TEMP_RELEASE_FILE"
+true > "$TEMP_RELEASE_FILE"
 trap "rm \"$TEMP_RELEASE_FILE\"" EXIT
 
 echo "toplevel=`git rev-parse --show-toplevel`" >> "$TEMP_RELEASE_FILE"
@@ -44,7 +44,7 @@ if git status --porcelain 2>/dev/null | egrep '^ M|^M' >/dev/null; then
     echo "warning=locally modified files exist" >> "$TEMP_RELEASE_FILE"
 fi
 
-if cmp "$TEMP_RELEASE_FILE" "$RELEASE_FILE" >/dev/null; then
+if cmp "$TEMP_RELEASE_FILE" "$RELEASE_FILE" >/dev/null 2>&1; then
     echo "Release information is unchanged."
 else
     echo "Updating release information in $RELEASE_FILE"

--- a/etc/.bash_history
+++ b/etc/.bash_history
@@ -1,1 +1,2 @@
+arthur.py settings
 arthur.py ping -q

--- a/etc/.bash_history
+++ b/etc/.bash_history
@@ -1,2 +1,5 @@
+arthur.py bootstrap_sources
+arthur.py sync --deploy
+arthur.py validate -nskq
 arthur.py settings
 arthur.py ping -q

--- a/etc/aws_template.yaml
+++ b/etc/aws_template.yaml
@@ -3,51 +3,51 @@
 #     DATA_WAREHOUSE_CONFIG="./etc" arthur.py settings
 {
     "object_store": {
-        "iam_role": "arn:aws:iam:REGION:11111111:ROLE",  # copy from the outputs of the VPC
+        "iam_role": "arn:aws:iam:REGION:11111111:ROLE", # Copy from Outputs of VPC stack: RedshiftCopyRole
         "s3": {
-            "bucket_name": "some-bucket"  # copy from the outputs of the VPC
+            "bucket_name": "object-store" # Copy from Outputs of VPC stack: ObjectStore
         }
     },
     "data_lake": {
-        "iam_role": "arn:aws:iam:REGION:11111111:ROLE",  # copy from the outputs of the VPC
+        "iam_role": "arn:aws:iam:REGION:11111111:ROLE", # Copy from Outputs of VPC stack: RedshiftCopyRole
         "s3": {
-            "bucket_name": "some-bucket"  # copy from the outputs of the VPC
+            "bucket_name": "data-lake"  # Copy from Outputs of VPC stack: DataLake
         }
     },
     "resources": {
-        "key_name": "dw-{env_type}-keypair.pem",  # copy from the outputs of the VPC
+        "key_name": "dw-env_type-keypair", # Env type is something like dev or prod.
         "VPC": {
-            "region": "copy from the outputs of the VPC",
-            "account": "copy from the outputs of the VPC",
-            "name": "env_type",  # argument to VPC creation, like 'dev' or 'prod'
-            "public_subnet": "copy from the outputs of the VPC",
-            "whitelist_security_group": "copy from the outputs of the VPC"
+            "region": "us-east-1", # Copy from Outputs of VPC stack: VpcRegion
+            "account": "123456789", # Copy from Outputs of VPC stack: Sorry, need to check any ARN to grab the account
+            "name": "dw-vpc-env_type", # Name of the stack
+            "public_subnet": "vpc-public_subnet", # Copy from Outputs of VPC stack: PublicSubnet
+            "whitelist_security_group": "vpc-security_group" # Copy from Outputs of VPC stack: WhitelistSecurityGroup
         },
         "EC2": {
-            "iam_instance_profile": "copy from the outputs of the VPC",
+            "iam_instance_profile": "instance-profile", # Copy from Outputs of VPC stack: EC2InstanceProfile
             "instance_type": "t2.small",
             "image_id": "ami-a4c7edb2",
-            "public_security_group": "copy from the outputs of the VPC"
+            "public_security_group": "security_group" # Copy from Outputs of VPC stack: PublicEC2SecurityGroups
         },
         "EMR": {
             "release_label": "emr-5.3.0",
             "master": {
                 "instance_type": "m4.2xlarge",
                 "instance_count": 1,
-                "managed_security_group": "copy from the outputs of the VPC"
+                "managed_security_group": "master_security_group" # Copy from Outputs of VPC stack: ManagedMasterSecurityGroup
                 },
             "core": {
                 "instance_type": "m4.4xlarge",
                 "instance_count": 4,
-                "managed_security_group": "copy from the outputs of the VPC"
+                "managed_security_group": "core_security_group" # Copy from Outputs of VPC stack: ManagedCoreSecurityGroup
             }
         },
         "DataPipeline": {
-            "role": "arn:aws:iam:REGION:11111111:ROLE"  # copy from the outputs of the VPC
+                "role": "dw-vpc-dev-DataPipelineRole-12345678"  # Copy from Outputs of VPC stack: DataPipelineRole
         },
         "RedshiftCluster": {
-            "max_concurrency": 2,  # make sure this suits the hardware allocation
-            "wlm_query_slots": 4  # make sure this works with the rest of the WLM settings
+            "max_concurrency": 2, # Make sure this suits the hardware allocation
+            "wlm_query_slots": 4  # Make sure this works with the rest of the WLM settings
         }
     }
 }

--- a/etc/warehouse_template.yaml
+++ b/etc/warehouse_template.yaml
@@ -1,0 +1,32 @@
+{
+    "data_warehouse": {
+        "transformations": [
+            {
+                "name": "common",
+                "description": "common views and tables such as numbers or days",
+                "groups": [ "etl_ro" ]
+            }
+        ]
+    },
+    "sources": [
+        {
+            "name": "webapp",
+            "description": "Main web application",
+            "read_access": "WEBAPP_PRODUCTION",
+            "include_tables": [
+                "public.orders",
+             ],
+             "exclude_tables": [
+                "public.migration_*"
+             ],
+             "readers": [ "etl_ro" ]
+        },
+        {
+            "name": "uploads",
+            "description": "Random uploads in S3",
+            "s3_bucket": "your-random-stuff-bucket",
+            "s3_path_template": "prefix",
+            "readers": [ "etl_ro" ]
+        }
+    ]
+}

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -36,14 +36,26 @@
     },
     # AWS resource configuration
     "resources": {
-        # Set a default value for spot instances that is high enough that engineers do not need
-        # to think about it for most use cases.
+        "VPC": {
+            "region": "us-east-1"
+        },
+        "EC2": {
+            "image_id": "ami-a4c7edb2",
+            "instance_type": "t2.small"
+        },
         "EMR": {
-            "core": {
-                "bid_price": 10.0
-            },
+            "release_label": "emr-5.3.0",
             "master": {
-                "bid_price": 10.0
+                "bid_price": 10.0,
+                "instance_type": "m4.2xlarge",
+                "instance_count": 1
+            },
+            "core": {
+                # Set a default value for spot instances that is high enough that engineers do not need
+                # to think about it for most use cases.
+                "bid_price": 10.0,
+                "instance_type": "m4.4xlarge",
+                "instance_count": 4
             },
             "max_partitions": 32
         }


### PR DESCRIPTION
This updates our AWS template and adds a new one to make it easier to get started with Arthur.

(Looking at this template, I realize that we could create `aws.yaml` using a script that inspects the CloudFormation Outputs.)