### PR TITLE
Fix index level calculation

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1220,8 +1220,18 @@ class ShowDownstreamDependentsCommand(SubCommand):
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern", "prefix", "scheme", "continue-from"])
-        parser.add_argument(
-            "--list-dependencies", help="show list of dependencies after every relation", action="store_true"
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--list-dependencies",
+            help="deprecated in favor of --with-dependencies",
+            action="store_true",
+            dest="with_dependencies",
+        )
+        group.add_argument(
+            "--with-dependencies", help="show list of dependencies (downstream) for every relation", action="store_true"
+        )
+        group.add_argument(
+            "--with-dependents", help="show list of dependents (upstream) for every relation", action="store_true"
         )
 
     def callback(self, args, config):
@@ -1229,7 +1239,11 @@ class ShowDownstreamDependentsCommand(SubCommand):
             args, required_relation_selector=config.required_in_full_load_selector, return_all=True
         )
         etl.load.show_downstream_dependents(
-            relations, args.pattern, continue_from=args.continue_from, list_dependencies=args.list_dependencies
+            relations,
+            args.pattern,
+            continue_from=args.continue_from,
+            with_dependencies=args.with_dependencies,
+            with_dependents=args.with_dependents,
         )
 
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1257,7 +1257,7 @@ def show_downstream_dependents(
     current_index = {relation.identifier: i + 1 for i, relation in enumerate(selected_relations)}
     # Note that external tables are not in the list of relations (always level = 0),
     # and if a relation isn't part of downstream, they're considered built already (level = 0).
-    current_level = defaultdict(int)
+    current_level: Dict[str, int] = defaultdict(int)
     # Now set the level that we show so that it starts at 1 for the relations we're building here.
     # Pass 1: find out the largest level, ignoring pg_catalog dependencies.
     for relation in selected_relations:

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1237,7 +1237,8 @@ def show_downstream_dependents(
 
     max_len = max(len(relation.identifier) for relation in selected_relations)
     line_template = (
-        "{relation.identifier:{width}s} # kind={relation.kind} index={index:4d} level={relation.level:3d}"
+        "{relation.identifier:{width}s}"
+        " # kind={relation.kind} index={index:4d} level={relation.execution_level:3d}"
         " flag={flag:9s}"
         " is_required={relation.is_required}"
     )
@@ -1254,7 +1255,7 @@ def show_downstream_dependents(
             for dependency in sorted(relation.dependencies):
                 if dependency in relation_map:
                     print(
-                        "  #> {relation.identifier:{width}s} # level={relation.level:3d}".format(
+                        "  #> {relation.identifier:{width}s} # level={relation.execution_level:3d}".format(
                             relation=relation_map[dependency], width=max_len
                         )
                     )

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -84,7 +84,10 @@ class RelationDescription:
         # table design.
         self._table_design = None  # type: Optional[Dict[str, Any]]
         self._query_stmt = None  # type: Optional[str]
+
         self._dependencies = None  # type: Optional[FrozenSet[TableName]]
+        self._execution_level = None  # type: Union[None, bool]
+        self._execution_order = None  # type: Union[None, bool]
         self._is_required = None  # type: Union[None, bool]
 
     @property
@@ -174,6 +177,20 @@ class RelationDescription:
     @property
     def is_unloadable(self) -> bool:
         return "unload_target" in self.table_design
+
+    @property
+    def execution_level(self) -> bool:
+        """All relations of the same level may be loaded in parallel."""
+        if self._execution_level is None:
+            raise ETLRuntimeError("execution level unknown for RelationDescription '{0.identifier}'".format(self))
+        return self._execution_level
+
+    @property
+    def execution_order(self) -> bool:
+        """All relations can be ordered to load properly in series based on their dependencies."""
+        if self._execution_order is None:
+            raise ETLRuntimeError("execution order unknown for RelationDescription '{0.identifier}'".format(self))
+        return self._execution_order
 
     @property
     def is_required(self) -> bool:
@@ -377,7 +394,7 @@ class SortableRelationDescription:
     Facade to add modifiable list of dependencies.
 
     This adds decoration around relation descriptions so that we can easily
-    compute the execution order and then throw away our intermediate results.
+    compute the execution order by updating the "dependencies" list.
     """
 
     def __init__(self, original_description: RelationDescription) -> None:
@@ -473,7 +490,7 @@ def _sort_by_dependencies(descriptions: List[SortableRelationDescription]) -> No
             queue.put((max(latest_order, minimum_order) + 1, tie_breaker, description))
 
 
-def order_by_dependencies(relation_descriptions):
+def order_by_dependencies(relation_descriptions: List[RelationDescription]) -> List[RelationDescription]:
     """
     Sort the relations such that any dependents surely are loaded afterwards.
 
@@ -487,19 +504,26 @@ def order_by_dependencies(relation_descriptions):
     Provides warnings about:
         * relations that directly depend on relations not in the input
         * relations that are depended upon but are not in the input
+
+    Side-effect: the order and level of the relations is set.
+    (So should this be invoked a second time, we'll skip computations if order is already set.)
     """
     RelationDescription.load_in_parallel(relation_descriptions)
-    descriptions = [SortableRelationDescription(description) for description in relation_descriptions]
 
-    _sanitize_dependencies(descriptions)
-    _sort_by_dependencies(descriptions)
+    # Sorting is all-or-nothing so we get away with checking for just one relation's order.
+    if relation_descriptions and relation_descriptions[0]._execution_order is not None:
+        logger.info("Reusing previously computed execution order of %d relation(s)", len(relation_descriptions))
+    else:
+        sortable_descriptions = [SortableRelationDescription(description) for description in relation_descriptions]
+        _sanitize_dependencies(sortable_descriptions)
+        _sort_by_dependencies(sortable_descriptions)
+        # A functional approach would be to create new instances here. Instead we reach back. Shrug.
+        # TODO Sort by level first, then order.
+        for sortable in sortable_descriptions:
+            sortable.original_description._execution_order = sortable.order
+            sortable.original_description._execution_level = sortable.level
 
-    # TODO Find a better way to back-annotate the relation descriptions. Having "level" reach
-    # in here is bad.
-    for description in descriptions:
-        description.original_description.level = description.level
-
-    return [description.original_description for description in sorted(descriptions, key=attrgetter("order"))]
+    return [description for description in sorted(relation_descriptions, key=attrgetter("execution_order"))]
 
 
 def set_required_relations(relations: List[RelationDescription], required_selector: TableSelector) -> None:


### PR DESCRIPTION
When checking downstream dependents, there are now two options to add more details.

* Add more information from tables that are depended upon (upstream)
```
arthur.py show_downstream_dependents --with-dependencies staging.users

staging.users                 # kind=CTAS index=   1 level=  1 flag=selected  is_required=True
  #<- user_database.users           level=  0
staging.emails                # kind=VIEW index=   2 level=  2 flag=immediate is_required=True
  #<- crm.emails                    level=  0
  #<- staging.users                 level=  1
...
```

* Add more information from tables that are (eventually found) downstream:
```
arthur.py show_downstream_dependents --with-dependents staging.users

staging.users                 # kind=CTAS index=   1 level=  1 flag=selected  is_required=True
  #-> staging.emails                index=   2 level=  2
staging.emails                # kind=VIEW index=   2 level=  2 flag=immediate is_required=True
  #-> dw.fact_emails                index=   4 level=  3
...
```

Overall:
* The "level" is 0 if the table is assumed to already exist or to already have been built.
* If you were to build all tables on one level in parallel before going on to the next level, it'd be alright.
* The PR is called a "fix to the level" since the value of level was confusing previously when only a subset of tables was selected.
* This also fixes the double ordering issue where warnings about tables not managed by Arthur pop up twice.
* To avoid information overload, you can only pick one of the two `--with` options.
* The previously defined `--list-dependencies` is deprecated in favor of `--with-dependencies`.

Note that this now stores the execution order and level on the relation description.
