### PR TITLE
DENG-528: Upgrade Python Arthur

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 # N.B. Make sure to keep the Dockerfile and bootstrap script in sync wrt. packages.
 
-FROM amazonlinux:2017.03
+FROM amazonlinux:2018.03
 
 RUN yum install -y \
         aws-cli \
@@ -13,14 +13,10 @@ RUN yum install -y \
         jq \
         libyaml-devel \
         openssh-clients \
-        postgresql95-devel \
-        python35 \
-        python35-devel \
-        python35-pip \
         tmux \
         vim-minimal \
     && \
-    pip-3.5 install --upgrade --disable-pip-version-check virtualenv
+    python3 -m pip install --upgrade --disable-pip-version-check virtualenv
 
 # Run as non-priviledged user "arthur".
 RUN useradd --comment 'Arthur ETL' --user-group --create-home arthur && \
@@ -39,8 +35,8 @@ COPY --chown=arthur:arthur \
 COPY requirements*.txt /tmp/
 RUN virtualenv --python=python3 /opt/local/redshift_etl/venv && \
     source /opt/local/redshift_etl/venv/bin/activate && \
-    pip3 install --upgrade pip --disable-pip-version-check --no-cache-dir && \
-    pip3 install --requirement /tmp/requirements-dev.txt --disable-pip-version-check --no-cache-dir
+    python3 -m pip install --upgrade pip --disable-pip-version-check --no-cache-dir && \
+    python3 -m pip install --requirement /tmp/requirements-dev.txt --disable-pip-version-check --no-cache-dir
 
 # Create an empty .pgpass file to help with create_user and update_user commands.
 RUN echo '# Format to set password (used by create_user and update_user): *:5439:*:<user>:<password>' > /home/arthur/.pgpass \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,10 @@ RUN yum install -y \
         jq \
         libyaml-devel \
         openssh-clients \
-        postgresql95-devel \
-        python35 \
-        python35-devel \
-        python35-pip \
         tmux \
         vim-minimal \
     && \
-    pip-3.5 install --upgrade --disable-pip-version-check virtualenv
+    python3 -m pip install --upgrade --disable-pip-version-check virtualenv
 
 # Run as non-priviledged user "arthur".
 RUN useradd --comment 'Arthur ETL' --user-group --create-home arthur && \
@@ -39,8 +35,8 @@ COPY --chown=arthur:arthur \
 COPY requirements*.txt /tmp/
 RUN virtualenv --python=python3 /opt/local/redshift_etl/venv && \
     source /opt/local/redshift_etl/venv/bin/activate && \
-    pip3 install --upgrade pip --disable-pip-version-check --no-cache-dir && \
-    pip3 install --requirement /tmp/requirements-dev.txt --disable-pip-version-check --no-cache-dir
+    python3 -m pip install --upgrade pip --disable-pip-version-check --no-cache-dir && \
+    python3 -m pip install --requirement /tmp/requirements-dev.txt --disable-pip-version-check --no-cache-dir
 
 # Create an empty .pgpass file to help with create_user and update_user commands.
 RUN echo '# Format to set password (used by create_user and update_user): *:5439:*:<user>:<password>' > /home/arthur/.pgpass \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN yum install -y \
         libyaml-devel \
         openssh-clients \
         postgresql \
+        procps-ng \
         python3 \
         python3-devel \
         tmux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,19 @@
 #
 # N.B. Make sure to keep the Dockerfile and bootstrap script in sync wrt. packages.
 
-FROM amazonlinux:2018.03
+FROM amazonlinux:2.0.20201218.1
 
 RUN yum install -y \
-        aws-cli \
+        awscli \
         gcc \
         jq \
         libyaml-devel \
         openssh-clients \
+        postgresql \
+        python3 \
+        python3-devel \
         tmux \
-        vim-minimal \
-    && \
-    python3 -m pip install --upgrade --disable-pip-version-check virtualenv
+        vim-minimal
 
 # Run as non-priviledged user "arthur".
 RUN useradd --comment 'Arthur ETL' --user-group --create-home arthur && \
@@ -33,7 +34,7 @@ COPY --chown=arthur:arthur \
     /opt/local/redshift_etl/bin/
 
 COPY requirements*.txt /tmp/
-RUN virtualenv --python=python3 /opt/local/redshift_etl/venv && \
+RUN python3 -m venv /opt/local/redshift_etl/venv && \
     source /opt/local/redshift_etl/venv/bin/activate && \
     python3 -m pip install --upgrade pip --disable-pip-version-check --no-cache-dir && \
     python3 -m pip install --requirement /tmp/requirements-dev.txt --disable-pip-version-check --no-cache-dir

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,14 @@ RUN yum install -y \
         jq \
         libyaml-devel \
         openssh-clients \
