### PR TITLE
Add show_ddl command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ data/
 dist/
 build/
 venv/
+venv_arthur/
 *.egg-info
 **/.mypy_cache/
 **/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # virtual environment and local install
 venv/
+venv_arthur/
 /dist/
 /build/
 *.egg-info

--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -33,6 +33,7 @@ _arthur_completion()
                 render_template
                 selftest
                 settings
+                show_ddl
                 show_dependents
                 show_downstream_dependents
                 show_pipelines

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -24,7 +24,7 @@ import etl.config.env
 import etl.data_warehouse
 import etl.db
 import etl.design.bootstrap
-import etl.design.redshift
+import etl.dialect
 import etl.explain
 import etl.extract
 import etl.file_sets
@@ -1127,7 +1127,7 @@ class ShowDdlCommand(SubCommand):
         descriptions = [
             etl.relation.RelationDescription(file_set) for file_set in local_files if file_set.design_file_name
         ]
-        etl.design.redshift.show_ddl(descriptions)
+        etl.dialect.show_ddl(descriptions)
 
 
 class ListFilesCommand(SubCommand):

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -24,6 +24,7 @@ import etl.config.env
 import etl.data_warehouse
 import etl.db
 import etl.design.bootstrap
+import etl.design.redshift
 import etl.explain
 import etl.extract
 import etl.file_sets
@@ -288,6 +289,7 @@ def build_full_parser(prog_name):
         BootstrapTransformationsCommand,
         ValidateDesignsCommand,
         ExplainQueryCommand,
+        ShowDdlCommand,
         SyncWithS3Command,
         # ETL commands to extract, load (or update), or transform
         ExtractToS3Command,
@@ -1107,6 +1109,25 @@ class ExplainQueryCommand(SubCommand):
             descriptions = self.find_relation_descriptions(args)
         with etl.db.log_error():
             etl.explain.explain_queries(config.dsn_etl, descriptions)
+
+
+class ShowDdlCommand(SubCommand):
+    def __init__(self):
+        super().__init__(
+            "show_ddl",
+            "show the DDL that will be used to create the table",
+            "Show DDL corresponding to the selected relations based on their (local) table designs.",
+        )
+
+    def add_arguments(self, parser):
+        add_standard_arguments(parser, ["pattern"])
+
+    def callback(self, args, config):
+        local_files = etl.file_sets.find_file_sets(self.location(args, "file"), args.pattern)
+        descriptions = [
+            etl.relation.RelationDescription(file_set) for file_set in local_files if file_set.design_file_name
+        ]
+        etl.design.redshift.show_ddl(descriptions)
 
 
 class ListFilesCommand(SubCommand):

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -6,7 +6,11 @@
         "extract_retries": 1,
         "copy_data_retries": 3,
         "insert_data_retries": 3,
