### PR TITLE
Grant and revoke for groups within one statement

### DIFF
--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -16,7 +16,7 @@ import etl.relation
 import etl.s3
 from etl.config.dw import DataWarehouseSchema
 from etl.design import Attribute, ColumnDefinition
-from etl.names import TableName, TableSelector, join_with_quotes
+from etl.names import TableName, TableSelector, join_with_single_quotes
 from etl.relation import RelationDescription
 
 logger = logging.getLogger(__name__)
@@ -480,10 +480,14 @@ def create_table_designs_from_source(source, selector, local_dir, local_files, d
     upstream = frozenset(name.identifier for name in source_tables)
     not_found = upstream.difference(existent)
     if not_found:
-        logger.warning("New table(s) in source '%s' without local design: %s", source.name, join_with_quotes(not_found))
+        logger.warning(
+            "New table(s) in source '%s' without local design: %s", source.name, join_with_single_quotes(not_found)
+        )
     too_many = existent.difference(upstream)
     if too_many:
-        logger.error("Local table design(s) without table in source '%s': %s", source.name, join_with_quotes(too_many))
+        logger.error(
+            "Local table design(s) without table in source '%s': %s", source.name, join_with_single_quotes(too_many)
+        )
 
     return len(source_tables)
 

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -20,7 +20,7 @@ import etl.db
 import etl.file_sets
 import etl.s3
 from etl.errors import SchemaValidationError, TableDesignParseError, TableDesignSemanticError, TableDesignSyntaxError
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -139,7 +139,7 @@ def validate_column_references(table_design):
             cols = [col for constraint in constraints for col in constraint.get(key, [])]
         else:  # 'attributes'
             cols = table_design.get(obj, {}).get(key, [])
-        unknown = join_with_quotes(frozenset(cols).difference(valid_columns))
+        unknown = join_with_single_quotes(frozenset(cols).difference(valid_columns))
         if unknown:
             raise TableDesignSemanticError(
                 "{key} columns in {obj} contain unknown column(s): {unknown}".format(obj=obj, key=key, unknown=unknown)

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -1,4 +1,4 @@
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 
 class ETLError(Exception):
@@ -147,7 +147,7 @@ class MissingExtractEventError(RelationDataError):
         missing_relations = [relation for relation in source_relations if relation.identifier not in extracted_targets]
         self.message = (
             "Some source relations did not have extract events after the step start time: "
-            + join_with_quotes(missing_relations)
+            + join_with_single_quotes(missing_relations)
         )
 
     def __str__(self):
@@ -172,7 +172,7 @@ class FailedConstraintError(RelationDataError):
 
 class RequiredRelationLoadError(ETLRuntimeError):
     def __init__(self, failed_relations, bad_apple=None):
-        self.message = "required relation(s) with failure: " + join_with_quotes(failed_relations)
+        self.message = "required relation(s) with failure: " + join_with_single_quotes(failed_relations)
         if bad_apple:
             self.message += ", triggered by load failure of '{}'".format(bad_apple)
 

--- a/python/etl/extract/__init__.py
+++ b/python/etl/extract/__init__.py
@@ -36,7 +36,7 @@ from etl.extract.spark import SparkExtractor
 from etl.extract.sqoop import SqoopExtractor
 from etl.extract.static import StaticExtractor
 from etl.relation import RelationDescription
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -105,5 +105,5 @@ def filter_relations_for_sources(
     selected = [relation for relation in relations if relation.source_name in source_lookup]
     if selected:
         sources = frozenset(relation.source_name for relation in selected)
-        logger.info("Selected %d relation(s) from source(s): %s", len(selected), join_with_quotes(sources))
+        logger.info("Selected %d relation(s) from source(s): %s", len(selected), join_with_single_quotes(sources))
     return selected

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -17,7 +17,7 @@ import etl.s3
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import DataExtractError, ETLRuntimeError, MissingCsvFilesError
 from etl.relation import RelationDescription
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 from etl.timer import Timer
 from etl.util.retry import call_with_retry
 
@@ -156,7 +156,9 @@ class Extractor:
             else:
                 done, not_done = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_EXCEPTION)
         if self.failed_sources:
-            self.logger.error("Failed to extract from these source(s): %s", join_with_quotes(self.failed_sources))
+            self.logger.error(
+                "Failed to extract from these source(s): %s", join_with_single_quotes(self.failed_sources)
+            )
 
         # Note that iterating over result of futures may raise an exception which surfaces
         # exceptions from threads. This happens when there is (at least) one required table
@@ -169,7 +171,7 @@ class Extractor:
             self.logger.warning(
                 "Failed to extract %d relation(s): %s",
                 len(missing_tables),
-                join_with_quotes(missing_tables),
+                join_with_single_quotes(missing_tables),
             )
         if not_done:
             raise DataExtractError("Extract failed to complete for {:d} source(s)".format(len(not_done)))

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -76,7 +76,7 @@ from etl.errors import (
 )
 from etl.names import TableName, TableSelector, TempTableName
 from etl.relation import RelationDescription
-from etl.text import join_column_list, join_with_quotes
+from etl.text import join_with_double_quotes, join_with_single_quotes
 from etl.timer import Timer
 from etl.util.retry import call_with_retry
 
@@ -203,7 +203,9 @@ class LoadableRelation:
         identifiers = [dependent.identifier for dependent in dependents]
         if identifiers:
             logger.warning(
-                "Continuing while leaving %d relation(s) empty: %s", len(identifiers), join_with_quotes(identifiers)
+                "Continuing while leaving %d relation(s) empty: %s",
+                len(identifiers),
+                join_with_single_quotes(identifiers),
             )
 
     @property
@@ -359,11 +361,11 @@ def grant_access(conn: connection, relation: LoadableRelation, dry_run=False):
         if dry_run:
             logger.info(
                 "Dry-run: Skipping granting of select access on {:x} to {}".format(
-                    relation, join_with_quotes(reader_groups)
+                    relation, join_with_single_quotes(reader_groups)
                 )
             )
         else:
-            logger.info("Granting select access on {:x} to {}".format(relation, join_with_quotes(reader_groups)))
+            logger.info("Granting select access on {:x} to {}".format(relation, join_with_single_quotes(reader_groups)))
             for reader in reader_groups:
                 etl.db.grant_select(conn, target.schema, target.table, reader)
 
@@ -371,11 +373,11 @@ def grant_access(conn: connection, relation: LoadableRelation, dry_run=False):
         if dry_run:
             logger.info(
                 "Dry-run: Skipping granting of write access on {:x} to {}".format(
-                    relation, join_with_quotes(writer_groups)
+                    relation, join_with_single_quotes(writer_groups)
                 )
             )
         else:
-            logger.info("Granting write access on {:x} to {}".format(relation, join_with_quotes(writer_groups)))
+            logger.info("Granting write access on {:x} to {}".format(relation, join_with_single_quotes(writer_groups)))
             for writer in writer_groups:
                 etl.db.grant_select_and_write(conn, target.schema, target.table, writer)
 
@@ -507,7 +509,7 @@ def load_ctas_using_temp_table(conn: connection, relation: LoadableRelation, dry
         ]
         insert_from_query(conn, relation, table_name=temp_name, columns=temp_columns, dry_run=dry_run)
 
-        inner_stmt = "SELECT {} FROM {}".format(join_column_list(relation.unquoted_columns), temp_name)
+        inner_stmt = "SELECT {} FROM {}".format(join_with_double_quotes(relation.unquoted_columns), temp_name)
         if relation.target_table_name.table.startswith("dim_"):
             missing_dimension = create_missing_dimension_row(relation.table_design["columns"])
             inner_stmt += "\nUNION ALL SELECT {}".format(", ".join(missing_dimension))
@@ -559,7 +561,7 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
 
     for constraint in constraints:
         [[constraint_type, columns]] = constraint.items()  # There will always be exactly one item.
-        quoted_columns = join_column_list(columns)
+        quoted_columns = join_with_double_quotes(columns)
         if constraint_type == "unique":
             condition = " AND ".join('"{}" IS NOT NULL'.format(name) for name in columns)
         else:
@@ -569,14 +571,14 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
         if dry_run:
             logger.info(
                 "Dry-run: Skipping check of {} constraint in {:x} on column(s): {}".format(
-                    constraint_type, relation, join_with_quotes(columns)
+                    constraint_type, relation, join_with_single_quotes(columns)
                 )
             )
             etl.db.skip_query(conn, statement)
         else:
             logger.info(
                 "Checking {} constraint in {:x} on column(s): {}".format(
-                    constraint_type, relation, join_with_quotes(columns)
+                    constraint_type, relation, join_with_single_quotes(columns)
                 )
             )
             results = etl.db.query(conn, statement)
@@ -917,7 +919,7 @@ def create_source_tables_when_ready(
 
     failed = [relation.identifier for relation in source_relations if relation.failed]
     if failed:
-        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_quotes(failed))
+        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_single_quotes(failed))
     logger.info("Finished with %d relation(s) in source schemas (%s)", len(source_relations), timer)
 
 
@@ -976,7 +978,7 @@ def create_source_tables_in_parallel(relations: List[LoadableRelation], max_conc
 
     failed = [relation.identifier for relation in source_relations if relation.failed]
     if failed:
-        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_quotes(failed))
+        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_single_quotes(failed))
     logger.info("Finished with %d relation(s) in source schemas (%s)", len(source_relations), timer)
 
 
