### PR TITLE
Improve tags of EC2 instances, reduce launch noise

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -89,14 +89,16 @@ python3 -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
 # Update instance name to tie it back to the EMR cluster
 TMP_DOCUMENT="$PROJ_TEMP/document"
 trap "rm -f '$TMP_DOCUMENT'" EXIT
-curl --silent --show-error http://169.254.169.254/latest/dynamic/instance-identity/document | tee "$TMP_DOCUMENT"
+curl --silent --show-error http://169.254.169.254/latest/dynamic/instance-identity/document |
+tee "$TMP_DOCUMENT"
 echo
 
 INSTANCE_ID=$(jq -r ".instanceId" "$TMP_DOCUMENT")
 REGION=$(jq -r ".region" "$TMP_DOCUMENT")
 JOB_FLOW_ID=$(
     aws ec2 describe-tags --region "$REGION" \
-        --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=aws:elasticmapreduce:job-flow-id" |
+        --filters "Name=resource-id,Values=$INSTANCE_ID" \
+            "Name=key,Values=aws:elasticmapreduce:job-flow-id" |
     jq -r ".Tags[0].Value // empty"
 )
 if [[ -n "$INSTANCE_ID" ]]; then

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -8,24 +8,25 @@ PROJ_PACKAGES="awscli jq libyaml-devel postgresql procps-ng python3 python3-deve
 
 PROJ_TEMP="/tmp/$PROJ_NAME"
 
