### PR TITLE
Add UUID type

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -101,7 +101,7 @@
       "json": ["varchar(65535)", "%s::varchar(65535)", "string"],
       # N.B. This requires a PostgreSQL version of 9.3 or better.
       "hstore": ["varchar(65535)", "public.hstore_to_json(%s)::varchar(65535)", "string"],
-      "uuid": ["varchar(36)", "%s::varchar(36)", "string"],
+      "uuid": ["varchar(36)", "%s::varchar(36)", "uuid"],
       # The numeric data type without precision and scale should not be used upstream!
       "numeric": ["decimal(18,4)", "%s::decimal(18,4)", "string"],
       # The bytea data type is probably not useful, but we'll try to pull it in base64 format.

--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -39,14 +39,15 @@
             "description": "Generic type modeled loosely after Avro and Hive with easy mapping to those",
             "enum": [
                 "boolean",
+                "date",
+                "decimal",
+                "double",
+                "float",
                 "int",
                 "long",
-                "float",
-                "double",
-                "decimal",
                 "string",
                 "timestamp",
-                "date"
+                "uuid"
             ]
         },
         "compression_encoding": {


### PR DESCRIPTION
Adds a `uuid` type to the others like `int`, `string` etc. When the upstream table has a `uuid` column, its type is carried into the table design.

Having a dedicated type for UUID columns gives us additional information that we may validate later or to use these columns in partitioning during extract. (This PR just lays the groundwork.)

Also, let's try to keep things organized, possibly alphabetically.

Closes #338 