### PR TITLE
Pin pip and python versions (also in Docker image)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - name: Checkout out code
       uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
     - name: Cache pip
       uses: actions/cache@v2
       with:
@@ -27,7 +27,7 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements-linters.txt') }}
     - name: Install dependencies
       run: |-
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip==20.3.4
         python3 -m pip install --requirement requirements-linters.txt
     - name: Lint with black
       run: |-
@@ -43,10 +43,10 @@ jobs:
     steps:
     - name: Checkout out code
       uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
     - name: Cache pip
       uses: actions/cache@v2
       with:
@@ -54,7 +54,7 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements-linters.txt') }}
     - name: Install dependencies
       run: |-
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip==20.3.4
         python3 -m pip install --requirement requirements-linters.txt
     - name: Run type checker
       run: |-

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - name: Checkout out code
       uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
     - name: Cache pip
       uses: actions/cache@v2
       with:
@@ -27,7 +27,7 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
     - name: Install dependencies
       run: |-
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip==20.3.4
         python3 -m pip install --requirement requirements.txt
         python3 setup.py develop
     - name: Run doctests

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --chown=arthur:arthur \
 COPY requirements*.txt /tmp/
 RUN python3 -m venv /opt/local/redshift_etl/venv && \
     source /opt/local/redshift_etl/venv/bin/activate && \
-    python3 -m pip install --upgrade pip --disable-pip-version-check --no-cache-dir && \
+    python3 -m pip install --upgrade pip==20.3.4 --disable-pip-version-check --no-cache-dir && \
     python3 -m pip install --requirement /tmp/requirements-dev.txt --disable-pip-version-check --no-cache-dir
 
 # Create an empty .pgpass file to help with create_user and update_user commands.
@@ -54,7 +54,6 @@ RUN source /opt/local/redshift_etl/venv/bin/activate && \
     python3 setup.py install && \
     rm -rf build dist && \
     arthur.py --version
-
 
 # Whenever there is an ETL running, it offers progress information on port 8086.
 EXPOSE 8086

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ FROM amazonlinux:2.0.20201218.1
 
 RUN yum install -y \
         awscli \
-        gcc \
         jq \
         libyaml-devel \
         openssh-clients \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 FROM amazonlinux:2.0.20201218.1
 
-# See the same settingin bin/bootstrap.sh
+# See the same setting in bin/bootstrap.sh
 ARG PROJ_NAME=redshift_etl
 
 RUN yum install -y \

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -4,7 +4,7 @@
 # Make sure to keep this in sync with our Dockerfile.
 
 PROJ_NAME="redshift_etl"
-PROJ_PACKAGES="awscli gcc jq libyaml-devel postgresql procps-ng python3 python3-devel tmux"
+PROJ_PACKAGES="awscli jq libyaml-devel postgresql procps-ng python3 python3-devel tmux"
 
 PROJ_TEMP="/tmp/$PROJ_NAME"
 

--- a/etc/future_pyproject.toml
+++ b/etc/future_pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 include = '\.pyi?$'
 line-length = 100
-target-version = ['py35']
+target-version = ['py36']
 
 [tool.isort]
 default_section = "THIRDPARTY"

--- a/etc/future_setup.cfg
+++ b/etc/future_setup.cfg
@@ -19,7 +19,7 @@ max-line-length = 100
 max-complexity = 30
 
 [mypy]
-python_version = 3.5
+python_version = 3.6
 # disallow_untyped_defs = True
 ignore_missing_imports = True
 strict_optional = True

--- a/etc/pyproject.toml
+++ b/etc/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 include = '\.pyi?$'
 line-length = 120
-target-version = ['py35']
+target-version = ['py36']
 
 [tool.isort]
 default_section = "THIRDPARTY"

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ max-line-length = 120
 max-complexity = 30
 
 [mypy]
-python_version = 3.5
+python_version = 3.6
 # disallow_untyped_defs = True
 ignore_missing_imports = True
 strict_optional = True

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     package_dir={"": "python"},
     packages=find_packages("python"),
     package_data={"etl": ["assets/*", "config/*", "templates/*"]},
+    python_requires=">=3.6, <4",
     scripts=[
         "python/scripts/compare_events.py",
         "python/scripts/install_extraction_pipeline.sh",


### PR DESCRIPTION
This generally sets the Python version to 3.7 and PIP version to 20.3.4. The min Python version that's expected now is 3.6. (We're likely to start using `f`-strings!)

It seems that we no longer need `gcc` so that's removed from the installed packages.

Also, small cleanup in `Dockerfile` to use `PROJ_NAME` just like `boostrap.sh` does.