-show_usage_and_exit () {
-    cat <<EOF
+show_usage_and_exit() {
+    cat <<USAGE
 
-Usage: `basename $0` <bucket_name> <environment>
+Usage: $(basename $0) <bucket_name> <environment>
 
 Download files from the S3 bucket into $PROJ_TEMP on this instance
 and install the Python code in a virtual environment.
-We will also try to set tags for this instance.
-EOF
+
+If we find this instance is part of an EMR cluster, we'll update the tag "Name" accordingly.
+USAGE
     exit ${1-0}
 }
 
-log () {
+log() {
     set +o xtrace
-    echo "`date '+%Y-%m-%d %H:%M:%S %Z'`: $*"
+    echo "$(date '+%Y-%m-%d %H:%M:%S %Z'): $*"
 }
 
-if [[ ${1-"-h"} = "-h" ]]; then
+if [[ ${1-"-h"} == "-h" ]]; then
     show_usage_and_exit
 fi
 
@@ -76,33 +77,41 @@ python3 -m pip install --requirement ./jars/requirements.txt
 # This trick with sed transforms project-<dotted version>.tar.gz into project.<dotted_version>.tar.gz
 # so that the sort command can split correctly on '.' with the -t option.
 # We then use the major (3), minor (4) and patch (5) version to sort numerically in reverse order.
-LATEST_TAR_FILE=`
+LATEST_TAR_FILE=$(
     ls -1 ./jars/ |
     sed -n "s:${PROJ_NAME}-:${PROJ_NAME}.:p" |
     sort -t. -n -r -k 3,3 -k 4,4 -k 5,5 |
     sed "s:${PROJ_NAME}\.:${PROJ_NAME}-:" |
-    head -1`
+    head -1
+)
 python3 -m pip install --upgrade "./jars/$LATEST_TAR_FILE"
 
-# Update instance tags
+# Update instance name to tie it back to the EMR cluster
 TMP_DOCUMENT="$PROJ_TEMP/document"
 trap "rm -f '$TMP_DOCUMENT'" EXIT
 curl --silent --show-error http://169.254.169.254/latest/dynamic/instance-identity/document | tee "$TMP_DOCUMENT"
 echo
-INSTANCE_ID=`jq -r ".instanceId" "$TMP_DOCUMENT"`
-REGION=`jq -r ".region" "$TMP_DOCUMENT"`
-JOB_FLOW_ID=$( aws ec2 describe-tags --region "$REGION" \
-                   --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=aws:elasticmapreduce:job-flow-id" |
-               jq -r ".Tags[0].Value // empty" )
 
+INSTANCE_ID=$(jq -r ".instanceId" "$TMP_DOCUMENT")
+REGION=$(jq -r ".region" "$TMP_DOCUMENT")
+JOB_FLOW_ID=$(
+    aws ec2 describe-tags --region "$REGION" \
+        --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=aws:elasticmapreduce:job-flow-id" |
+    jq -r ".Tags[0].Value // empty"
+)
 if [[ -n "$INSTANCE_ID" ]]; then
+    INSTANCE_NAME="Arthur ETL ($BUCKET_NAME\, $ENVIRONMENT)"
     if [[ -n "$JOB_FLOW_ID" ]]; then
-        INSTANCE_NAME="$PROJ_NAME ($BUCKET_NAME\, $ENVIRONMENT\, $JOB_FLOW_ID)"
-    else
-        INSTANCE_NAME="$PROJ_NAME ($BUCKET_NAME\, $ENVIRONMENT)"
+        INSTANCE_NAME="Arthur ETL ($BUCKET_NAME\, $ENVIRONMENT\, $JOB_FLOW_ID)"
+        log "Changing 'Name' tag of $INSTANCE_ID to '$INSTANCE_NAME'"
+        aws ec2 create-tags --resources "$INSTANCE_ID" --region "$REGION" \
+            --tags "Key=Name,Value=$INSTANCE_NAME"
     fi
-    aws ec2 create-tags --resources "$INSTANCE_ID" --region "$REGION" --tags Key=Name,Value="$INSTANCE_NAME"
-    aws ec2 create-tags --resources "$INSTANCE_ID" --region "$REGION" --tags Key=user:name,Value="$INSTANCE_NAME"
+    # Note that Data Pipeline enforces tags separately so this has no effect in a pipeline :(
+    aws ec2 create-tags --resources "$INSTANCE_ID" --region "$REGION" \
+        --tags "Key=user:instance-name,Value=$INSTANCE_NAME"
+else
+    log "Failed to find instance id?"
 fi
 
 log "Finished \"$0 $BUCKET_NAME $ENVIRONMENT\""

--- a/python/etl/templates/ec2_instance.json
+++ b/python/etl/templates/ec2_instance.json
@@ -21,7 +21,7 @@
             "Tags": [
                 {
                     "Key": "Name",
-                    "Value": "redshift_etl (running bootstrap...)"
+                    "Value": "Arthur ETL (Initializing...)"
                 },
                 {
                     "Key": "user:project",

--- a/python/scripts/install_extraction_pipeline.sh
+++ b/python/scripts/install_extraction_pipeline.sh
@@ -49,7 +49,7 @@ fi
 set -o xtrace
 
 # Note: "key" and "value" are lower-case keywords here.
-AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=extraction"
 
 PIPELINE_NAME="Extraction Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"

--- a/python/scripts/install_pizza_load_pipeline.sh
+++ b/python/scripts/install_pizza_load_pipeline.sh
@@ -46,7 +46,7 @@ fi
 set -o xtrace
 
 # Note: "key" and "value" are lower-case keywords here.
-AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=pizza"
 
 PIPELINE_NAME="ETL Pizza Loader Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"

--- a/python/scripts/install_rebuild_pipeline.sh
+++ b/python/scripts/install_rebuild_pipeline.sh
@@ -48,7 +48,7 @@ fi
 set -o xtrace
 
 # Note: "key" and "value" are lower-case keywords here.
-AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=rebuild"
 
 PIPELINE_NAME="ETL Rebuild Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"

--- a/python/scripts/install_refresh_pipeline.sh
+++ b/python/scripts/install_refresh_pipeline.sh
@@ -52,7 +52,7 @@ fi
 set -o xtrace
 
 # Note: "key" and "value" are lower-case keywords here.
-AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=refresh"
 
 PIPELINE_NAME="ETL Refresh Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -46,7 +46,7 @@ fi
 set -o xtrace
 
 # Note: "key" and "value" are lower-case keywords here.
-AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=upgrade"
 
 PIPELINE_NAME="Upgrade Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -54,7 +54,7 @@ else
 fi
 
 # Note: "key" and "value" are lower-case keywords here.
-AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl"
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=validation"
 
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"

--- a/python/scripts/launch_ec2_instance.sh
+++ b/python/scripts/launch_ec2_instance.sh
@@ -87,7 +87,7 @@ aws ec2 create-tags --resources "$INSTANCE_ID" --tags "Key=Name,Value=$INSTANCE_
 
 PUBLIC_DNS_NAME=$(
     aws ec2 describe-instances --instance-ids "$INSTANCE_ID" |
-        jq --raw-output '.Reservations[0].Instances[0].PublicDnsName'
+    jq --raw-output '.Reservations[0].Instances[0].PublicDnsName'
 )
 
 set +x +v

--- a/python/scripts/launch_ec2_instance.sh
+++ b/python/scripts/launch_ec2_instance.sh
@@ -12,8 +12,9 @@ set -e -u
 show_usage_and_exit() {
     cat <<USAGE
 
-Usage: `basename $0` [<environment>]
+Usage: $(basename $0) [<environment>]
 
+Start a new EC2 instance tied to the given environment.
 The environment defaults to "$DEFAULT_PREFIX".
 
 USAGE
@@ -21,15 +22,15 @@ USAGE
 }
 
 while getopts ":h" opt; do
-  case $opt in
-    h)
-      show_usage_and_exit
-      ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      exit 1
-      ;;
-  esac
+    case $opt in
+        h)
+            show_usage_and_exit
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
 done
 
 if [[ $# -gt 1 ]]; then
@@ -40,17 +41,18 @@ set -x
 
 # === Basic configuration ===
 
-PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
-PROJ_ENVIRONMENT=$( arthur.py show_value --prefix "${1-$DEFAULT_PREFIX}" object_store.s3.prefix )
+PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
+PROJ_ENVIRONMENT=$(arthur.py show_value --prefix "${1-$DEFAULT_PREFIX}" object_store.s3.prefix)
 
 # === Derived configuration ===
 
-INSTANCE_NAME="Arthur (env=$PROJ_ENVIRONMENT\, user=$DEFAULT_PREFIX\, `date '+%s'`)"
+# This is more specific and allows us to see who started the instance.
+INSTANCE_NAME="Arthur ETL ($PROJ_BUCKET\, $PROJ_ENVIRONMENT\, user=$DEFAULT_PREFIX\, $(date '+%s'))"
 
 # === Validate bucket and environment information (sanity check on args) ===
 
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
-if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
+if ! aws s3 ls "$BOOTSTRAP" >/dev/null; then
     set +x
     echo "Failed to find \"$BOOTSTRAP\""
     echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
@@ -59,17 +61,19 @@ fi
 
 # === Fill in config templates ===
 
-CLI_INPUT_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compact ec2_instance )
-USER_DATA_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compact cloud_init )
+CLI_INPUT_JSON=$(arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compact ec2_instance)
+USER_DATA_JSON=$(arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compact cloud_init)
 
 # ===  Start instance ===
 
 INSTANCE_ID_FILE="/tmp/instance_id_${USER}$$.json"
 trap "rm -f \"$INSTANCE_ID_FILE\"" EXIT
 
-aws ec2 run-instances --cli-input-json "$CLI_INPUT_JSON" --user-data "$USER_DATA_JSON" | tee "$INSTANCE_ID_FILE"
+aws ec2 run-instances --cli-input-json "$CLI_INPUT_JSON" --user-data "$USER_DATA_JSON" |
+    tee "$INSTANCE_ID_FILE" |
+    jq '.Instances[] | {Monitoring: .Monitoring, InstanceId: .InstanceId, ImageId: .ImageId}'
 
-INSTANCE_ID=`jq --raw-output < "$INSTANCE_ID_FILE" '.Instances[0].InstanceId'`
+INSTANCE_ID=$(jq --raw-output '.Instances[0].InstanceId' <"$INSTANCE_ID_FILE")
 
 if [[ -z "$INSTANCE_ID" ]]; then
     set +x
@@ -79,13 +83,16 @@ fi
 
 aws ec2 wait instance-exists --instance-ids "$INSTANCE_ID"
 aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+aws ec2 create-tags --resources "$INSTANCE_ID" --tags "Key=Name,Value=$INSTANCE_NAME"
 
-PUBLIC_DNS_NAME=`aws ec2 describe-instances --instance-ids "$INSTANCE_ID" |
-    jq --raw-output '.Reservations[0].Instances[0].PublicDnsName'`
+PUBLIC_DNS_NAME=$(
+    aws ec2 describe-instances --instance-ids "$INSTANCE_ID" |
+        jq --raw-output '.Reservations[0].Instances[0].PublicDnsName'
+)
 
 set +x +v
 
-KEYPAIR=$( arthur.py show_value resources.key_name )
+KEYPAIR=$(arthur.py show_value resources.key_name)
 
 cat <<EOF
 # Give the EC2 instance a few more seconds to bootstrap before you try logging in with:

--- a/python/scripts/launch_emr_cluster.sh
+++ b/python/scripts/launch_emr_cluster.sh
@@ -17,6 +17,7 @@ show_usage_and_exit() {
 
 Usage: `basename $0` [<environment>]
 
+Start an EMR cluster in AWS for running ETL steps.
 The environment defaults to "$DEFAULT_PREFIX".
 
 USAGE
@@ -72,7 +73,6 @@ APPLICATION_ENV_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT" -
 EC2_ATTRIBUTES_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compact ec2_attributes )
 BOOTSTRAP_ACTIONS_JSON=$( arthur.py render_template --prefix "$PROJ_ENVIRONMENT" --compact bootstrap_actions )
 EMR_SERVICE_ROLE=$( arthur.py show_value resources.DataPipeline.role )
-AWS_TAGS="user:project=data-warehouse user:sub-project=dw-etl"
 
 # ===  Start cluster ===
 
@@ -83,7 +83,7 @@ aws emr create-cluster \
         --name "$CLUSTER_NAME" \
         --release-label "$CLUSTER_RELEASE_LABEL" \
         --applications "$CLUSTER_APPLICATIONS" \
-        --tags $AWS_TAGS \
+        --tags "user:project=data-warehouse" "user:sub-project=dw-etl" "Name=Arthur ETL EMR Cluster starting" \
         --log-uri "$CLUSTER_LOGS" \
         --enable-debugging \
         --region "$CLUSTER_REGION" \
@@ -110,7 +110,9 @@ sleep 10
 aws emr wait cluster-running --cluster-id "$CLUSTER_ID"
 
 set +x +v
-say "Your cluster is now running. All functions appear normal." || echo "Your cluster is now running. All functions appear normal."
+type say 2>/dev/null &&
+say "Your cluster is now running. All functions appear normal." ||
+echo "Your cluster is now running. All functions appear normal."
 
 KEYPAIR=$( arthur.py show_value resources.key_name )
 


### PR DESCRIPTION
Motivation: use `jq` to reduce the output from the launch script to meaningful values:
```
    jq '.Instances[] | {Monitoring: .Monitoring, InstanceId: .InstanceId, ImageId: .ImageId}'
```

Related changes:
* The bootstrap script now only change the `Name` tag on instances for those from an EMR cluster.
* One-off instances set the name in the launch script and instances in a data pipeline get their `Name` reset by the data pipeline system.
* This change popped into this PR because it was confusing why the launch script didn't have control over `Name`.

Follow-up:
* We should add more tags to the data pipeline (like environment or bucket), knowing that we can't do this on the instance level.

General changes
* Change formatting to follow our `.editorconfig`
* Use descriptive tokens in "here" docs
* Prefer `$( ... )` over backticks
* Use `function_name() {`