@@ -1013,12 +1015,12 @@ def create_transformations_sequentially(relations: List[LoadableRelation], wlm_q
 
     failed = [relation.identifier for relation in transformations if relation.failed]
     if failed:
-        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_quotes(failed))
+        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_single_quotes(failed))
     skipped = [
         relation.identifier for relation in transformations if relation.skip_copy and not relation.is_view_relation
     ]
     if 0 < len(skipped) < len(transformations):
-        logger.warning("These %d relation(s) were left empty: %s", len(skipped), join_with_quotes(skipped))
+        logger.warning("These %d relation(s) were left empty: %s", len(skipped), join_with_single_quotes(skipped))
     logger.info("Finished with %d relation(s) in transformation schemas (%s)", len(transformations), timer)
 
 

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 
 import etl.config
 from etl.errors import ETLSystemError
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 
 def as_staging_name(name):
@@ -463,7 +463,7 @@ class TableSelector:
         if len(self._patterns) == 0:
             return "['*.*']"
         else:
-            return "[{}]".format(join_with_quotes(p.identifier for p in self._patterns))
+            return "[{}]".format(join_with_single_quotes(p.identifier for p in self._patterns))
 
     def match_schema(self, schema) -> bool:
         """

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -12,7 +12,7 @@ import funcy
 import simplejson as json
 
 import etl.text
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -287,12 +287,12 @@ def show_pipelines(selection: List[str], as_json=False) -> None:
             logger.warning("Selection matched more than one pipeline")
         logger.info(
             "Currently selected pipelines: %s",
-            join_with_quotes(pipeline.pipeline_id for pipeline in pipelines),
+            join_with_single_quotes(pipeline.pipeline_id for pipeline in pipelines),
         )
     else:
         logger.info(
             "Available pipelines: %s",
-            join_with_quotes(pipeline.pipeline_id for pipeline in pipelines),
+            join_with_single_quotes(pipeline.pipeline_id for pipeline in pipelines),
         )
     if as_json:
         print(DataPipeline.as_json(pipelines))

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -39,7 +39,7 @@ import etl.timer
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import CyclicDependencyError, ETLRuntimeError, MissingQueryError
 from etl.names import TableName, TableSelector, TempTableName
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -290,7 +290,9 @@ class RelationDescription:
             if file_set.design_file_name is not None:
                 relations.append(cls(file_set))
             else:
-                logger.warning("Found file(s) without matching table design: %s", join_with_quotes(file_set.files))
+                logger.warning(
+                    "Found file(s) without matching table design: %s", join_with_single_quotes(file_set.files)
+                )
 
         if required_relation_selector:
             set_required_relations(relations, required_relation_selector)
@@ -434,7 +436,7 @@ def _sanitize_dependencies(descriptions: List[SortableRelationDescription]) -> N
             logger.info(
                 "The following dependencies for relation '%s' are not managed by Arthur: %s",
                 description.identifier,
-                join_with_quotes([dep.identifier for dep in unmanaged_dependencies]),
+                join_with_single_quotes([dep.identifier for dep in unmanaged_dependencies]),
             )
         if pg_catalog_dependencies:
             has_pg_catalog_dependencies.add(description.target_table_name)
@@ -442,11 +444,11 @@ def _sanitize_dependencies(descriptions: List[SortableRelationDescription]) -> N
     if has_unknown_dependencies:
         logger.warning(
             "These relations were unknown during dependency ordering: %s",
-            join_with_quotes([dep.identifier for dep in known_unknowns]),
+            join_with_single_quotes([dep.identifier for dep in known_unknowns]),
         )
         logger.warning(
             "This caused these relations to have dependencies that are not known: %s",
-            join_with_quotes([dep.identifier for dep in has_unknown_dependencies]),
+            join_with_single_quotes([dep.identifier for dep in has_unknown_dependencies]),
         )
 
     # Make tables that depend on tables in pg_catalog depend on all our tables (except those

--- a/python/etl/selftest.py
+++ b/python/etl/selftest.py
@@ -45,7 +45,7 @@ def load_tests(loader, tests, pattern):
     See https://docs.python.org/3.5/library/unittest.html#load-tests-protocol
     """
     etl_modules = sorted(mod for mod in sys.modules if mod.startswith("etl"))
