### PR TITLE
Make sure to create all groups when loading warehouse

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -17,6 +17,7 @@ _arthur_completion()
                 auto_design
                 bootstrap_sources
                 bootstrap_transformations
+                create_groups
                 create_index
                 create_schemas
                 create_user

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -583,7 +583,9 @@ class CreateGroupsCommand(SubCommand):
             "create_groups",
             "create all groups from the configuration",
             "Make sure that all groups mentioned in the configuration file actually exist."
-            " This allows to specify a group where the user is not also in the configuration.",
+            " (This allows to specify a group (as reader or writer) on a schema when that"
+            " group does not appear with a user and thus may not have been previously"
+            " created using a 'create_user' call.)",
         )
 
     def add_arguments(self, parser):

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -293,6 +293,7 @@ def build_full_parser(prog_name):
         # Commands to deal with data warehouse as admin:
         InitializeSetupCommand,
         ShowRandomPassword,
+        CreateGroupsCommand,
         CreateUserCommand,
         UpdateUserCommand,
         # Commands to help with table designs and uploading them
@@ -574,6 +575,23 @@ class ShowRandomPassword(SubCommand):
         random_password = uuid.uuid4().hex
         example_password = random_password[:16].upper() + random_password[16:].lower()
         print(example_password)
+
+
+class CreateGroupsCommand(SubCommand):
+    def __init__(self):
+        super().__init__(
+            "create_groups",
+            "create all groups from the configuration",
+            "Make sure that all groups mentioned in the configuration file actually exist."
+            " This allows to specify a group where the user is not also in the configuration.",
+        )
+
+    def add_arguments(self, parser):
+        add_standard_arguments(parser, ["dry-run"])
+
+    def callback(self, args, config):
+        with etl.db.log_error():
+            etl.data_warehouse.create_groups(dry_run=args.dry_run)
 
 
 class CreateUserCommand(SubCommand):

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -259,9 +259,11 @@ def initial_setup(config, with_user_creation=False, force=False, dry_run=False):
             "Refused to initialize non-validation database '%s' without the --force option" % database_name
         )
     # Create all defined users which includes the ETL user needed before next step (so that
-    # database is owned by ETL)
+    # database is owned by ETL). Also create all groups referenced in the configuration.
     if with_user_creation:
+        groups = sorted(group for schema in config.schemas for group in schema.groups)
         with closing(etl.db.connection(config.dsn_admin, autocommit=True, readonly=dry_run)) as conn:
+            _create_groups(conn, groups, dry_run=dry_run)
             for user in config.users:
                 _create_or_update_cluster_user(conn, user, dry_run=dry_run)
 

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -14,9 +14,9 @@ For user management, we require to have passwords for all declared users in a ~/
 
 import logging
 from contextlib import closing
-from typing import List, Optional
+from typing import Iterable, List
 
-from psycopg2.extensions import connection  # only for type annotation
+from psycopg2.extensions import connection as Connection  # only for typing
 
 import etl.commands
 import etl.config
@@ -143,7 +143,7 @@ def publish_schemas(schemas: List[DataWarehouseSchema], dry_run=False) -> None:
     _promote_schemas(schemas, "staging", dry_run=dry_run)
 
 
-def grant_schema_permissions(conn: connection, schema: DataWarehouseSchema) -> None:
+def grant_schema_permissions(conn: Connection, schema: DataWarehouseSchema) -> None:
     """Grant usage & select on all tables, grant write on all tables only to writers."""
     for reader_group in schema.reader_groups:
         etl.db.grant_usage(conn, schema.name, reader_group)
@@ -153,7 +153,7 @@ def grant_schema_permissions(conn: connection, schema: DataWarehouseSchema) -> N
         etl.db.grant_select_and_write_on_all_tables_in_schema(conn, schema.name, writer_group)
 
 
-def revoke_schema_permissions(conn: connection, schema: DataWarehouseSchema) -> None:
+def revoke_schema_permissions(conn: Connection, schema: DataWarehouseSchema) -> None:
     """Revoke usage & select on all tables, also revoke write on all tables from writers."""
     for reader_group in schema.reader_groups:
         etl.db.revoke_usage(conn, schema.name, reader_group)
