### PR TITLE
Escape . from schema.table as schema[.]table

### DIFF
--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -210,10 +210,12 @@ class LoadableRelation:
     def query_stmt(self) -> str:
         stmt = self._relation_description.query_stmt
         if self.use_staging:
-            # Rewrite the query to use staging schemas:
+            # Rewrite the query to use staging schemas by changing identifiers to their staging
+            # version. This requires all tables to be fully qualified. There is a small chance
+            # that we're too aggressive and change a table name inside a string.
             for dependency in self.dependencies:
                 staging_dependency = dependency.as_staging_table_name()
-                stmt = re.sub(r"\b" + dependency.identifier + r"\b", staging_dependency.identifier, stmt)
+                stmt = re.sub(dependency.identifier_as_re, staging_dependency.identifier, stmt)
         return stmt
 
     @property

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -9,6 +9,7 @@ by a pattern from the command line.
 """
 
 import fnmatch
+import re
 import uuid
 from typing import List, Optional
 
@@ -151,6 +152,22 @@ class TableName:
         'hello.world'
         """
         return "{}.{}".format(*self.to_tuple())
+
+    @property
+    def identifier_as_re(self) -> str:
+        r"""
+        Return a regular expression that would look for the (unquoted) identifier.
+
+        >>> tn = TableName("dw", "fact")
+        >>> tn.identifier_as_re
+        '\\bdw\\.fact\\b'
+        >>> import re
+        >>> re.match(tn.identifier_as_re, "dw.fact") is not None
+        True
+        >>> re.match(tn.identifier_as_re, "dw_fact") is None
+        True
+        """
+        return r"\b{}\b".format(re.escape(self.identifier))
 
     @property
     def is_managed(self) -> bool:


### PR DESCRIPTION
We're rewriting queries while building them so that we can build them in a staging schema. A bug crept in when a CTE had the same name as an upstream table on which the target table depended on.

Example:
```
WITH dw_fact AS (
  SELECT ... 
  FROM dw.fact
)
SELECT ..
FROM dw_fact
```

Before this fix:
```
WITH etl_staging$dw.fact AS (
  SELECT ... 
  FROM etl_staging$dw.fact
)
SELECT ..
FROM etl_staging$dw.fact
```

After this fix:
```
WITH dw_fact AS (
  SELECT ... 
  FROM etl_staging$dw.fact
)
SELECT ..
FROM dw_fact
```