-    logger.info("Adding tests from %s", etl.names.join_with_quotes(etl_modules))
+    logger.info("Adding tests from %s", etl.names.join_with_single_quotes(etl_modules))
     for mod in etl_modules:
         tests.addTests(doctest.DocTestSuite(mod))
     return tests

--- a/python/etl/text.py
+++ b/python/etl/text.py
@@ -1,11 +1,11 @@
 """
 Deal with text, mostly around iterables of texts which we want to pretty print.
 
-Should not import Arthur modules (so that etl.errors remains widely importable)
+Should not import other Arthur modules so that etl.text remains widely importable.
 """
 
 import textwrap
-from typing import List
+from typing import Iterable
 
 from tabulate import tabulate
 
@@ -45,7 +45,7 @@ def approx_pretty_size(total_bytes) -> str:
     return "{:d}{}".format(div, unit)
 
 
-def join_with_quotes(names):
+def join_with_single_quotes(names: Iterable[str]) -> str:
     """
     Individually wrap the names in quotes and return comma-separated names in a string.
 
@@ -53,22 +53,29 @@ def join_with_quotes(names):
     If the input is a list of names, the order of the list is respected.
     If the input is cheese, the order is for more red wine.
 
-    >>> join_with_quotes(["foo", "bar"])
+    >>> join_with_single_quotes(["foo", "bar"])
     "'foo', 'bar'"
-    >>> join_with_quotes({"foo", "bar"})
+    >>> join_with_single_quotes({"foo", "bar"})
     "'bar', 'foo'"
-    >>> join_with_quotes(frozenset(["foo", "bar"]))
+    >>> join_with_single_quotes(frozenset(["foo", "bar"]))
     "'bar', 'foo'"
     """
     if isinstance(names, (set, frozenset)):
         return ", ".join("'{}'".format(name) for name in sorted(names))
