### PR TITLE
Improve create user command

### DIFF
--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -156,6 +156,6 @@ set +o xtrace
 # If you're confident enough to use "-y", you should know already about next steps.
 if [[ "$assume_yes" != "YES" ]]; then
     echo
-    echo "# You should *now* sync your data warehouse::"
+    echo "# You should *now* sync your data warehouse:"
     echo "arthur.py sync --deploy --prefix \"$PROJ_TARGET_ENVIRONMENT\""
 fi

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1265,7 +1265,7 @@ class RenderTemplateCommand(SubCommand):
         parser.set_defaults(log_level="CRITICAL")
         add_standard_arguments(parser, ["prefix"])
         group = parser.add_mutually_exclusive_group(required=True)
-        group.add_argCRITICALument("-l", "--list", help="list available templates", action="store_true")
+        group.add_argument("-l", "--list", help="list available templates", action="store_true")
         group.add_argument("template", help="name of template", nargs="?")
         parser.add_argument("-t", "--compact", help="produce compact output", action="store_true")
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -223,6 +223,7 @@ class FancyArgumentParser(argparse.ArgumentParser):
 
 
 def isoformat_datetime_string(argument):
+    # "isoformat" is used as a verb here.
     return datetime.strptime(argument, "%Y-%m-%dT%H:%M:%S")
 
 
@@ -282,6 +283,7 @@ def build_full_parser(prog_name):
     for klass in [
         # Commands to deal with data warehouse as admin:
         InitializeSetupCommand,
+        ShowRandomPassword,
         CreateUserCommand,
         UpdateUserCommand,
         # Commands to help with table designs and uploading them
@@ -541,25 +543,42 @@ class InitializeSetupCommand(SubCommand):
             )
 
 
+class ShowRandomPassword(SubCommand):
+    def __init__(self):
+        super().__init__(
+            "show_random_password",
+            "show a random password compatible with Redshift",
+            "Show a random password with upper-case, lower-case and a number.",
+        )
+
+    def add_arguments(self, parser):
+        parser.set_defaults(log_level="CRITICAL")
+
+    def callback(self, args, config):
+        random_password = uuid.uuid4().hex
+        example_password = random_password[:16].upper() + random_password[16:].lower()
+        print(example_password)
+
+
 class CreateUserCommand(SubCommand):
     def __init__(self):
         super().__init__(
             "create_user",
             "add new user",
             "Add new user and set group membership, optionally create a personal schema."
-            " Note that you have to set a password for the user in your .pgpass file"
+            " It is ok to re-initialize a user defined in a settings file."
+            " Note that you have to set a password for the user in your '~/.pgpass' file"
             " before invoking this command. The password must be valid in Redshift,"
-            " so must contain upper case and lower case characters as well as numbers."
-            " It is ok to re-initialize a user defined in a settings file.",
+            " so must contain upper-case and lower-case characters as well as numbers.",
         )
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["dry-run"])
-        parser.add_argument("username", help="name for new user")
         parser.add_argument("-g", "--group", help="add user to specified group")
         parser.add_argument(
             "-a", "--add-user-schema", help="add new schema, writable for the user", action="store_true"
         )
+        parser.add_argument("username", help="name for new user")
 
     def callback(self, args, config):
         with etl.db.log_error():
@@ -570,25 +589,22 @@ class CreateUserCommand(SubCommand):
 
 class UpdateUserCommand(SubCommand):
     def __init__(self):
-        random_password = uuid.uuid4().hex
-        example_password = random_password[:16].upper() + random_password[16:].lower()
         super().__init__(
             "update_user",
             "update user's group, password, and path",
             "Update an existing user with group membership, password, and search path."
-            " Note that you have to have set a password for the user in your .pgpass file"
+            " Note that you have to set a password for the user in your '~/.pgpass' file"
             " before invoking this command. The password must be valid in Redshift,"
-            " so must contain upper case and lower case characters as well as numbers"
-            " (for example: %s)" % example_password,
+            " so must contain upper-case and lower-case characters as well as numbers.",
         )
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["dry-run"])
-        parser.add_argument("username", help="name of existing user")
         parser.add_argument("-g", "--group", help="add user to specified group")
         parser.add_argument(
             "-a", "--add-user-schema", help="add new schema, writable for the user", action="store_true"
         )