-        "retriable_error_codes": "8001,15001,15005"
+        "retriable_error_codes": "8001,15001,15005",
+        "redshift": {
+            # Computing column encoding is turned off if all columns have a specified encoding.
+            "relation_column_encoding": "ON"
+        }
     },
     # Target (Redshift) cluster
     "data_warehouse": {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -157,6 +157,17 @@
                 "retriable_error_codes": {
                     "description": "Comma-separated list of pgcode values which can be safely retried",
                     "type": "string"
+                },
+                "redshift": {
+                    "description": "Settings specific to the Redshift dialect",
+                    "type": "object",
+                    "properties": {
+                        "relation_column_encoding": {
+                            "description": "Set encoding on COPY (with ON or PRESET) or automatically based on column usage.",
+                            "enum": [ "AUTO", "OFF", "ON", "PRESET" ]
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "required": [ "extract_retries", "copy_data_retries" ],

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -17,7 +17,6 @@ import logging
 import os
 import os.path
 import re
-import textwrap
 from contextlib import closing, contextmanager
 from typing import Dict, List, Optional
 
@@ -173,7 +172,7 @@ def remove_password(s):
 
 def mogrify(cursor, stmt, args=()):
     """Build the statement by filling in the arguments and cleaning up whitespace along the way."""
-    stripped = textwrap.dedent(stmt).strip("\n")
+    stripped = etl.text.whitespace_cleanup(stmt)
     if len(args):
         actual_stmt = cursor.mogrify(stripped, args)
     else:

--- a/python/etl/dialect/__init__.py
+++ b/python/etl/dialect/__init__.py
@@ -14,5 +14,5 @@ def show_ddl(relations: List[RelationDescription]) -> None:
             ddl_stmt = build_view_ddl(relation.target_table_name, relation.unquoted_columns, relation.query_stmt)
         else:
             ddl_stmt = build_table_ddl(relation.target_table_name, relation.table_design)
-        print("-- target: {table}".format(table=relation.target_table_name.identifier))
+        print("-- arthur.target: {table}".format(table=relation.target_table_name.identifier))
         print(ddl_stmt + "\n;")

--- a/python/etl/dialect/__init__.py
+++ b/python/etl/dialect/__init__.py
@@ -1,0 +1,18 @@
+from typing import List
+
+# If we ever support more than one "dialect" of SQL, we'd have to pick the correct one here.
+from etl.dialect.redshift import build_table_ddl, build_view_ddl
+from etl.relation import RelationDescription
+
+
+def show_ddl(relations: List[RelationDescription]) -> None:
+    """Print to stdout the DDL used to create the corresponding tables or views."""
+    for i, relation in enumerate(relations):
+        if i > 0:
+            print()
+        if relation.is_view_relation:
+            ddl_stmt = build_view_ddl(relation.target_table_name, relation.unquoted_columns, relation.query_stmt)
+        else:
+            ddl_stmt = build_table_ddl(relation.target_table_name, relation.table_design)
+        print("-- target: {table}".format(table=relation.target_table_name.identifier))
+        print(ddl_stmt + "\n;")

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -244,7 +244,7 @@ def copy_using_manifest(
     data_format: Optional[str] = None,
     format_option: Optional[str] = None,
     file_compression: Optional[str] = None,
-    need_compupdate=False,
+    compupdate="ON",
     dry_run=False,
 ) -> None:
 
@@ -267,7 +267,7 @@ def copy_using_manifest(
         table=table_name,
         columns=join_column_list(column_list),
         data_format_parameters=data_format_parameters,
-        compupdate="PRESET" if need_compupdate else "OFF",
+        compupdate=compupdate,
     )
     if dry_run:
         logger.info("Dry-run: Skipping copying data into '%s' using '%s'", table_name.identifier, s3_uri)
@@ -342,7 +342,7 @@ def copy_from_uri(
     data_format: Optional[str] = None,
     format_option: Optional[str] = None,
     file_compression: Optional[str] = None,
-    need_compupdate=False,
+    compupdate="ON",
     dry_run=False,
 ) -> None:
     """Load data into table in the data warehouse using the COPY command."""
@@ -355,7 +355,7 @@ def copy_from_uri(
         data_format,
         format_option,
         file_compression,
-        need_compupdate,
+        compupdate,
         dry_run,
     )
     query_load_commits(conn, table_name, s3_uri, dry_run)

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -1,5 +1,5 @@
 """
-This module contains functions to maintain relations in Redshift.
+This module contains functions to maintain relations in the "dialect" of AWS Redshift.
 
 Note that overall we try to have this minimally depend on other data structures -- actually
 we use only TableName which is handy to get a qualified and quoted name as needed.
@@ -18,7 +18,6 @@ import etl.config
 import etl.db
 from etl.errors import ETLRuntimeError, ETLSystemError, TransientETLError
 from etl.names import TableName
-from etl.relation import RelationDescription
 from etl.text import join_column_list, whitespace_cleanup
 
 logger = logging.getLogger(__name__)
@@ -383,16 +382,3 @@ def insert_from_query(
             else:
                 logger.warning("Unretriable SQL Error: pgcode=%s, pgerror=%s", exc.pgcode, exc.pgerror)
                 raise
-
-
-def show_ddl(relations: List[RelationDescription]) -> None:
-    """Print to stdout the DDL used to create the corresponding tables or views."""
-    for i, relation in enumerate(relations):
-        if i > 0:
-            print()
-        if relation.is_view_relation:
-            ddl_stmt = build_view_ddl(relation.target_table_name, relation.unquoted_columns, relation.query_stmt)
-        else:
-            ddl_stmt = build_table_ddl(relation.target_table_name, relation.table_design)
-        print("-- target: {table}".format(table=relation.target_table_name.identifier))
-        print(ddl_stmt + "\n;")

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -400,6 +400,13 @@ def copy_data(conn: connection, relation: LoadableRelation, dry_run=False):
             raise MissingManifestError(
                 "relation '{}' is missing manifest file '{}'".format(relation.identifier, s3_uri)
             )
+
+    compupdate_setting = etl.config.get_config_value("arthur_settings.redshift.relation_column_encoding")
+    if not relation.is_missing_encoding:
+        compupdate = "OFF"
+    else:
+        compupdate = compupdate_setting or "ON"
+
     copy_func = partial(
         etl.dialect.redshift.copy_from_uri,
         conn,
@@ -410,7 +417,7 @@ def copy_data(conn: connection, relation: LoadableRelation, dry_run=False):
         data_format=relation.schema_config.s3_data_format.format,
         format_option=relation.schema_config.s3_data_format.format_option,
         file_compression=relation.schema_config.s3_data_format.compression,
-        need_compupdate=relation.is_missing_encoding,
+        compupdate=compupdate,
         dry_run=dry_run,
     )
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -294,15 +294,14 @@ def create_table(
         message = "Creating temporary table for {:x}".format(relation)
         is_temp = True
 
-    ddl_stmt = etl.design.redshift.build_table_ddl(relation.table_design, ddl_table_name, is_temp=is_temp)
+    ddl_stmt = etl.design.redshift.build_table_ddl(ddl_table_name, relation.table_design, is_temp=is_temp)
     etl.db.run(conn, message, ddl_stmt, dry_run=dry_run)
 
 
 def create_view(conn: connection, relation: LoadableRelation, dry_run=False) -> None:
     """Create VIEW using the relation's query."""
-    view_name = relation.target_table_name
-    columns = join_column_list(relation.unquoted_columns)
-    stmt = """CREATE VIEW {} (\n{}\n) AS\n{}""".format(view_name, columns, relation.query_stmt)
+    ddl_view_name = relation.target_table_name
+    stmt = etl.design.redshift.build_view_ddl(ddl_view_name, relation.unquoted_columns, relation.query_stmt)
     etl.db.run(conn, "Creating view {:x}".format(relation), stmt, dry_run=dry_run)
 
 

--- a/python/etl/text.py
+++ b/python/etl/text.py
@@ -5,6 +5,7 @@ Should not import Arthur modules (so that etl.errors remains widely importable)
 """
 
 import textwrap
+from typing import List
 
 
 def approx_pretty_size(total_bytes) -> str:
@@ -63,9 +64,14 @@ def join_with_quotes(names):
         return ", ".join("'{}'".format(name) for name in names)
 
 
-def join_column_list(columns):
+def join_column_list(columns: List[str], sep=", ") -> str:
     """Return string with comma-separated, delimited column names."""
-    return ", ".join('"{}"'.format(column) for column in columns)
+    return sep.join('"{}"'.format(column) for column in columns)
+
+
+def whitespace_cleanup(value: str) -> str:
+    """Return the string value with (per line) leading and any trailing whitespace removed."""
+    return textwrap.dedent(value).strip("\n")
 
 
 class ColumnWrapper(textwrap.TextWrapper):


### PR DESCRIPTION
Eventually, this will add a selection of the column encoding based on #229 but for now we'll just show the DDL statement that would be used to create a table or view. 

Usage:
```
arthur.py show_ddl
```

Along the line, this adds a new setting to specify the `COMPUPDATE` setting on the `COPY` command. For now it's setting is backwards compatible so that adopting this change has no operational impact.

Note this also sneaks in a two-line change to allow the alternative name `venv_arthur` for the local virtual environment.