-    else:
-        return ", ".join("'{}'".format(name) for name in names)
+    return ", ".join("'{}'".format(name) for name in names)
 
 
-def join_column_list(columns: List[str], sep=", ") -> str:
-    """Return string with comma-separated, delimited column names."""
-    return sep.join('"{}"'.format(column) for column in columns)
+def join_with_double_quotes(names: Iterable[str], sep=", ", prefix="") -> str:
+    """
+    Return string with comma-separated, delimited names.
+
+    This step ensures that our identifiers are wrapped in double quotes.
+    >>> join_with_double_quotes(["foo", "bar"])
+    '"foo", "bar"'
+    >>> join_with_double_quotes(["foo", "bar"], sep=", USER ", prefix="USER ")
+    'USER "foo", USER "bar"'
+    """
+    return prefix + sep.join('"{}"'.format(name) for name in names)
 
 
 def whitespace_cleanup(value: str) -> str:


### PR DESCRIPTION
## Description

We used to call `GRANT` or `REVOKE` for every group individually, which is a bit expensive. Each of those calls takes up to 1s. So this PR merges the calls. Note that it's important to reduce the time it takes to cut over since during the time of promoting the staging schemas (and backup up first the original schemas), the users can sometimes not see a schema, leading to strange errors during queries.

### Example

Going from:
```
GRANT USAGE ON SCHEMA "common" TO GROUP "etl_ro"
GRANT USAGE ON SCHEMA "common" TO GROUP "analyst_ro"
```
to:
```
GRANT USAGE ON SCHEMA "common" TO GROUP "etl_ro", GROUP "analyst_ro"
```

### Other changes

In `etl.text` some utility functions are renamed to make it easier to distinguish them and use them.

Old name | New name
---|---
`join_with_quotes`  | `join_with_single_quotes`
`join_column_list` | `join_with_double_quotes`

## How to test
Schemas can be created and moved around using the schemas commands.

1. Connect to "your" validation database by copying the `credentials_validation.sh` file into your local config directory.
2. Run through the various steps
```
arthur.py create_schemas --prolix common
arthur.py create_schemas --with-backup --prolix common
arthur.py create_schemas --with-staging --prolix common
arthur.py promote_schemas --from-position staging --prolix common
arthur.py promote_schemas --from-position backup --prolix common
```
(The `--prolix` flag makes it easier to observe the queries.)

Don't forget to remove the `credentials_validation.sh` file so that you're connected to the correct database again.

