### PR TITLE
Teach bootstrap transformations to find external dependencies

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -64,7 +64,7 @@ _arthur_completion()
             COMPREPLY=( $(compgen -A variable -P '$' -- "${cur#'$'}") )
             ;;
         "auto_design"|"bootstrap_transformations")
-            COMPREPLY=( $(compgen -W "CTAS VIEW UPDATE" -- "$cur") )
+            COMPREPLY=( $(compgen -W "CTAS VIEW update" -- "$cur") )
             ;;
         *)
             case "$cur" in

--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -64,7 +64,7 @@ _arthur_completion()
             COMPREPLY=( $(compgen -A variable -P '$' -- "${cur#'$'}") )
             ;;
         "auto_design"|"bootstrap_transformations")
-            COMPREPLY=( $(compgen -W "CTAS VIEW" -- "$cur") )
+            COMPREPLY=( $(compgen -W "CTAS VIEW UPDATE" -- "$cur") )
             ;;
         *)
             case "$cur" in

--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -64,7 +64,7 @@ _arthur_completion()
             COMPREPLY=( $(compgen -A variable -P '$' -- "${cur#'$'}") )
             ;;
         "auto_design"|"bootstrap_transformations")
-            COMPREPLY=( $(compgen -W "CTAS VIEW update" -- "$cur") )
+            COMPREPLY=( $(compgen -W "CTAS VIEW update check-only" -- "$cur") )
             ;;
         *)
             case "$cur" in

--- a/python/etl/assets/__init__.py
+++ b/python/etl/assets/__init__.py
@@ -4,19 +4,19 @@ from functools import lru_cache
 from typing import Dict, List, Union
 
 import pkg_resources
-import simplejson
+import simplejson as json
 
 from etl.json_encoder import FancyJsonEncoder
 
 
 class Content:
-    def __init__(self, name: str = None, json: Union[List, Dict] = None) -> None:
+    def __init__(self, name: str = None, some_json: Union[List, Dict] = None) -> None:
         if name is not None:
             self.content = pkg_resources.resource_string(__name__, name)
             self.content_type, self.content_encoding = mimetypes.guess_type(name)
             self.cache_control = None
-        elif json is not None:
-            json_text = simplejson.dumps(json, sort_keys=True, cls=FancyJsonEncoder)
+        elif some_json is not None:
+            json_text = json.dumps(some_json, sort_keys=True, cls=FancyJsonEncoder)
             self.content = (json_text + "\n").encode("utf-8")
             self.content_type, self.content_encoding = "application/json", "UTF-8"
             self.cache_control = "no-cache, no-store, must-revalidate"

--- a/python/etl/assets/__init__.py
+++ b/python/etl/assets/__init__.py
@@ -4,19 +4,19 @@ from functools import lru_cache
 from typing import Dict, List, Union
 
 import pkg_resources
-import simplejson as json
+import simplejson
 
 from etl.json_encoder import FancyJsonEncoder
 
 
 class Content:
-    def __init__(self, name: str = None, some_json: Union[List, Dict] = None) -> None:
+    def __init__(self, name: str = None, json: Union[List, Dict] = None) -> None:
         if name is not None:
             self.content = pkg_resources.resource_string(__name__, name)
             self.content_type, self.content_encoding = mimetypes.guess_type(name)
             self.cache_control = None
-        elif some_json is not None:
-            json_text = json.dumps(some_json, sort_keys=True, cls=FancyJsonEncoder)
+        elif json is not None:
+            json_text = simplejson.dumps(json, sort_keys=True, cls=FancyJsonEncoder)
             self.content = (json_text + "\n").encode("utf-8")
             self.content_type, self.content_encoding = "application/json", "UTF-8"
             self.cache_control = "no-cache, no-store, must-revalidate"

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -735,18 +735,22 @@ class BootstrapTransformationsCommand(SubCommand):
         )
 
     def add_arguments(self, parser):
-        parser.add_argument(
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
             "-f", "--force", help="overwrite table design file if it already exists", default=False, action="store_true"
         )
-        parser.add_argument(
+        group.add_argument(
             "-u",
             "--update",
-            help="EXPERIMENTAL merge with existing table design if available",
+            help="merge new information with existing table design",
             default=False,
             action="store_true",
         )
         parser.add_argument(
-            "type", choices=["CTAS", "VIEW"], help="pick whether to create table designs for 'CTAS' or 'VIEW' relations"
+            "type",
+            choices=["CTAS", "VIEW", "UPDATE"],
+            help="pick whether to create table designs for 'CTAS' or 'VIEW' relations"
+            " or update the current relation",
         )
         add_standard_arguments(parser, ["pattern", "dry-run"])
 
@@ -758,8 +762,8 @@ class BootstrapTransformationsCommand(SubCommand):
             dw_config.schemas,
             args.table_design_dir,
             local_files,
-            args.type == "VIEW",
-            update=args.update,
+            args.type if args.type != "UPDATE" else None,
+            update=args.update or args.type == "UPDATE",
             replace=args.force,
             dry_run=args.dry_run,
         )

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -80,8 +80,7 @@ def execute_or_bail():
         logger.error("ETL never got off the ground: %r", exc)
         croak(exc, 1)
     except ETLError as exc:
-        logger.debug("Caught exception:", exc_info=True)
-        logger.critical("Something bad happened in the ETL: %s\n%s", type(exc).__name__, exc)
+        logger.critical("Something bad happened in the ETL: %s\n%s", type(exc).__name__, exc, exc_info=True)
         if exc.__cause__ is not None:
             exc_cause_type = type(exc.__cause__)
             logger.info(

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -730,12 +730,20 @@ class BootstrapTransformationsCommand(SubCommand):
             "bootstrap_transformations",
             "bootstrap schema information from transformations",
             "Download schema information as if transformation had been run in data warehouse."
-            " If there is no local design file, then create one as a starting point.",
+            " If there is no local design file, then create one as a starting point."
+            " (With --check-only, no file is written and only changes in the design are flagged.)",
             aliases=["auto_design"],
         )
 
     def add_arguments(self, parser):
         group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "-c",
+            "--check-only",
+            help="only advise whether bootstrap would make any changes on the table design file",
+            default=False,
+            action="store_true",
+        )
         group.add_argument(
             "-f", "--force", help="overwrite table design file if it already exists", default=False, action="store_true"
         )
@@ -763,6 +771,7 @@ class BootstrapTransformationsCommand(SubCommand):
             args.table_design_dir,
             local_files,
             args.type if args.type != "UPDATE" else None,
