### PR TITLE
Docstring changes for future max line width

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -180,6 +180,8 @@ def submit_step(cluster_id, sub_command):
 
 class FancyArgumentParser(argparse.ArgumentParser):
     """
+    Fancier version of the argument parser supporting "@file".
+
     Add feature to read command line arguments from files and support:
         * One argument per line (whitespace is trimmed)
         * Comments or empty lines (either are ignored)
@@ -443,7 +445,7 @@ class SubCommand:
         return parser
 
     def add_arguments(self, parser):
-        """Override this method for sub-classes"""
+        """Override this method for sub-classes."""
         pass
 
     @staticmethod
@@ -493,14 +495,12 @@ class SubCommand:
         return descriptions
 
     def callback(self, args, config):
-        """Override this method for sub-classes"""
+        """Override this method for sub-classes."""
         raise NotImplementedError("Instance of {} has no proper callback".format(self.__class__.__name__))
 
 
 class MonitoredSubCommand(SubCommand):
-    """
-    A sub-command that will also use monitors to update some event table
-    """
+    """A sub-command that will also use monitors to update some event table."""
 
     def add_to_parser(self, parent_parser) -> argparse.ArgumentParser:
         parser = super().add_to_parser(parent_parser)

--- a/python/etl/config/dw.py
+++ b/python/etl/config/dw.py
@@ -1,6 +1,4 @@
-"""
-Data warehouse configuration based on the config file for setup, sources, transformations, users.
-"""
+"""Data warehouse configuration based on config files for setup, sources, transformations, users."""
 
 from typing import Dict
 

--- a/python/etl/config/env.py
+++ b/python/etl/config/env.py
@@ -19,10 +19,9 @@ def get(name: str, default: Union[str, None] = None) -> str:
 
 def get_default_prefix() -> str:
     """
-    Return default prefix which is the first non-emtpy value of:
-      - the environment variable ARTHUR_DEFAULT_PREFIX
-      - the environment variable USER
-      - the "user name" as determined by the getpass module
+    Return default prefix, gleaned from the environment in ARTHUR_DEFAULT_PREFIX or USER.
+
+    We have a last resort by checking the user name using the getapass module.
 
     >>> os.environ["ARTHUR_DEFAULT_PREFIX"] = "doctest"
     >>> get_default_prefix()

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -190,10 +190,13 @@ def fetch_dependencies(cx: connection, table_name: TableName) -> List[str]:
 
 def create_partial_table_design(conn: connection, source_table_name: TableName, target_table_name: TableName):
     """
-    Return partial table design that contains
+    Start a table design for the relation.
+
+    This returns a partial table design that contains
         - the name (identifier of our target table)
         - full column information (extracted from database source or data warehouse)
         - a description (with a timestamp)
+
     What is missing then to make it a valid table design is at least the "source_name".
     """
     type_maps = etl.config.get_dw_config().type_maps
@@ -237,7 +240,9 @@ def create_partial_table_design_for_transformation(
     conn: connection, tmp_view_name: TableName, relation: RelationDescription, update_keys: Union[List, None] = None
 ):
     """
-    Create a partial design that's applicable to transformations, which
+    Create a partial design that's applicable to transformations.
+
+    This partial design:
         - cleans up the column information (dropping accidental expressions)
         - adds dependencies (which only transformations can have)
         - and optionally updates from the existing table design
@@ -281,11 +286,13 @@ def create_partial_table_design_for_transformation(
 
 def update_column_definition(new_column: dict, old_column: dict):
     """
-    Update column definition derived from inspecting the view created for the transformation
+    Update column definition found automatically with previous information from table design.
+
+    This carefully merges the information from inspecting the view created for the transformation
     with information from the existing table design.
 
     Copied directly: "description", "encoding", "references", and "not_null"
-    Updated carefully: "sql_type", "type" (always together)
+    Updated carefully: "sql_type" and "type" (always together)
     """
     ok_to_copy = frozenset(["description", "encoding", "references", "not_null"])
     for key in ok_to_copy.intersection(old_column):

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -1,8 +1,10 @@
 """
+Slurp in "table design" files and validate the relation's design.
+
 Table designs describe the columns, like their name and type, as well as how the data
 should be organized once loaded into Redshift, like the distribution style or sort key.
 
-Table designs are dictionaries of dictionaries or lists etc.
+Table designs are implemented as dictionaries of dictionaries or lists etc.
 """
 
 import logging
@@ -99,9 +101,7 @@ def validate_table_design_syntax(table_design, table_name):
 
 
 def validate_identity_as_surrogate_key(table_design):
-    """
-    Check whether specification of our identity column is valid and whether it matches surrogate key.
-    """
+    """Check whether specification of our identity column is valid and matches surrogate key."""
     identity_columns = []
     for column in table_design["columns"]:
         if column.get("identity"):

--- a/python/etl/extract/database_extractor.py
+++ b/python/etl/extract/database_extractor.py
@@ -54,6 +54,8 @@ class DatabaseExtractor(Extractor):
 
     def maximize_partitions(self, table_size: int) -> int:
         """
+        Return largest "legal" number of partions for this table.
+
         Determine the maximum number of row-wise partitions a table can be divided into while respecting a minimum
         partition size, and a limit on the number of partitions.
 

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -24,6 +24,8 @@ from etl.timer import Timer
 
 class Extractor:
     """
+    Parent class of extractors that organizes per-source extraction.
+
     The extractor base class provides the basic mechanics to
     * iterate over sources
       * iterate over tables in each source
@@ -58,7 +60,7 @@ class Extractor:
         """
         Return list of "options" that describe the extract.
 