@@ -163,42 +163,33 @@ def revoke_schema_permissions(conn: connection, schema: DataWarehouseSchema) -> 
         etl.db.revoke_select_and_write_on_all_tables_in_schema(conn, schema.name, writer_group)
 
 
-def create_groups(groups: Optional[List[str]] = None, dry_run=False) -> None:
+def create_groups(dry_run=False) -> None:
     """Create all groups from the data warehouse configuration or just those passed in."""
     config = etl.config.get_dw_config()
-    config_groups = frozenset(group for schema in config.schemas for group in schema.groups)
-    if groups is None:
-        selected_groups = sorted(config_groups)
-    else:
-        for group in groups:
-            if group not in config_groups:
-                raise ValueError("group has not been configured: '{}'".format(group))
-        selected_groups = sorted(groups)
-    with closing(etl.db.connection(config.dsn_admin_on_etl_db, autocommit=True, readonly=dry_run)) as conn:
-        _create_groups(conn, selected_groups, dry_run=dry_run)
+    groups = sorted(frozenset(group for schema in config.schemas for group in schema.groups))
+    with closing(etl.db.connection(config.dsn_admin_on_etl_db, readonly=dry_run)) as conn:
+        _create_groups(conn, groups, dry_run=dry_run)
 
 
-def _create_groups(conn: connection, groups: List[str], dry_run=False) -> None:
+def _create_groups(conn: Connection, groups: Iterable[str], dry_run=False) -> None:
     """Make sure that all groups in the list exist."""
     with conn:
         for group in groups:
-            if not etl.db.group_exists(conn, group):
-                if dry_run:
-                    logger.info("Dry-run: Skipping creating group '%s'", group)
-                else:
-                    logger.info("Creating group '%s'", group)
-                    etl.db.create_group(conn, group)
+            if etl.db.group_exists(conn, group):
+                continue
+            if dry_run:
+                logger.info("Dry-run: Skipping creating group '%s'", group)
+                continue
+            logger.info("Creating group '%s'", group)
+            etl.db.create_group(conn, group)
 
 
-def _create_or_update_cluster_user(conn: connection, user, only_update=False, dry_run=False):
+def _create_or_update_user(conn: Connection, user, only_update=False, dry_run=False):
     """
     Create user in its group, or add user to its group.
 
-    If the user's group does not exist, it is automatically created.
-    The connection may point to 'dev' database since users are not tied to a database (but the
-    cluster).
+    The connection may point to 'dev' database since users are tied to the cluster, not a database.
     """
-    _create_groups(conn, [user.group], dry_run=dry_run)
     with conn:
         if only_update or etl.db.user_exists(conn, user.name):
             if dry_run:
@@ -261,35 +252,33 @@ def initial_setup(config, with_user_creation=False, force=False, dry_run=False):
     # Create all defined users which includes the ETL user needed before next step (so that
     # database is owned by ETL). Also create all groups referenced in the configuration.
     if with_user_creation:
-        groups = sorted(group for schema in config.schemas for group in schema.groups)
-        with closing(etl.db.connection(config.dsn_admin, autocommit=True, readonly=dry_run)) as conn:
+        groups = sorted(frozenset(group for schema in config.schemas for group in schema.groups))
+        with closing(etl.db.connection(config.dsn_admin, readonly=dry_run)) as conn:
             _create_groups(conn, groups, dry_run=dry_run)
             for user in config.users:
-                _create_or_update_cluster_user(conn, user, dry_run=dry_run)
+                _create_or_update_user(conn, user, dry_run=dry_run)
 
     if dry_run:
         logger.info("Dry-run: Skipping drop and create of database '%s' with owner '%s'", database_name, config.owner)
     else:
-        admin_dev_conn = etl.db.connection(config.dsn_admin, autocommit=True)
-        with closing(admin_dev_conn):
+        with closing(etl.db.connection(config.dsn_admin, autocommit=True)) as conn:
             logger.info("Dropping and creating database '%s' with owner '%s'", database_name, config.owner)