+            check_only=args.check_only,
             update=args.update or args.type == "UPDATE",
             replace=args.force,
             dry_run=args.dry_run,

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -756,7 +756,7 @@ class BootstrapTransformationsCommand(SubCommand):
         )
         parser.add_argument(
             "type",
-            choices=["CTAS", "VIEW", "UPDATE"],
+            choices=["CTAS", "VIEW", "update"],
             help="pick whether to create table designs for 'CTAS' or 'VIEW' relations"
             " or update the current relation",
         )
@@ -770,9 +770,9 @@ class BootstrapTransformationsCommand(SubCommand):
             dw_config.schemas,
             args.table_design_dir,
             local_files,
-            args.type if args.type != "UPDATE" else None,
+            args.type if args.type != "update" else None,
             check_only=args.check_only,
-            update=args.update or args.type == "UPDATE",
+            update=args.update or args.type == "update",
             replace=args.force,
             dry_run=args.dry_run,
         )

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -66,46 +66,47 @@
   },
   # Type information from source (PostgreSQL) to target (Redshift)
   "type_maps": {
-    # Types that may be used "as-is", see also
-    # http://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
-    # The keys are regular expression (with escaped backslashes!) and the
-    # values are the serialization formats in Avro files.
+    # Types that may be used "as-is"
+    # See also # http://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
+    # The keys are regular expression (with escaped backslashes!) and the values are
+    # serialization formats (logical types).
     "as_is_att_type": {
-      "smallint": "int",
-      "integer": "int",
       "bigint": "long",
-      "real": "double",
-      "double precision": "double",
-      "numeric\\(\\d+,\\d+\\)": "string",
       "boolean": "boolean",
       "character\\(\\d+\\)": "string",
       "character varying\\(\\d+\\)": "string",
       "date": "date",
+      "double precision": "double",
+      "integer": "int",
+      "numeric\\(\\d+,\\d+\\)": "string",
+      "real": "double",
+      "smallint": "int",
       "timestamp without time zone": "timestamp"
     },
-    # Map of known PostgreSQL attribute types to usable types in Redshift.
-    # The first element in the list is the new type, the second element is the necessary cast expression,
-    # the third element is the serialization format in Avro files.
-    # Note that in every expression, %s is replaced by the column name within quotes.
+    # Map of known PostgreSQL attribute types to usable types in Redshift
+    # -------------------------------------------------------------------
+    # The first element in the list is the new type, the second element is the necessary cast
+    # expression, the third element is a serialization format.
+    # Note that in every expression, %s is replaced by the column name already within quotes.
     "cast_needed_att_type": {
-      "int4range": ["varchar(65535)", "%s::varchar(65535)", "string"],
-      "integer\\[\\]": ["varchar(65535)", "%s::varchar(65535)", "string"],
       "bigint\\[\\]": ["varchar(65535)", "%s::varchar(65535)", "string"],
+      # The bytea data type is probably not useful, but we'll try to pull it in base64 format.
+      "bytea": ["varchar(65535)", "encode(%s, 'base64')", "string"],
       # NOTE varchar counts characters but Redshift is byte limitations.
       # We are setting the max here to 10k ... you need to evaluate on live table what that the limit should be.
       "character varying": ["varchar(10000)", "%s::varchar(10000)", "string"],
+      # N.B. This requires a PostgreSQL version of 9.3 or better.
+      "hstore": ["varchar(65535)", "public.hstore_to_json(%s)::varchar(65535)", "string"],
+      "int4range": ["varchar(65535)", "%s::varchar(65535)", "string"],
+      "integer\\[\\]": ["varchar(65535)", "%s::varchar(65535)", "string"],
+      "json": ["varchar(65535)", "%s::varchar(65535)", "string"],
+      # The numeric data type without precision and scale should not be used upstream!
+      "numeric": ["decimal(18,4)", "%s::decimal(18,4)", "string"],
       "text": ["varchar(10000)", "%s::varchar(10000)", "string"],
       "time without time zone": ["varchar(256)", "%s::varchar(256)", "string"],
       # CAVEAT EMPTOR This only works if your database is running in UTC.
       "timestamp with time zone": ["timestamp without time zone", "%s::varchar(256)", "timestamp"],
-      "json": ["varchar(65535)", "%s::varchar(65535)", "string"],
-      # N.B. This requires a PostgreSQL version of 9.3 or better.
-      "hstore": ["varchar(65535)", "public.hstore_to_json(%s)::varchar(65535)", "string"],
-      "uuid": ["varchar(36)", "%s::varchar(36)", "uuid"],
-      # The numeric data type without precision and scale should not be used upstream!
-      "numeric": ["decimal(18,4)", "%s::decimal(18,4)", "string"],
-      # The bytea data type is probably not useful, but we'll try to pull it in base64 format.
-      "bytea": ["varchar(65535)", "encode(%s, 'base64')", "string"]
+      "uuid": ["varchar(36)", "%s::varchar(36)", "uuid"]
     },
     # Default type as a fallback solution. Example use case is for enumeration types.
     "default_att_type": ["varchar(10000)", "%s::varchar(10000)", "string"],

--- a/python/etl/design/__init__.py
+++ b/python/etl/design/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from difflib import context_diff
 
 import simplejson as json
 
@@ -130,3 +131,10 @@ class TableDesign:
     def as_string(table_design: dict) -> str:
         # We use JSON pretty printing because it is prettier than YAML printing.
         return json.dumps(table_design, indent="    ", item_sort_key=TableDesign.make_item_sorter()) + "\n"
+
+
+# TODO(tom): This uses the "dict" interface, not the TableDesign class.
+def diff_table_designs(from_design: dict, to_design: dict, from_file: str, to_file: str) -> str:
+    from_lines = TableDesign.as_string(from_design).splitlines(keepends=True)
+    to_lines = TableDesign.as_string(to_design).splitlines(keepends=True)
+    return "".join(context_diff(from_lines, to_lines, fromfile=from_file, tofile=to_file))

--- a/python/etl/design/__init__.py
+++ b/python/etl/design/__init__.py
@@ -1,7 +1,12 @@
 import logging
 import re
+from collections import OrderedDict
+from typing import Dict, List, Optional
 
 import simplejson as json
+from tabulate import tabulate
+
+from etl.relation import RelationDescription
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/design/__init__.py
+++ b/python/etl/design/__init__.py
@@ -1,12 +1,7 @@
 import logging
 import re
-from collections import OrderedDict
-from typing import Dict, List, Optional
 
 import simplejson as json
-from tabulate import tabulate
-
-from etl.relation import RelationDescription
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -16,7 +16,7 @@ import etl.file_sets
 import etl.relation
 import etl.s3
 from etl.config.dw import DataWarehouseSchema
-from etl.design import Attribute, ColumnDefinition
+from etl.design import Attribute, ColumnDefinition, TableDesign
 from etl.names import TableName, TableSelector, join_with_single_quotes
 from etl.relation import RelationDescription
 
@@ -161,7 +161,10 @@ def fetch_constraints(cx: connection, table_name: TableName) -> List[Mapping[str
             columns = list(att["name"] for att in attributes)
             constraint: Mapping[str, List[str]] = {constraint_type: columns}
             logger.info(
-                "Index '%s' of '%s' adds constraint %s", index_name, table_name.identifier, json.dumps(constraint)
+                "Index '%s' of '%s' adds constraint %s",
+                index_name,
+                table_name.identifier,
+                json.dumps(constraint, sort_keys=True),
             )
             found.append(constraint)
     return found
@@ -352,53 +355,12 @@ def create_table_design_for_view(
     return table_design
 
 
-def make_item_sorter():
-    """
-    Return some value that allows sorting keys that appear in any "object" (JSON-speak for dict).
-
-    The sort order makes the resulting order of keys easier to digest by humans.
-
-    Input to the sorter is a tuple of (key, value) from turning a dict into a list of items.
-    Output (return value) of the sorter is a tuple of (preferred order, key name).
-    If a key is not known, it's sorted alphabetically (ignoring case) after all known ones.
-    """
-    preferred_order = [
-        # always (tables, columns, etc.)
-        "name",
-        "description",
-        # only tables
-        "source_name",
-        "unload_target",
-        "depends_on",
-        "constraints",
-        "attributes",
-        "columns",
-        # only columns
-        "sql_type",
-        "type",
-        "expression",
-        "source_sql_type",
-        "not_null",
-        "identity",
-    ]
-    order_lookup = {key: (i, key) for i, key in enumerate(preferred_order)}
-    max_index = len(preferred_order)
-
-    def sort_key(item):
-        key, value = item
-        return order_lookup.get(key, (max_index, key))
-
-    return sort_key
-
-
 def save_table_design(
-    source_dir: str,
-    source_table_name: TableName,
     target_table_name: TableName,
     table_design: dict,
+    filename: str,
     overwrite=False,
     dry_run=False,
-    current_file=False,
 ) -> None:
     """
     Write new table design file to disk.
@@ -426,10 +388,8 @@ def save_table_design(
         return
 
     logger.info("Writing new table design file for '%s' to '%s'", this_table, filename)
-    # We use JSON pretty printing because it is prettier than YAML printing.
     with open(filename, "w") as o:
-        json.dump(table_design, o, indent="    ", item_sort_key=make_item_sorter())
-        o.write("\n")
+        o.write(TableDesign.as_string(table_design))
     logger.debug("Completed writing '%s'", filename)
 
 
@@ -479,7 +439,12 @@ def create_table_designs_from_source(source, selector, local_dir, local_files, d
                 else:
                     target_table_name = TableName(source.name, source_table_name.table)
                     table_design = create_table_design_for_source(conn, source_table_name, target_table_name)
-                    save_table_design(source_dir, source_table_name, target_table_name, table_design, dry_run=dry_run)
+
+                    filename = os.path.join(
+                        source_dir, "{}-{}.yaml".format(source_table_name.schema, source_table_name.table)
+                    )
+                    save_table_design(target_table_name, table_design, filename, dry_run=dry_run)
+
         logger.info("Done with %d table(s) from source '%s'", len(source_tables), source.name)
     except Exception:
         logger.error("Error while processing source '%s'", source.name)
@@ -571,27 +536,39 @@ def bootstrap_transformations(
                 if check_only:
                     if relation.table_design != table_design:
                         print("Change detected in table desing for {:x}".format(relation))
-                        before = json.dumps(relation.table_design, indent="    ", item_sort_key=make_item_sorter())
-                        after = json.dumps(table_design, indent="    ", item_sort_key=make_item_sorter())
+                        before = TableDesign.as_string(relation.table_design)
+                        after = TableDesign.as_string(table_design)
                         print(
                             "".join(
-                                list(
-                                    context_diff(
-                                        before.splitlines(keepends=True),
-                                        after.splitlines(keepends=True),
-                                    )
-                                )[2:]
+                                context_diff(
+                                    before.splitlines(keepends=True),
+                                    after.splitlines(keepends=True),
+                                    fromfile=relation.design_file_name,
+                                    tofile="bootstrap",
+                                )
                             )
                         )
                     continue
 
+                if update and relation.table_design == table_design:
+                    logger.info("No updates detected in table design for {:x}, skipping write".format(relation))
+                    continue
+
                 source_dir = os.path.join(local_dir, relation.source_name)
+
+                if relation.design_file_name is None:
+                    # TODO(tom): Drop the leading schema name for transformations.
+                    filename = os.path.join(
+                        source_dir,
+                        "{}-{}.yaml".format(relation.target_table_name.schema, relation.target_table_name.table),
+                    )
+                else:
+                    filename = relation.design_file_name
+
                 save_table_design(
-                    source_dir,
-                    relation.target_table_name,
                     relation.target_table_name,
                     table_design,
+                    filename,
                     overwrite=update or replace,
                     dry_run=dry_run,
-                    current_file=relation.design_file_name,
                 )

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -571,7 +571,7 @@ def bootstrap_transformations(
             assert (source_name or current_source_name) in ("CTAS", "VIEW")
 
             # Use a quick check of the query plan whether we depend on external schemas.
-            with relation.matching_temporary_view(conn, as_late_binding_view=True) as tmp_view_name:
+            with relation.matching_temporary_view(conn, as_late_binding_view=True):
                 has_s3_scans = any(fetch_dependency_hints(conn, relation.query_stmt))
 
             with relation.matching_temporary_view(conn, as_late_binding_view=has_s3_scans) as tmp_view_name:
@@ -610,16 +610,16 @@ def bootstrap_transformations(
                     continue
 
                 source_dir = os.path.join(local_dir, relation.source_name)
-
-                if relation.design_file_name is None:
-                    # TODO(tom): Drop the leading schema name for transformations.
+                # Derive preferred name from the current design or SQL file.
+                if relation.design_file_name is not None:
+                    filename = relation.design_file_name
+                elif relation.sql_file_name is not None:
+                    filename = re.sub(r".sql$", ".yaml", relation.sql_file_name)
+                else:
                     filename = os.path.join(
                         source_dir,
                         "{}-{}.yaml".format(relation.target_table_name.schema, relation.target_table_name.table),
                     )
-                else:
-                    filename = relation.design_file_name
-
                 save_table_design(
                     relation.target_table_name,
                     table_design,

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -17,7 +17,7 @@ import etl.relation
 import etl.s3
 from etl.config.dw import DataWarehouseSchema
 from etl.design import Attribute, ColumnDefinition, TableDesign
-from etl.names import TableName, TableSelector, join_with_single_quotes
+from etl.names import TableName, TableSelector, TempTableName, join_with_single_quotes
 from etl.relation import RelationDescription
 
 logger = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ def fetch_attributes(cx: connection, table_name: TableName) -> List[Attribute]:
     """Retrieve table definition (column names and types)."""
     # Make sure to turn on "User Parameters" in the Database settings of PyCharm so that `%s`
     # works in the editor.
-    if getattr(table_name, "is_late_binding_view", False):
+    if isinstance(table_name, TempTableName) and table_name.is_late_binding_view:
         stmt = """
             SELECT col_name AS "name"
                  , col_type AS "sql_type"
@@ -171,7 +171,11 @@ def fetch_constraints(cx: connection, table_name: TableName) -> List[Mapping[str
 
 
 def fetch_dependencies(cx: connection, table_name: TableName) -> List[str]:
-    """Lookup dependencies (other tables)."""
+    """
+    Lookup dependencies (other relations).
+
+    Note that this will return an empty list for a late-binding view.
+    """
     # See https://github.com/awslabs/amazon-redshift-utils/blob/master/src/AdminViews/v_constraint_dependency.sql
     stmt = """
         SELECT DISTINCT
@@ -190,6 +194,24 @@ def fetch_dependencies(cx: connection, table_name: TableName) -> List[str]:
         """
     dependencies = etl.db.query(cx, stmt, (table_name.schema, table_name.table))
     return [TableName(**row).identifier for row in dependencies]
+
+
+def fetch_dependency_hints(cx: connection, stmt: str) -> List[str]:
+    """
+    Parse a query plan for hints of which relations we might depend on.
+
+    This is still a bit under construction.
+    """
+    logger.debug("Looking at query plan to find dependencies")
+    s3_scan = re.compile(r"\s*->  S3 (?:Seq Scan|Nested Subquery) (\w+\.\w+) location:")
+    plan = etl.db.explain(cx, stmt)
+
+    dependencies = []
+    for row in plan:
+        match = s3_scan.match(row)
+        if match:
+            dependencies.append(match.groups()[0])
+    return sorted(dependencies)
 
 
 def create_partial_table_design(conn: connection, source_table_name: TableName, target_table_name: TableName):
@@ -241,7 +263,7 @@ def create_table_design_for_source(conn: connection, source_table_name: TableNam
 
 
 def create_partial_table_design_for_transformation(
-    conn: connection, tmp_view_name: TableName, relation: RelationDescription, update_keys: Union[List, None] = None
+    conn: connection, tmp_view_name: TempTableName, relation: RelationDescription, update_keys: Union[List, None] = None
 ):
     """
     Create a partial design that's applicable to transformations.
@@ -258,7 +280,10 @@ def create_partial_table_design_for_transformation(
             del column["expression"]
             del column["source_sql_type"]  # expression and source_sql_type always travel together
 
-    dependencies = fetch_dependencies(conn, tmp_view_name)
+    if tmp_view_name.is_late_binding_view:
+        dependencies = fetch_dependency_hints(conn, relation.query_stmt)
+    else:
+        dependencies = fetch_dependencies(conn, tmp_view_name)
     if dependencies:
         table_design["depends_on"] = dependencies
 
@@ -321,7 +346,7 @@ def update_column_definition(new_column: dict, old_column: dict):
 
 
 def create_table_design_for_ctas(
-    conn: connection, tmp_view_name: TableName, relation: RelationDescription, update: bool
+    conn: connection, tmp_view_name: TempTableName, relation: RelationDescription, update: bool
 ):
     """
     Create new table design for a CTAS.
@@ -336,7 +361,7 @@ def create_table_design_for_ctas(
 
 
 def create_table_design_for_view(
-    conn: connection, tmp_view_name: TableName, relation: RelationDescription, update: bool
+    conn: connection, tmp_view_name: TempTableName, relation: RelationDescription, update: bool
 ):
     """
     Create (and return) new table design suited for a view.
@@ -519,7 +544,11 @@ def bootstrap_transformations(
             current_source_name = relation.kind if relation.design_file_name else None
             assert (source_name or current_source_name) in ("CTAS", "VIEW")
 
-            with relation.matching_temporary_view(conn, assume_external_schema=not update) as tmp_view_name:
+            # Use a quick check of the query plan whether we depend on external schemas.
+            with relation.matching_temporary_view(conn, as_late_binding_view=True) as tmp_view_name:
+                has_s3_scans = any(fetch_dependency_hints(conn, relation.query_stmt))
+
+            with relation.matching_temporary_view(conn, as_late_binding_view=has_s3_scans) as tmp_view_name:
                 try:
                     if (source_name or current_source_name) == "CTAS":
                         table_design = create_table_design_for_ctas(conn, tmp_view_name, relation, update)

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -259,7 +259,7 @@ def create_partial_table_design_for_transformation(
         table_design["depends_on"] = dependencies
 
     if update_keys is not None and relation.design_file_name:
-        logger.info("Experimental update of existing table design file in progress...")
+        logger.info("Update of existing table design file in progress...")
         existing_table_design = relation.table_design
         if "columns" in update_keys:
             # If the old design had added an identity column, we carry it forward
@@ -397,6 +397,7 @@ def save_table_design(
     table_design: dict,
     overwrite=False,
     dry_run=False,
+    current_file=False,
 ) -> None:
     """
     Write new table design file to disk.
@@ -409,19 +410,26 @@ def save_table_design(
     etl.design.load.validate_table_design(table_design, target_table_name)
 
     # TODO(tom): Move this logic into file sets (note that "source_name" is in table_design)
-    filename = os.path.join(source_dir, "{}-{}.yaml".format(source_table_name.schema, source_table_name.table))
+    if current_file is None:
+        filename = os.path.join(source_dir, "{}-{}.yaml".format(source_table_name.schema, source_table_name.table))
+    else:
+        filename = current_file
+
     this_table = target_table_name.identifier
     if dry_run:
         logger.info("Dry-run: Skipping writing new table design file for '%s'", this_table)
-    elif os.path.exists(filename) and not overwrite:
+        return
+
+    if os.path.exists(filename) and not overwrite:
         logger.warning("Skipping writing new table design for '%s' since '%s' already exists", this_table, filename)
-    else:
-        logger.info("Writing new table design file for '%s' to '%s'", this_table, filename)
-        # We use JSON pretty printing because it is prettier than YAML printing.
-        with open(filename, "w") as o:
-            json.dump(table_design, o, indent="    ", item_sort_key=make_item_sorter())
-            o.write("\n")
-        logger.debug("Completed writing '%s'", filename)
+        return
+
+    logger.info("Writing new table design file for '%s' to '%s'", this_table, filename)
+    # We use JSON pretty printing because it is prettier than YAML printing.
+    with open(filename, "w") as o:
+        json.dump(table_design, o, indent="    ", item_sort_key=make_item_sorter())
+        o.write("\n")
+    logger.debug("Completed writing '%s'", filename)
 
 
 def normalize_and_create(directory: str, dry_run=False) -> str:
@@ -513,35 +521,44 @@ def bootstrap_sources(schemas, selector, table_design_dir, local_files, dry_run=
 
 
 def bootstrap_transformations(
-    dsn_etl, schemas, local_dir, local_files, as_view, update=False, replace=False, dry_run=False
+    dsn_etl, schemas, local_dir, local_files, source_name, update=False, replace=False, dry_run=False
 ):
-    """Download design information for transformations by test-running in the data warehouse."""
+    """
+    Download design information for transformations by test-running in the data warehouse.
+
+    "source_name" should be "CTAS" or "VIEW or None (in which case the relation type currently
+    specified will continue to be used).
+    """
     transformation_schema = {schema.name for schema in schemas if schema.has_transformations}
     transforms = [file_set for file_set in local_files if file_set.source_name in transformation_schema]
     if not (update or replace):
+        # Filter down to new transformations (SQL files without matching YAML file).
         transforms = [file_set for file_set in transforms if not file_set.design_file_name]
     if not transforms:
         logger.warning("Found no new queries without matching design files")
         return
+
     relations = [RelationDescription(file_set) for file_set in transforms]
     if update:
         logger.info("Loading existing table design file(s)")
         try:
-            # Unfortunately, this adds warnings about any of the upstream sources being unknown.
-            relations = etl.relation.order_by_dependencies(relations)
+            RelationDescription.load_in_parallel(relations)
         except ValueError as exc:
             logger.error("Failed to load existing design file(s) before update: %s", exc)
             raise
 
-    if as_view:
-        create_func = create_table_design_for_view
-    else:
-        create_func = create_table_design_for_ctas
-
     with closing(etl.db.connection(dsn_etl, autocommit=True)) as conn:
         for relation in relations:
+            # Be careful not to trigger a load of an unknown design file by accessing "kind".
+            current_source_name = relation.kind if relation.design_file_name else None
+            if (source_name or current_source_name) is None:
+                raise RuntimeError("failed to determine CTAS or VIEW for %x" % relation)
+
             with relation.matching_temporary_view(conn, assume_external_schema=not update) as tmp_view_name:
-                table_design = create_func(conn, tmp_view_name, relation, update)
+                if (source_name or current_source_name) == "CTAS":
+                    table_design = create_table_design_for_ctas(conn, tmp_view_name, relation, update)
+                else:
+                    table_design = create_table_design_for_view(conn, tmp_view_name, relation, update)
                 source_dir = os.path.join(local_dir, relation.source_name)
                 save_table_design(
                     source_dir,
@@ -550,4 +567,5 @@ def bootstrap_transformations(
                     table_design,
                     overwrite=update or replace,
                     dry_run=dry_run,
+                    current_file=relation.design_file_name,
                 )

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -3,6 +3,7 @@ import os.path
 import re
 from contextlib import closing
 from datetime import datetime
+from difflib import context_diff
 from typing import List, Mapping, Union
 
 import simplejson as json
@@ -521,7 +522,7 @@ def bootstrap_sources(schemas, selector, table_design_dir, local_files, dry_run=
 
 
 def bootstrap_transformations(
-    dsn_etl, schemas, local_dir, local_files, source_name, update=False, replace=False, dry_run=False
+    dsn_etl, schemas, local_dir, local_files, source_name, check_only=False, update=False, replace=False, dry_run=False
 ):
     """
     Download design information for transformations by test-running in the data warehouse.
@@ -531,7 +532,7 @@ def bootstrap_transformations(
     """
     transformation_schema = {schema.name for schema in schemas if schema.has_transformations}
     transforms = [file_set for file_set in local_files if file_set.source_name in transformation_schema]
-    if not (update or replace):
+    if not (check_only or replace or update):
         # Filter down to new transformations (SQL files without matching YAML file).
         transforms = [file_set for file_set in transforms if not file_set.design_file_name]
     if not transforms:
@@ -539,26 +540,51 @@ def bootstrap_transformations(
         return
 
     relations = [RelationDescription(file_set) for file_set in transforms]
-    if update:
+    if check_only or update or (replace and source_name is None):
         logger.info("Loading existing table design file(s)")
-        try:
-            RelationDescription.load_in_parallel(relations)
-        except ValueError as exc:
-            logger.error("Failed to load existing design file(s) before update: %s", exc)
-            raise
+        RelationDescription.load_in_parallel(relations)
+        # TODO(tom): Collect all errors before dying.
+        for relation in relations:
+            if not relation.design_file_name:
+                raise RuntimeError("failed to load existing design file for {:x}".format(relation))
 
     with closing(etl.db.connection(dsn_etl, autocommit=True)) as conn:
         for relation in relations:
             # Be careful not to trigger a load of an unknown design file by accessing "kind".
             current_source_name = relation.kind if relation.design_file_name else None
-            if (source_name or current_source_name) is None:
-                raise RuntimeError("failed to determine CTAS or VIEW for %x" % relation)
+            assert (source_name or current_source_name) in ("CTAS", "VIEW")
 
             with relation.matching_temporary_view(conn, assume_external_schema=not update) as tmp_view_name:
-                if (source_name or current_source_name) == "CTAS":
-                    table_design = create_table_design_for_ctas(conn, tmp_view_name, relation, update)
-                else:
-                    table_design = create_table_design_for_view(conn, tmp_view_name, relation, update)
+                try:
+                    if (source_name or current_source_name) == "CTAS":
+                        table_design = create_table_design_for_ctas(conn, tmp_view_name, relation, update)
+                    else:
+                        table_design = create_table_design_for_view(conn, tmp_view_name, relation, update)
+                except RuntimeError as exc:
+                    if check_only:
+                        print(f"Failed to create table design for {relation:x}")
+                        print(f"Error: {exc}")
+                        continue
+                    else:
+                        raise
+
+                if check_only:
+                    if relation.table_design != table_design:
+                        print("Change detected in table desing for {:x}".format(relation))
+                        before = json.dumps(relation.table_design, indent="    ", item_sort_key=make_item_sorter())
+                        after = json.dumps(table_design, indent="    ", item_sort_key=make_item_sorter())
+                        print(
+                            "".join(
+                                list(
+                                    context_diff(
+                                        before.splitlines(keepends=True),
+                                        after.splitlines(keepends=True),
+                                    )
+                                )[2:]
+                            )
+                        )
+                    continue
+
                 source_dir = os.path.join(local_dir, relation.source_name)
                 save_table_design(
                     source_dir,

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -261,7 +261,7 @@ def fetch_dependency_hints(cx: connection, stmt: str) -> Optional[List[str]]:
         # Unfortunately the tables aren't qualified with a schema so we can't use the info.
         logger.warning(
             "Found dependencies in S3 AND these not in S3: %s",
-            join_with_quotes(xn_dependencies),
+            join_with_single_quotes(xn_dependencies),
         )
     return sorted(s3_dependencies)
 
@@ -665,7 +665,11 @@ def bootstrap_transformations(
     relations = [RelationDescription(file_set) for file_set in transforms]
     if check_only or update or (replace and source_name is None):
         logger.info("Loading existing table design file(s)")
-        RelationDescription.load_in_parallel(relations)
+        try:
+            RelationDescription.load_in_parallel(relations)
+        except Exception:
+            logger.warning("Make sure that table design files exist and are valid before trying to update")
+            raise
         # TODO(tom): Collect all errors before dying.
         for relation in relations:
             if not relation.design_file_name:

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -32,7 +32,7 @@ def fetch_tables(cx: connection, source: DataWarehouseSchema, selector: TableSel
     The list of tables matching the allowlist but not the denylist can be further narrowed
     down by the pattern in :selector.
     """
-    # Look for 'r'elations (ordinary tables), 'm'aterialized views, and 'v'iews in the catalog.
+    # Look for relations ('r', ordinary tables), materialized views ('m'), and views ('v').
     result = etl.db.query(
         cx,
         """
@@ -259,7 +259,7 @@ def create_partial_table_design(conn: connection, source_table_name: TableName, 
         for attribute in source_attributes
     ]
     table_design = {
-        "name": "%s" % target_table_name.identifier,
+        "name": target_table_name.identifier,
         "description": "",
         "columns": [column.to_dict() for column in target_columns],
     }
@@ -283,7 +283,7 @@ def create_table_design_for_source(conn: connection, source_table_name: TableNam
 
 def create_partial_table_design_for_transformation(
     conn: connection, tmp_view_name: TempTableName, relation: RelationDescription, update_keys: Union[List, None] = None
-):
+) -> dict:
     """
     Create a partial design that's applicable to transformations.
 
@@ -307,68 +307,132 @@ def create_partial_table_design_for_transformation(
     if dependencies:
         table_design["depends_on"] = dependencies
 
-    if update_keys is not None and relation.design_file_name:
-        logger.info("Update of existing table design file in progress...")
-        existing_table_design = relation.table_design
-        if "columns" in update_keys:
-            # If the old design had added an identity column, we carry it forward
-            # here (and always as the first column).
-            identity = [column for column in existing_table_design["columns"] if column.get("identity")]
-            if identity:
-                table_design["columns"][:0] = identity
-                table_design["columns"][0]["encoding"] = "raw"
-            column_lookup = {column["name"]: column for column in existing_table_design["columns"]}
-            for column in table_design["columns"]:
-                update_column_definition(column, column_lookup.get(column["name"], {}))
-        if "description" in update_keys:
-            # Force the "description" to show up to encourage its use, but remove the old
-            # passive-aggressive descriptions.
-            if "description" not in existing_table_design:
-                table_design["description"] = ""
-            elif existing_table_design["description"].startswith(
+    if update_keys is None or relation.design_file_name is None:
+        return table_design
+
+    logger.info("Update of existing table design file for '%s' in progress", relation.identifier)
+    existing_table_design = relation.table_design
+
+    if "description" in update_keys:
+        update_keys.remove("description")
+        if "description" in existing_table_design:
+            # Do not copy the old passive-aggressive descriptions.
+            if not existing_table_design["description"].startswith(
                 ("Automatically generated on", "Automatically updated on")
             ):
-                table_design["description"] = ""
-            else:
                 table_design["description"] = existing_table_design["description"]
-        # Now do the rest of the update keys.
-        for copy_key in (key for key in update_keys if key not in ("columns", "descriptions")):
-            if copy_key in existing_table_design:
-                # TODO(tom): May have to cleanup columns in constraints and attributes!
-                table_design[copy_key] = existing_table_design[copy_key]
+
+    if "columns" in update_keys:
+        update_keys.remove("columns")
+        # If the old design had added an identity column, we carry it forward
+        # here (and always as the first column).
+        identity = [column for column in existing_table_design["columns"] if column.get("identity")]
+        if identity:
+            table_design["columns"][:0] = identity
+            table_design["columns"][0]["encoding"] = "raw"
+
+        existing_column = {column["name"]: column for column in existing_table_design["columns"]}
+        for column in table_design["columns"]:
+            if column["name"] in existing_column:
+                # This modifies in-place until I have more time to fix this.
+                update_column_definition(relation.identifier, column, existing_column[column["name"]])
+
+    # Now do the rest of the update keys which require less attention to details.
+    for copy_key in [key for key in update_keys if key in existing_table_design]:
+        # TODO(tom): May have to cleanup columns in constraints and attributes!
+        table_design[copy_key] = existing_table_design[copy_key]
+
     return table_design
 
 
-def update_column_definition(new_column: dict, old_column: dict):
+def update_column_definition(target_table: str, new_column: dict, old_column: dict) -> dict:
     """
-    Update column definition found automatically with previous information from table design.
+    Update (in place) the bootstrapped column definition with existing information.
 
     This carefully merges the information from inspecting the view created for the transformation
     with information from the existing table design.
 
     Copied directly: "description", "encoding", "references", and "not_null"
     Updated carefully: "sql_type" and "type" (always together)
+
+    >>> update_column_definition("s.t", {
+    ...     "name": "doctest", "sql_type": "integer", "type": "int"
+    ... }, {
+    ...     "name": "doctest", "sql_type": "bigint", "type": "long"
+    ... })
+    {'name': 'doctest', 'sql_type': 'bigint', 'type': 'long'}
+    >>> update_column_definition("s.t", {
+    ...     "name": "doctest", "sql_type": "numeric(18,4)", "type": "string"
+    ... }, {
+    ...     "name": "doctest", "sql_type": "DECIMAL(12, 2)", "type": "string"
+    ... })
+    {'name': 'doctest', 'sql_type': 'numeric(12,2)', 'type': 'string'}
+    >>> update_column_definition("s.t", {
+    ...     "name": "doctest", "sql_type": "character varying(100)", "type": "string"
+    ... }, {
+    ...     "name": "doctest", "sql_type": "Varchar(200)", "type": "string"
+    ... })
+    {'name': 'doctest', 'sql_type': 'character varying(200)', 'type': 'string'}
     """
-    ok_to_copy = frozenset(["description", "encoding", "references", "not_null"])
-    for key in ok_to_copy.intersection(old_column):
-        new_column[key] = old_column[key]
-    if "sql_type" in old_column:
-        old_sql_type = old_column["sql_type"]
-        new_sql_type = new_column["sql_type"]
-        # Upgrade to "larger" type, mostly for keys
+    column_name = new_column["name"]
+    assert old_column["name"] == column_name
+
+    ok_to_copy = frozenset({"description", "encoding", "references", "not_null"})
+    have_old_value = ok_to_copy.intersection(old_column)
+    new_column.update({key: value for key, value in old_column.items() if key in have_old_value})
+
+    # When we update from VIEW to CTAS, there's not much to copy from.
+    if "sql_type" not in old_column:
+        return new_column
+
+    new_sql_type = new_column["sql_type"]
+    old_sql_type = old_column["sql_type"].strip()
+    logger.debug("Trying to update column '%s': new='%s', old='%s'", column_name, new_sql_type, old_sql_type)
+
+    # Upgrade to "larger" type if that was selected previously.
+    if new_sql_type in ("integer", "bigint"):
         if old_sql_type == "bigint" and new_sql_type == "integer":
-            new_column["sql_type"] = "bigint"
-            new_column["type"] = "long"
-        varchar_re = re.compile(r"(?:varchar|character varying)\((?P<size>\d+)\)")
-        old_text = varchar_re.search(old_sql_type)
-        new_text = varchar_re.search(new_sql_type)
-        if old_text and new_text:
-            new_column["sql_type"] = "character varying({})".format(old_text.group("size"))
-        numeric_re = re.compile(r"(?:numeric|decimal)\((?P<precision>\d+),(?P<scale>\d+)\)")
+            new_column.update(sql_type="bigint", type="long")
+            logger.warning("Keeping previous definition of '%s' for column '%s'", new_column["sql_type"], column_name)
+        return new_column
+
+    numeric_re = re.compile(r"(?:numeric|decimal)\(\s*(?P<precision>\d+),\s*(?P<scale>\d+)\)", re.IGNORECASE)
+    new_numeric = numeric_re.search(new_sql_type)
+    if new_numeric:
         old_numeric = numeric_re.search(old_sql_type)
-        new_numeric = numeric_re.search(new_sql_type)
-        if old_numeric and new_numeric:
-            new_column["sql_type"] = "numeric({},{})".format(old_numeric.group("precision"), old_numeric.group("scale"))
+        if old_numeric and new_numeric.groups() != old_numeric.groups():
+            new_column["sql_type"] = "numeric({precision},{scale})".format_map(old_numeric.groupdict())
+            # TODO(tom): Be smarter about precision and scale separately.
+            # TODO(tom): Allow to check for a fixed number of (precision, scale) combinations.
+            logger.warning("Keeping previous definition of '%s' for column '%s'", new_column["sql_type"], column_name)
+        return new_column
+
+    varchar_re = re.compile(r"(?:varchar|character varying)\((?P<size>\d+)\)", re.IGNORECASE)
+    new_text = varchar_re.search(new_sql_type)
+    if new_text:
+        old_text = varchar_re.search(old_sql_type)
+        if old_text:
+            new_size = int(new_text.groupdict()["size"])
+            old_size = int(old_text.groupdict()["size"])
+            if new_size < old_size:
+                logger.debug(
+                    "Found for '%s.%s': '%s', used previously: '%s'",
+                    target_table,
+                    column_name,
+                    new_column["sql_type"],
+                    old_column["sql_type"],
+                )
+                new_column["sql_type"] = "character varying({})".format(old_size)
+                logger.warning(
+                    "Re-using old definition for column '%s.%s': '%s' (please add a cast)",
+                    target_table,
+                    column_name,
+                    new_column["sql_type"],
+                )
+        return new_column
+
+    # Those types above are all that we understand how to update.
+    return new_column
 
 
 def create_table_design_for_ctas(
@@ -590,7 +654,7 @@ def bootstrap_transformations(
 
                 if check_only:
                     if relation.table_design != table_design:
-                        print("Change detected in table desing for {:x}".format(relation))
+                        print("Change detected in table design for {:x}".format(relation))
                         before = TableDesign.as_string(relation.table_design)
                         after = TableDesign.as_string(table_design)
                         print(

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -420,7 +420,7 @@ class RelationDescription:
         return None
 
     @contextmanager
-    def matching_temporary_view(self, conn, assume_external_schema=False):
+    def matching_temporary_view(self, conn, as_late_binding_view=False):
         """
         Create a temporary view (with a name loosely based around the reference passed in).
 
@@ -430,9 +430,9 @@ class RelationDescription:
 
         with etl.db.log_error():
             ddl_stmt = """CREATE OR REPLACE VIEW {} AS\n{}""".format(temp_view, self.query_stmt)
-            if assume_external_schema or any(dep.is_external for dep in self.dependencies):
-                ddl_stmt += "\nWITH NO SCHEMA BINDING"
+            if as_late_binding_view:
                 temp_view.is_late_binding_view = True
+                ddl_stmt += "\nWITH NO SCHEMA BINDING"
 
             logger.info("Creating view '%s' to match relation '%s'", temp_view.identifier, self.identifier)
             etl.db.execute(conn, ddl_stmt)
@@ -791,8 +791,7 @@ if __name__ == "__main__":
 
     import simplejson as json
 
-    from etl.design.bootstrap import make_item_sorter
-    from etl.json_encoder import FancyJsonEncoder
+    import etl.design
 
     config_dir = os.environ.get("DATA_WAREHOUSE_CONFIG", "./config")
     uri_parts = ("file", "localhost", "schemas")
@@ -814,4 +813,4 @@ if __name__ == "__main__":
         descriptions = [d for d in descriptions if selector.match(d.target_table_name)]
 
     native = [d.table_design for d in descriptions]
-    print(json.dumps(native, cls=FancyJsonEncoder, default=str, indent=4, item_sort_key=make_item_sorter()))
+    print(json.dumps(native, indent="    ", item_sort_key=etl.design.TableDesign.make_item_sorter()))

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -125,7 +125,7 @@ def validate_dependencies(conn: Connection, relation: RelationDescription, tmp_v
     dependencies = etl.design.bootstrap.fetch_dependencies(conn, tmp_view_name)
     # We break with tradition and show the list of dependencies such that they can be copied into
     # a design file.
-    logger.info("Dependencies of '%s' per catalog: %s", relation.identifier, json.dumps(dependencies))
+    logger.info("Dependencies of '%s' per catalog: %s", relation.identifier, json.dumps(dependencies, sort_keys=True))
 
     difference = compare_query_to_design(dependencies, relation.table_design.get("depends_on", []))
     if difference:

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -181,11 +181,10 @@ def validate_single_transform(conn: Connection, relation: RelationDescription, k
             validate_dependencies(conn, relation, tmp_view_name)
             validate_column_ordering(conn, relation, tmp_view_name)
     except (ETLConfigError, ETLRuntimeError, psycopg2.Error):
-        if keep_going:
-            _error_occurred.set()
-            logger.exception("Ignoring failure to validate '%s' and proceeding as requested:", relation.identifier)
-        else:
+        if not keep_going:
             raise
+        _error_occurred.set()
+        logger.exception("Ignoring failure to validate '%s' and proceeding as requested:", relation.identifier)
 
 
 def validate_transforms(dsn: dict, relations: List[RelationDescription], keep_going: bool = False) -> None:

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -117,15 +117,15 @@ def compare_query_to_design(from_query: Iterable, from_design: Iterable) -> Opti
 def validate_dependencies(conn: Connection, relation: RelationDescription, tmp_view_name: TempTableName) -> None:
     """Download the dependencies (based on a temporary view) and compare with table design."""
     if tmp_view_name.is_late_binding_view:
-        logger.warning(
-            "Dependencies of '%s' cannot be verified because it depends on an external table", relation.identifier
-        )
-        return
-
-    dependencies = etl.design.bootstrap.fetch_dependencies(conn, tmp_view_name)
-    # We break with tradition and show the list of dependencies such that they can be copied into
-    # a design file.
-    logger.info("Dependencies of '%s' per catalog: %s", relation.identifier, json.dumps(dependencies, sort_keys=True))
+        dependencies = etl.design.bootstrap.fetch_dependency_hints(conn, relation.query_stmt)
+        method = "query plan"
+    else:
+        dependencies = etl.design.bootstrap.fetch_dependencies(conn, tmp_view_name)
+        method = "catalog"
+    # Show a JSON-friendly list of dependencies such that they can be copied into a design file.
+    logger.info(
+        "Dependencies of '%s' per %s: %s", relation.identifier, method, json.dumps(dependencies, sort_keys=True)
+    )
 
     difference = compare_query_to_design(dependencies, relation.table_design.get("depends_on", []))
     if difference:
@@ -178,8 +178,9 @@ def validate_single_transform(conn: Connection, relation: RelationDescription, k
     With a view created, we can extract dependency information and a list of columns
     to make sure table design and query match up.
     """
+    has_external_dependencies = any(dependency.is_external for dependency in relation.dependencies)
     try:
-        with relation.matching_temporary_view(conn) as tmp_view_name:
+        with relation.matching_temporary_view(conn, as_late_binding_view=has_external_dependencies) as tmp_view_name:
             validate_dependencies(conn, relation, tmp_view_name)
             validate_column_ordering(conn, relation, tmp_view_name)
     except (ETLConfigError, ETLRuntimeError, psycopg2.Error):

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -122,10 +122,7 @@ def validate_dependencies(conn: Connection, relation: RelationDescription, tmp_v
     else:
         dependencies = etl.design.bootstrap.fetch_dependencies(conn, tmp_view_name)
         method = "catalog"
-    # Show a JSON-friendly list of dependencies such that they can be copied into a design file.
-    logger.info(
-        "Dependencies of '%s' per %s: %s", relation.identifier, method, json.dumps(dependencies, sort_keys=True)
-    )
+    logger.info("Dependencies of '%s' per %s: %s", relation.identifier, method, join_with_quotes(dependencies))
 
     difference = compare_query_to_design(dependencies, relation.table_design.get("depends_on", []))
     if difference:

--- a/python/etl/validate.py
+++ b/python/etl/validate.py
@@ -26,7 +26,6 @@ from operator import attrgetter
 from typing import Iterable, List, Optional
 
 import psycopg2
-import simplejson as json
 from psycopg2.extensions import connection as Connection  # only for type annotation
 
 import etl.db
@@ -121,10 +120,12 @@ def validate_dependencies(conn: Connection, relation: RelationDescription, tmp_v
         if dependencies is None:
             logger.warning("Unable to validate '%s' which depends on external tables", relation.identifier)
             return
-        logger.info("Dependencies of '%s' per query plan: %s", relation.identifier, join_with_quotes(dependencies))
+        logger.info(
+            "Dependencies of '%s' per query plan: %s", relation.identifier, join_with_single_quotes(dependencies)
+        )
     else:
         dependencies = etl.design.bootstrap.fetch_dependencies(conn, tmp_view_name)
-        logger.info("Dependencies of '%s' per catalog: %s", relation.identifier, join_with_quotes(dependencies))
+        logger.info("Dependencies of '%s' per catalog: %s", relation.identifier, join_with_single_quotes(dependencies))
 
     difference = compare_query_to_design(dependencies, relation.table_design.get("depends_on", []))
     if difference:


### PR DESCRIPTION
## Initial motivation (internal changes)

This PR patches the current bug where the list of dependencies is left empty on the initial `bootstrap_transformations`. (Subsequent runs with `--update` added the list correctly.). We will now check the query to see whether it will use an external schema (which requires late binding views for our analysis). If it doesn't, we'll find the list of dependencies based on `pg_catalog` tables. If it does, we'll use the query plan to guess the required external tables.

## Workflow (transformations)

### Initial run

To create the initial table design based on the a query, say in `schemas/staging/staging-users.sql`, run:
```
arthur.py bootstrap_transformations CTAS staging.users
arthur.py bootstrap_transformations VIEW staging.users
```

### Updates

After changing the query or making changes to the table design file, run:
```
arthur.py bootstrap_transformations update staging.users
```

### Switching between CTAS and VIEW

#### Switching to a CTAS
```
arthur.py bootstrap_transformations --update CTAS staging.users
```

#### Switching to a VIEW
```
arthur.py bootstrap_transformations --update VIEW staging.users
```

(Note that you will lose some information like not-null constraints or encodings when running this switch.)

## Validation or Bootstrap Check-Only?

This command will only check content but not the exact format:
```
arthur.py validate staging.users
```

This command will check content and format:
```
arthur.py bootstrap_transformations check-only staging.users
```

## Workflow (sources)

It is now possible to update table design files for upstream sources:
```
arthur.py bootstrap_sources web_app.users
arthur.py bootstrap_sources --update web_app.users
```