-        This list will be part of the step monitor
+        This list will be part of the step monitor.
         """
         return ["with-{0.name}-extractor".format(self)]
 

--- a/python/etl/extract/spark.py
+++ b/python/etl/extract/spark.py
@@ -68,9 +68,7 @@ class SparkExtractor(DatabaseExtractor):
         return SQLContext(sc)
 
     def extract_table(self, source: DataWarehouseSchema, relation: RelationDescription):
-        """
-        Using Spark's dataframe API, read the table in as a dataframe before writing it out to CSV.
-        """
+        """Read the table before writing it out to CSV using Spark's dataframe API."""
         with etl.db.log_error():
             df = self.read_table_as_dataframe(source, relation)
             self.write_dataframe_as_csv(df, relation)

--- a/python/etl/file_sets.py
+++ b/python/etl/file_sets.py
@@ -393,9 +393,7 @@ def find_data_files_in_s3(bucket_name: str, prefix: str) -> Iterator[str]:
 
 
 def delete_files_in_s3(bucket_name: str, prefix: str, selector: TableSelector, dry_run: bool = False) -> None:
-    """
-    Delete all files that might be relevant given the choice of schemas and the target selection.
-    """
+    """Delete all files that might be relevant given the environment and selected relations."""
     iterable = etl.s3.list_objects_for_prefix(bucket_name, prefix + "/data", prefix + "/schemas")
     deletable = [file_info.filename for file_info in _find_matching_files_from(iterable, selector)]
     if dry_run:

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -491,9 +491,7 @@ def create_missing_dimension_row(columns: List[dict]) -> List[str]:
 
 
 def load_ctas_using_temp_table(conn: connection, relation: LoadableRelation, dry_run=False) -> None:
-    """
-    Run query to fill temp table, then copy data (possibly along with missing dimension) into CTAS relation.
-    """
+    """Run query to fill temp table and copy data (option: with missing dimension) into target."""
     temp_name = TempTableName.for_table(relation.target_table_name)
     create_table(conn, relation, table_name=temp_name, dry_run=dry_run)
     try:
@@ -621,8 +619,9 @@ def create_schemas_for_rebuild(schemas: List[DataWarehouseSchema], use_staging: 
 
 def update_table(conn: connection, relation: LoadableRelation, dry_run=False) -> None:
     """
-    Update table contents either from CSV files from upstream sources or by running some SQL
-    for CTAS relations. This assumes that the table was previously created.
+    Update table contents either from CSV files from upstream sources or by running some SQL query.
+
+    This assumes that the table was previously created.
 
     1. For tables backed by upstream sources, data is copied in.
     2. If the CTAS doesn't have a key (no identity column), then values are inserted straight
@@ -1030,9 +1029,7 @@ def set_redshift_wlm_slots(conn: connection, slots: int, dry_run: bool) -> None:
 def create_relations(
     relations: List[LoadableRelation], max_concurrency=1, wlm_query_slots=1, concurrent_extract=False, dry_run=False
 ) -> None:
-    """
-    "Building" relations refers to creating them, granting access, and if they should hold data, loading them.
-    """
+    """Build relations by creating them, granting access, and loading them (if they hold data)."""
     if concurrent_extract:
         create_source_tables_when_ready(relations, max_concurrency, dry_run=dry_run)
     else:

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -450,8 +450,10 @@ class TableSelector:
 
     def match_schema(self, schema) -> bool:
         """
-        Match against schema name, return true if any pattern matches the schema name
-        and the schema is part of the base schemas (if defined).
+        Match this schema name against the patterns.
+
+        This returns true if any pattern matches the schema name and the schema is part of the
+        base schemas (if defined).
 
         >>> tnp = TableSelector(["www.orders", "factory.products"])
         >>> tnp.match_schema("www")
@@ -492,8 +494,10 @@ class TableSelector:
 
     def match(self, table_name):
         """
-        Match names of schema and table against known patterns, return true if any pattern matches
-        and the schema is part of the base schemas (if defined).
+        Match relation on schema and table patterns (possibly limited to base schemas).
+
+        This returns true if any pattern matches and the schema is part of the base schemas
+        (if defined).
 
         >>> ts = TableSelector(["www.orders", "www.prod*"])
         >>> name = TableName("www", "products")

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -1,9 +1,10 @@
 """
-The purpose of "validate" is to exercise the configuration, schemas, and queries that make up
-the data warehouse description (and eventually, its state).
+The purpose of "validate" is to exercise the configuration, schemas, and queries.
 
-This includes static and runtime checks.  As always, the "dry-run" option tries to run as much
-as possible but doesn't change any state (i.e. doesn't write or create tables or...)
+This includes static and runtime checks of our the description of the data warehouse.
+
+As always, the "dry-run" option tries to run as much as possible but doesn't change any state
+(i.e. doesn't write or create tables).
 
 Validating the warehouse schemas (definition of upstream tables and their transformations) includes:
 * Syntax checks (valid JSON?, valid against the JSON schema?)


### PR DESCRIPTION
After these changes, we should have only E501s (line too long) left when re-formatting for 100 line width. (We'll be moving towards tighter formatting in arthur etl and arthur tools.)

Check using:
```
flake8 --config etc/future_setup.cfg --extend-ignore E501 python setup.py
```

Automatic reformatting will happen using:
```
black --config ./etc/future_pyproject.toml python setup.py
```