### PR TITLE
Allow read-only source directory

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -23,11 +23,11 @@ if [[ -r "/opt/local/redshift_etl/venv/bin/activate" ]]; then
 
     # Using "--quiet" here to reduce the startup noise for "end users."
     if [[ -d "/opt/src/arthur-redshift-etl/.git" ]]; then
-      (
-        set -o xtrace
-        cd /opt/src/arthur-redshift-etl
-        python3 setup.py --quiet develop
-      )
+        (
+          set -o xtrace
+          cd /opt/src/arthur-redshift-etl
+          python3 setup.py --quiet develop || echo "Warning: Failed to update image to latest source version" 2>&1
+        )
     fi
 fi
 


### PR DESCRIPTION
The entrypoint of the Docker image is vulnerable right now to the failing of `python setup.py develop`. Though that step is necessary when the source is mounted and users expect to image to reflect the state of the git repo, it's also preventing debugging any issues that might come up. So this version of the entrypoint allows a failure of `python setup.py develop` and gives just a warning instead of blocking the start.
See issue #237 