+        postgresql95-devel \
+        python35 \
+        python35-devel \
+        python35-pip \
         tmux \
         vim-minimal \
     && \
-    python3 -m pip install --upgrade --disable-pip-version-check virtualenv
+    pip-3.5 install --upgrade --disable-pip-version-check virtualenv
 
 # Run as non-priviledged user "arthur".
 RUN useradd --comment 'Arthur ETL' --user-group --create-home arthur && \
@@ -35,8 +39,8 @@ COPY --chown=arthur:arthur \
 COPY requirements*.txt /tmp/
 RUN virtualenv --python=python3 /opt/local/redshift_etl/venv && \
     source /opt/local/redshift_etl/venv/bin/activate && \
-    python3 -m pip install --upgrade pip --disable-pip-version-check --no-cache-dir && \
-    python3 -m pip install --requirement /tmp/requirements-dev.txt --disable-pip-version-check --no-cache-dir
+    pip3 install --upgrade pip --disable-pip-version-check --no-cache-dir && \
+    pip3 install --requirement /tmp/requirements-dev.txt --disable-pip-version-check --no-cache-dir
 
 # Create an empty .pgpass file to help with create_user and update_user commands.
 RUN echo '# Format to set password (used by create_user and update_user): *:5439:*:<user>:<password>' > /home/arthur/.pgpass \

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -4,7 +4,7 @@
 # Make sure to keep this in sync with our Dockerfile.
 
 PROJ_NAME="redshift_etl"
-PROJ_PACKAGES="aws-cli gcc jq libyaml-devel postgresql95-devel python35 python35-devel python35-pip tmux"
+PROJ_PACKAGES="aws-cli gcc jq libyaml-devel tmux"
 
 PROJ_TEMP="/tmp/$PROJ_NAME"
 
@@ -45,7 +45,7 @@ set -o xtrace
 
 sudo yum install --assumeyes $PROJ_PACKAGES
 
-# Install virtualenv using pip since the python35-virtualenv packages are out of date.
+# Install virtualenv using pip
 sudo python3 -m pip install --upgrade --disable-pip-version-check virtualenv
 
 # Set creation mask to: u=rwx,g=rx,o=
@@ -73,8 +73,8 @@ set +o nounset
 source venv/bin/activate
 set -o nounset
 
-python -m pip install --upgrade pip --disable-pip-version-check
-python -m pip install --requirement ./jars/requirements.txt
+python3 -m pip install --upgrade pip --disable-pip-version-check
+python3 -m pip install --requirement ./jars/requirements.txt
 
 # This trick with sed transforms project-<dotted version>.tar.gz into project.<dotted_version>.tar.gz
 # so that the sort command can split correctly on '.' with the -t option.
@@ -85,7 +85,7 @@ LATEST_TAR_FILE=`
     sort -t. -n -r -k 3,3 -k 4,4 -k 5,5 |
     sed "s:${PROJ_NAME}\.:${PROJ_NAME}-:" |
     head -1`
-python -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
+python3 -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
 
 # Update instance tags
 TMP_DOCUMENT="$PROJ_TEMP/document"

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -4,7 +4,7 @@
 # Make sure to keep this in sync with our Dockerfile.
 
 PROJ_NAME="redshift_etl"
-PROJ_PACKAGES="aws-cli gcc jq libyaml-devel tmux"
+PROJ_PACKAGES="aws-cli gcc jq libyaml-devel postgresql95-devel python35 python35-devel python35-pip tmux"
 
 PROJ_TEMP="/tmp/$PROJ_NAME"
 
@@ -45,7 +45,7 @@ set -o xtrace
 
 sudo yum install --assumeyes $PROJ_PACKAGES
 
-# Install virtualenv using pip
+# Install virtualenv using pip since the python35-virtualenv packages are out of date.
 sudo python3 -m pip install --upgrade --disable-pip-version-check virtualenv
 
 # Set creation mask to: u=rwx,g=rx,o=
@@ -73,8 +73,8 @@ set +o nounset
 source venv/bin/activate
 set -o nounset
 
-python3 -m pip install --upgrade pip --disable-pip-version-check
-python3 -m pip install --requirement ./jars/requirements.txt
+python -m pip install --upgrade pip --disable-pip-version-check
+python -m pip install --requirement ./jars/requirements.txt
 
 # This trick with sed transforms project-<dotted version>.tar.gz into project.<dotted_version>.tar.gz
 # so that the sort command can split correctly on '.' with the -t option.
