### PR TITLE
Add "run_query" command

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -31,6 +31,7 @@ _arthur_completion()
                 promote_schemas
                 query_events
                 render_template
+                run_query
                 selftest
                 settings
                 show_ddl

--- a/python/etl/text.py
+++ b/python/etl/text.py
@@ -136,6 +136,7 @@ def format_lines(value_rows, header_row=None, has_header=False, max_column_width
     Traceback (most recent call last):
     ValueError: unexpected row length: got 1, expected 2
     """
+    # TODO(tom): Open issue - Use tabulate from pypi #79
     if header_row is not None and has_header is True:
         raise ValueError("cannot have separate header row and mark first row as header")
     # Make sure that we are working with a list of lists of strings (and not generators and such).


### PR DESCRIPTION
This adds a new command `run_query` so that we see the result of queries underlying tables or views:
```
arthur.py run_query dw.fact
arthur.py run_query dw.fact --limit 10
```