+        parser.add_argument("username", help="name of existing user")
 
     def callback(self, args, config):
         with etl.db.log_error():

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -328,7 +328,7 @@ def build_full_parser(prog_name):
 
 def add_standard_arguments(parser, options):
     """
-    Add set of "standard" arguments.
+    Add from set of "standard" arguments.
 
     They are "standard" in that the name and description should be the same when used
     by multiple sub-commands.
@@ -397,8 +397,6 @@ def add_standard_arguments(parser, options):
             nargs="*",
             action=StorePatternAsSelector,
         )
-    # Cannot be set on the command line since changing it is not supported by file sets.
-    parser.set_defaults(table_design_dir="./schemas")
 
 
 class StorePatternAsSelector(argparse.Action):
@@ -438,6 +436,8 @@ class SubCommand:
         group.add_argument(
             "-q", "--quiet", help="decrease verbosity", action="store_const", const="WARNING", dest="log_level"
         )
+        # Cannot be set on the command line since changing it is not supported by file sets.
+        parser.set_defaults(table_design_dir="./schemas")
 
         self.add_arguments(parser)
         return parser

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -594,8 +594,9 @@ class UpdateUserCommand(SubCommand):
             "update user's group, password, and path",
             "Update an existing user with group membership, password, and search path."
             " Note that you have to set a password for the user in your '~/.pgpass' file"
-            " before invoking this command. The password must be valid in Redshift,"
-            " so must contain upper-case and lower-case characters as well as numbers.",
+            " before invoking this command if you want to update the password. The password must"
+            " be valid in Redshift, so must contain upper-case and lower-case characters as well"
+            " as numbers. If you leave the line out, the password will not be changed.",
         )
 
     def add_arguments(self, parser):
@@ -1264,7 +1265,7 @@ class RenderTemplateCommand(SubCommand):
         parser.set_defaults(log_level="CRITICAL")
         add_standard_arguments(parser, ["prefix"])
         group = parser.add_mutually_exclusive_group(required=True)
-        group.add_argument("-l", "--list", help="list available templates", action="store_true")
+        group.add_argCRITICALument("-l", "--list", help="list available templates", action="store_true")
         group.add_argument("template", help="name of template", nargs="?")
         parser.add_argument("-t", "--compact", help="produce compact output", action="store_true")
 

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -54,7 +54,7 @@ def create_schema_and_grant_access(conn, schema, owner=None, use_staging=False, 
         if use_staging:
             # Don't grant usage on staging schemas to readers/writers
             return None
-        logger.info("Granting access to %s", group_names)
+        logger.info("Granting access in '%s' to %s", name, group_names)
         for group in schema.groups:
             # Readers/writers are differentiated in table permissions, not schema permissions
             etl.db.grant_usage(conn, name, group)

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -186,7 +186,7 @@ def _create_or_update_cluster_user(conn, user, only_update=False, dry_run=False)
                 logger.info("Adding user '%s' to group '%s'", user.name, user.group)
                 etl.db.alter_group_add_user(conn, user.group, user.name)
                 logger.info("Updating password for user '%s'", user.name)
-                etl.db.alter_password(conn, user.name)
+                etl.db.alter_password(conn, user.name, ignore_missing_password=True)
         else:
             if dry_run:
                 logger.info("Dry-run: Skipping creating user '%s' in group '%s'", user.name, user.group)

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -359,7 +359,8 @@ def group_exists(cx, group) -> bool:
     return len(rows) > 0
 
 
-def _get_encrypted_password(cx, user):
+def _get_encrypted_password(cx, user) -> Optional[str]:
+    """Return MD5-hashed password if entry is found in PGPASSLIB or None otherwise."""
     dsn_complete = dict(kv.split("=") for kv in cx.dsn.split(" "))
     dsn_partial = {key: dsn_complete[key] for key in ["host", "port", "dbname"]}
     dsn_user = dict(dsn_partial, user=user)
@@ -371,9 +372,9 @@ def _get_encrypted_password(cx, user):
     except pgpasslib.InvalidPermissions as exc:
         logger.info("Update the permissions using: 'chmod go= ~/.pgpass'")
         raise ETLRuntimeError("PGPASSFILE file has invalid permissions") from exc
+
     if password is None:
-        logger.warning("Missing line in .pgpass file: '%(host)s:%(port)s:%(dbname)s:%(user)s:<password>'", dsn_user)
-        raise ETLRuntimeError("password missing from PGPASSFILE for user '{}'".format(user))
+        return None
     md5 = hashlib.md5()
     md5.update((password + user).encode())
     return "md5" + md5.hexdigest()
@@ -381,11 +382,19 @@ def _get_encrypted_password(cx, user):
 
 def create_user(cx, user, group):
     password = _get_encrypted_password(cx, user)
+    if password is None:
+        logger.warning("Missing entry in PGPASSFILE file for '%s'", user)
+        raise ETLRuntimeError("password missing from PGPASSFILE for user '{}'".format(user))
     execute(cx, """CREATE USER "{}" IN GROUP "{}" PASSWORD %s""".format(user, group), (password,))
 
 
-def alter_password(cx, user):
+def alter_password(cx, user, ignore_missing_password=False):
     password = _get_encrypted_password(cx, user)
+    if password is None:
+        logger.warning("Failed to find password in PGPASSFILE for '%s'", user)
+        if not ignore_missing_password:
+            raise ETLRuntimeError("password missing from PGPASSFILE for user '{}'".format(user))
+        return
     execute(cx, """ALTER USER "{}" PASSWORD %s""".format(user), (password,))
 
 


### PR DESCRIPTION
This PR makes creating and updating a users a bit easier.
* There is a dedicated command to create a valid password.
* It's now OK when updating a user for that user to not be in the `~/.pgpass` file.

Example steps:
```
REDSHIFT_USER=arthur
REDSHIFT_PASSWORD=$( arthur.py show_random_password )

echo "*:5439:*:$REDSHIFT_USER:$REDSHIFT_PASSWORD" | tee -a ~/.pgpass

arthur.py create_user $REDSHIFT_USER

# The next command succeeds even if you remove the corresponding line from ~/.pgpass
arthur.py update_user --add-user-schema $REDSHIFT_USER
```

Notes
* Also moves the default for the schemas dir into a more appropriate place.
* Updates log output to show more info.