@@ -85,7 +85,7 @@ LATEST_TAR_FILE=`
     sort -t. -n -r -k 3,3 -k 4,4 -k 5,5 |
     sed "s:${PROJ_NAME}\.:${PROJ_NAME}-:" |
     head -1`
-python3 -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
+python -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
 
 # Update instance tags
 TMP_DOCUMENT="$PROJ_TEMP/document"

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -4,7 +4,7 @@
 # Make sure to keep this in sync with our Dockerfile.
 
 PROJ_NAME="redshift_etl"
-PROJ_PACKAGES="aws-cli gcc jq libyaml-devel postgresql95-devel python35 python35-devel python35-pip tmux"
+PROJ_PACKAGES="awscli gcc jq libyaml-devel postgresql python3 python3-devel tmux"
 
 PROJ_TEMP="/tmp/$PROJ_NAME"
 
@@ -45,9 +45,6 @@ set -o xtrace
 
 sudo yum install --assumeyes $PROJ_PACKAGES
 
-# Install virtualenv using pip since the python35-virtualenv packages are out of date.
-sudo python3 -m pip install --upgrade --disable-pip-version-check virtualenv
-
 # Set creation mask to: u=rwx,g=rx,o=
 umask 0027
 
@@ -66,15 +63,15 @@ chmod +x ./bin/*.sh
 log "Creating virtual environment in \"$PROJ_TEMP/venv\""
 test -x deactivate && deactivate || echo "Already outside virtual environment"
 
-virtualenv --python=python3 venv
+python3 -m venv venv
 
 # Work around this error: "_OLD_VIRTUAL_PATH: unbound variable"
 set +o nounset
 source venv/bin/activate
 set -o nounset
 
-python -m pip install --upgrade pip --disable-pip-version-check
-python -m pip install --requirement ./jars/requirements.txt
+python3 -m pip install --upgrade pip --disable-pip-version-check
+python3 -m pip install --requirement ./jars/requirements.txt
 
 # This trick with sed transforms project-<dotted version>.tar.gz into project.<dotted_version>.tar.gz
 # so that the sort command can split correctly on '.' with the -t option.
@@ -85,7 +82,7 @@ LATEST_TAR_FILE=`
     sort -t. -n -r -k 3,3 -k 4,4 -k 5,5 |
     sed "s:${PROJ_NAME}\.:${PROJ_NAME}-:" |
     head -1`
-python -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
+python3 -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
 
 # Update instance tags
 TMP_DOCUMENT="$PROJ_TEMP/document"

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -4,7 +4,7 @@
 # Make sure to keep this in sync with our Dockerfile.
 
 PROJ_NAME="redshift_etl"
-PROJ_PACKAGES="awscli gcc jq libyaml-devel postgresql python3 python3-devel tmux"
+PROJ_PACKAGES="awscli gcc jq libyaml-devel postgresql procps-ng python3 python3-devel tmux"
 
 PROJ_TEMP="/tmp/$PROJ_NAME"
 

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -46,7 +46,7 @@ set -o xtrace
 sudo yum install --assumeyes $PROJ_PACKAGES
 
 # Install virtualenv using pip since the python35-virtualenv packages are out of date.
-sudo pip-3.5 install --upgrade --disable-pip-version-check virtualenv
+sudo python3 -m pip install --upgrade --disable-pip-version-check virtualenv
 
 # Set creation mask to: u=rwx,g=rx,o=
 umask 0027
@@ -73,8 +73,8 @@ set +o nounset
 source venv/bin/activate
 set -o nounset
 
-pip3 install --upgrade pip --disable-pip-version-check
-pip3 install --requirement ./jars/requirements.txt
+python -m pip install --upgrade pip --disable-pip-version-check
+python -m pip install --requirement ./jars/requirements.txt
 
 # This trick with sed transforms project-<dotted version>.tar.gz into project.<dotted_version>.tar.gz
 # so that the sort command can split correctly on '.' with the -t option.
@@ -85,7 +85,7 @@ LATEST_TAR_FILE=`
     sort -t. -n -r -k 3,3 -k 4,4 -k 5,5 |
     sed "s:${PROJ_NAME}\.:${PROJ_NAME}-:" |
     head -1`
-pip3 install --upgrade "./jars/$LATEST_TAR_FILE"
+python -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
 
 # Update instance tags
 TMP_DOCUMENT="$PROJ_TEMP/document"

--- a/etc/aws_template.yaml
+++ b/etc/aws_template.yaml
@@ -26,11 +26,9 @@
         "EC2": {
             "iam_instance_profile": "instance-profile", # Copy from Outputs of VPC stack: EC2InstanceProfile
             "instance_type": "t2.small",
-            "image_id": "ami-01d7070812ee4de14",
             "public_security_group": "security_group" # Copy from Outputs of VPC stack: PublicEC2SecurityGroups
         },
         "EMR": {
-            "release_label": "emr-6.2.0",
             "master": {
                 "instance_type": "m4.2xlarge",
                 "instance_count": 1,

--- a/etc/aws_template.yaml
+++ b/etc/aws_template.yaml
@@ -26,11 +26,11 @@
         "EC2": {
             "iam_instance_profile": "instance-profile", # Copy from Outputs of VPC stack: EC2InstanceProfile
             "instance_type": "t2.small",
-            "image_id": "ami-a4c7edb2",
+            "image_id": "ami-01d7070812ee4de14",
             "public_security_group": "security_group" # Copy from Outputs of VPC stack: PublicEC2SecurityGroups
         },
         "EMR": {
-            "release_label": "emr-5.3.0",
+            "release_label": "emr-6.2.0",
             "master": {
                 "instance_type": "m4.2xlarge",
                 "instance_count": 1,

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -158,6 +158,7 @@ def configure_logging(full_format: bool = False, log_level: str = None) -> None:
     logger.info('Command line: "%s"', " ".join(sys.argv))
     logger.debug("Current working directory: '%s'", os.getcwd())
     logger.info(get_release_info())
+    logger.info(get_python_info())
 
 
 def load_environ_file(filename: str) -> None:
@@ -202,6 +203,13 @@ def load_settings_file(filename: str, settings: dict) -> None:
     with open(filename) as content:
         new_settings = yaml.safe_load(content)
     _deep_update(settings, new_settings)
+
+
+def get_python_info() -> str:
+    """Return minimal information about this Python version."""
+    return ("Running Python {version_info[0]}.{version_info[1]}.{version_info[2]} ({platform})").format(
+        version_info=sys.version_info, platform=sys.platform
+    )
 
 
 def get_release_info() -> str:

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -44,7 +44,7 @@
             "region": "us-east-1"
         },
         "EC2": {
-            "image_id": "ami-0623133d3181bb2d9",
+            "image_id": "ami-0be2609ba883822ec",
             "instance_type": "t2.small"
         },
         "EMR": {

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -40,11 +40,11 @@
             "region": "us-east-1"
         },
         "EC2": {
-            "image_id": "ami-a4c7edb2",
+            "image_id": "ami-01d7070812ee4de14",
             "instance_type": "t2.small"
         },
         "EMR": {
-            "release_label": "emr-5.3.0",
+            "release_label": "emr-6.2.0",
             "master": {
                 "bid_price": 10.0,
                 "instance_type": "m4.2xlarge",

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -40,11 +40,11 @@
             "region": "us-east-1"
         },
         "EC2": {
-            "image_id": "ami-01d7070812ee4de14",
+            "image_id": "ami-0623133d3181bb2d9",
             "instance_type": "t2.small"
         },
         "EMR": {
-            "release_label": "emr-6.2.0",
+            "release_label": "emr-6.1.0",
             "master": {
                 "bid_price": 10.0,
                 "instance_type": "m4.2xlarge",

--- a/python/etl/templates/extraction_pipeline.json
+++ b/python/etl/templates/extraction_pipeline.json
@@ -60,7 +60,7 @@
                 "${resources.VPC.whitelist_security_group}"
             ],
             "bootstrapAction": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh,${object_store.s3.bucket_name},${object_store.s3.prefix}",
-            "applications": [ "Spark", "Ganglia", "Zeppelin", "Sqoop" ],
+            "applications": [ "Ganglia", "Spark", "Sqoop", "Zeppelin" ],
             "configuration": []
         },
         {

--- a/python/etl/templates/extraction_pipeline.json
+++ b/python/etl/templates/extraction_pipeline.json
@@ -60,7 +60,7 @@
                 "${resources.VPC.whitelist_security_group}"
             ],
             "bootstrapAction": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh,${object_store.s3.bucket_name},${object_store.s3.prefix}",
-            "applications": [ "Ganglia", "Spark", "Sqoop", "Zeppelin" ],
+            "applications": [ "Ganglia", "Sqoop", "Zeppelin" ],
             "configuration": []
         },
         {


### PR DESCRIPTION
**Description**
This PR addresses the following:

1. Updates the AMI used for the EMR cluster to 6.1.0 which runs Python 3.7.9 – the same Python version used for the EC2 and local Docker image
2. Modifies the local Dockerfile to use the matching Amazon Linux 2 image
3. Changes `pip install` commands in the Dockerfile to use `python3 -m pip install` instead

**JIRA ticket**

https://harrys.atlassian.net/browse/DENG-528