-            etl.db.drop_and_create_database(admin_dev_conn, database_name, config.owner)
+            etl.db.drop_and_create_database(conn, database_name, config.owner)
 
-    admin_target_db_conn = etl.db.connection(config.dsn_admin_on_etl_db, autocommit=True, readonly=dry_run)
-    with closing(admin_target_db_conn):
+    with closing(etl.db.connection(config.dsn_admin_on_etl_db, autocommit=True, readonly=dry_run)) as conn:
         if dry_run:
-            logger.info("Dry-run: Skipping drop of PUBLIC schema in '%s'", database_name)
+            logger.info("Dry-run: Skipping dropping of PUBLIC schema in '%s'", database_name)
         else:
             logger.info("Dropping PUBLIC schema in '%s'", database_name)
-            etl.db.drop_schema(admin_target_db_conn, "PUBLIC")
+            etl.db.drop_schema(conn, "PUBLIC")
         if with_user_creation:
             for user in config.users:
                 if user.schema:
-                    _create_schema_for_user(admin_target_db_conn, user, config.groups[0], dry_run=dry_run)
-                _update_search_path(admin_target_db_conn, user, dry_run=dry_run)
+                    _create_schema_for_user(conn, user, config.groups[0], dry_run=dry_run)
+                _update_search_path(conn, user, dry_run=dry_run)
 
 
-def _create_or_update_user(user_name, group_name=None, add_user_schema=False, only_update=False, dry_run=False):
+def create_or_update_user(user_name, group_name=None, add_user_schema=False, only_update=False, dry_run=False):
     """
     Add new user to cluster or update existing user.
 
@@ -315,10 +304,11 @@ def _create_or_update_user(user_name, group_name=None, add_user_schema=False, on
     if user.group not in config.groups and user.group != config.default_group:
         raise ValueError("specified group ('%s') not present in DataWarehouseConfig" % user.group)
 
-    with closing(etl.db.connection(config.dsn_admin_on_etl_db, autocommit=True, readonly=dry_run)) as conn:
-        with conn:
-            _create_or_update_cluster_user(conn, user, only_update=only_update, dry_run=dry_run)
+    with closing(etl.db.connection(config.dsn_admin_on_etl_db, readonly=dry_run)) as conn:
+        _create_groups(conn, [user.group], dry_run=dry_run)
+        _create_or_update_user(conn, user, only_update=only_update, dry_run=dry_run)
 
+        with conn:
             if add_user_schema:
                 _create_schema_for_user(conn, user, config.groups[0], dry_run=dry_run)
             elif user.schema is not None:
@@ -329,11 +319,11 @@ def _create_or_update_user(user_name, group_name=None, add_user_schema=False, on
 
 
 def create_new_user(new_user, group=None, add_user_schema=False, dry_run=False):
-    _create_or_update_user(new_user, group, add_user_schema=add_user_schema, only_update=False, dry_run=dry_run)
+    create_or_update_user(new_user, group, add_user_schema=add_user_schema, only_update=False, dry_run=dry_run)
 
 
 def update_user(old_user, group=None, add_user_schema=False, dry_run=False):
-    _create_or_update_user(old_user, group, add_user_schema=add_user_schema, only_update=True, dry_run=dry_run)
+    create_or_update_user(old_user, group, add_user_schema=add_user_schema, only_update=True, dry_run=dry_run)
 
 
 def list_open_transactions(cx):

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1090,6 +1090,7 @@ def load_data_warehouse(
         tx_info = etl.data_warehouse.list_open_transactions(conn)
         etl.db.print_result("List of sessions that have open transactions:", tx_info)
 
+    etl.data_warehouse.create_groups(dry_run=dry_run)
     create_schemas_for_rebuild(traversed_schemas, use_staging=use_staging, dry_run=dry_run)
     try:
         create_relations(


### PR DESCRIPTION
We can define groups in the configuration of the data warehouse and give them read or write access to schemas. This PR makes sure that all groups actually exist when that step is run for a rebuild ETL. You can also create the groups directly using the new `create_groups` command.

This does not allow to create arbitrary groups but only the ones referenced in the configuration file.