### PR TITLE
Improve load speed of table design files

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -22,6 +22,7 @@ import jsonschema
 import pkg_resources
 import simplejson as json
 import yaml
+from simplejson.errors import JSONDecodeError
 
 import etl.config.dw
 import etl.monitor
@@ -299,7 +300,7 @@ def validate_with_schema(obj: dict, schema_name: str) -> None:
     validation_internal_errors = (
         jsonschema.exceptions.ValidationError,
         jsonschema.exceptions.SchemaError,
-        json.scanner.JSONDecodeError,
+        JSONDecodeError,
     )
     schema = load_json_schema(schema_name)
     try:
@@ -332,6 +333,7 @@ def gather_setting_files(config_files: Sequence[str]) -> List[str]:
     return sorted(settings_with_path)
 
 
+@lru_cache()
 def load_json(filename: str):
     """Load JSON-formatted file into native data structure."""
     return json.loads(pkg_resources.resource_string(__name__, filename))
@@ -343,7 +345,7 @@ def load_json_schema(schema_name: str):
     validation_internal_errors = (
         jsonschema.exceptions.ValidationError,
         jsonschema.exceptions.SchemaError,
-        json.scanner.JSONDecodeError,
+        JSONDecodeError,
     )
     try:
         schema = load_json(schema_name)

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -14,6 +14,11 @@ import funcy as fy
 import yaml
 import yaml.parser
 
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader  # type: ignore
+
 import etl
 import etl.config
 import etl.db
@@ -33,7 +38,7 @@ def load_table_design(stream, table_name):
     The table design is validated before being returned.
     """
     try:
-        table_design = yaml.safe_load(stream)
+        table_design = yaml.load(stream, Loader=SafeLoader)
     except yaml.parser.ParserError as exc:
         raise TableDesignParseError(exc) from exc
 

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -37,8 +37,6 @@ def load_table_design(stream, table_name):
     except yaml.parser.ParserError as exc:
         raise TableDesignParseError(exc) from exc
 
-    etl.config.validate_with_schema(table_design, "table_design.schema")
-
     # We used to specify constraints using an object (before v0.24.0) and then switched to using
     # an array of objects (with v0.24.0). This rewrites the constraints into the new format
     # as needed.

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -22,12 +22,13 @@ import logging
 import os.path
 from contextlib import closing, contextmanager
 from copy import deepcopy
-from functools import partial
+from itertools import dropwhile
 from operator import attrgetter
 from queue import PriorityQueue
-from typing import Any, Dict, FrozenSet, List, Optional, Tuple, Union
+from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Tuple, Union
 
 import funcy as fy
+from tqdm import tqdm
 
 import etl.config
 import etl.db
@@ -126,31 +127,56 @@ class RelationDescription:
         else:
             raise ValueError("unsupported format code '{}' passed to RelationDescription".format(code))
 
-    def load(self) -> None:
+    def load(self, callback=None) -> None:
         """
         Force a loading of the table design (which is normally loaded "on demand").
 
         Strictly speaking, this isn't thread-safe. But if you worry about thread safety here,
         rethink your code.
         """
-        if self._table_design is None:
-            if self.bucket_name:
-                loader = partial(etl.design.load.load_table_design_from_s3, self.bucket_name)
-            else:
-                loader = partial(etl.design.load.load_table_design_from_localfile)
-            self._table_design = loader(self.design_file_name, self.target_table_name)
+        if self._table_design is not None:
+            pass  # previously (pre-)loaded
+        elif self.scheme == "s3":
+            self._table_design = etl.design.load.load_table_design_from_s3(
+                self.bucket_name, self.design_file_name, self.target_table_name
+            )
+        else:
+            self._table_design = etl.design.load.load_table_design_from_localfile(
+                self.design_file_name, self.target_table_name
+            )
+        if callback:
+            callback()
 
     @staticmethod
-    def load_in_parallel(relations: List["RelationDescription"]) -> None:
+    def load_in_parallel(relations: Sequence["RelationDescription"]) -> None:
         """Load all relations' table design file in parallel."""
-        max_workers = 8
-        logger.debug("Starting parallel load of %d table design file(s) on %d workers.", len(relations), max_workers)
-        with etl.timer.Timer() as timer:
+        remaining_relations = [relation for relation in relations if relation._table_design is None]
+        if len(remaining_relations) == 0:
+            return
+
+        # Show a pretty loading bar but only if this goes to a terminal.
+        tqdm_bar = tqdm(desc="Loading table designs", disable=None, total=len(remaining_relations))
+        timer = etl.timer.Timer()
+
+        # Load one relation. First, because it's silly to run a single relation in parallel.
+        # Second, because this forces a load and validation of the schema for table designs.
+        first_relation = remaining_relations.pop()
+        first_relation.load(tqdm_bar.update)
+
+        if len(remaining_relations):
+            max_workers = 8
+            logger.debug(
+                "Starting parallel load of %d table design file(s) on %d workers.",
+                len(remaining_relations),
+                max_workers,
+            )
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=max_workers, thread_name_prefix="load-parallel"
             ) as executor:
-                executor.map(lambda relation: relation.load(), relations)
-        logger.info("Finished loading %d table design file(s) (%s)", len(relations), timer)
+                executor.map(lambda relation: relation.load(tqdm_bar.update), remaining_relations)
+
+        tqdm_bar.close()
+        logger.info("Finished loading %d table design file(s) (%s)", len(remaining_relations), timer)
 
     @property  # This property is lazily loaded.
     def table_design(self) -> Dict[str, Any]:

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -22,7 +22,6 @@ import logging
 import os.path
 from contextlib import closing, contextmanager
 from copy import deepcopy
-from itertools import dropwhile
 from operator import attrgetter
 from queue import PriorityQueue
 from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Tuple, Union
@@ -144,39 +143,53 @@ class RelationDescription:
             self._table_design = etl.design.load.load_table_design_from_localfile(
                 self.design_file_name, self.target_table_name
             )
-        if callback:
+        if callback is not None:
             callback()
 
     @staticmethod
     def load_in_parallel(relations: Sequence["RelationDescription"]) -> None:
-        """Load all relations' table design file in parallel."""
+        """
+        Load all relations' table design file in parallel.
+
+        If there no relation left which hasn't loaded the table design, do nothing.
+        If there is only one relation, then that one is loaded directly and without threads.
+        If there are only two relations, then both are loaded directly and without threads.
+        If there are more than two relations, then the first is loaded directly to validate
+        our setup (in particular the schemas of table designs) and then rest is actually
+        loaded in parallel using threads.
+        """
         remaining_relations = [relation for relation in relations if relation._table_design is None]
         if len(remaining_relations) == 0:
             return
 
-        # Show a pretty loading bar but only if this goes to a terminal.
-        tqdm_bar = tqdm(desc="Loading table designs", disable=None, total=len(remaining_relations))
+        # This section loads threads directly up to the "parallel start index".
         timer = etl.timer.Timer()
+        parallel_start_index = 2 if len(remaining_relations) == 2 else 1
+        for relation in remaining_relations[:parallel_start_index]:
+            relation.load()
+        if parallel_start_index == len(remaining_relations):
+            logger.info("Finished loading %d table design file(s) (%s)", len(remaining_relations), timer)
+            return
 
-        # Load one relation. First, because it's silly to run a single relation in parallel.
-        # Second, because this forces a load and validation of the schema for table designs.
-        first_relation = remaining_relations.pop()
-        first_relation.load(tqdm_bar.update)
-
-        if len(remaining_relations):
-            max_workers = 8
-            logger.debug(
-                "Starting parallel load of %d table design file(s) on %d workers.",
-                len(remaining_relations),
-                max_workers,
-            )
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=max_workers, thread_name_prefix="load-parallel"
-            ) as executor:
-                executor.map(lambda relation: relation.load(tqdm_bar.update), remaining_relations)
+        # This section loads the remaining relations from the "parallel start index" onwards
+        # and shows a pretty loading bar (but only if this goes to a terminal).
+        tqdm_bar = tqdm(desc="Loading table designs", disable=None, leave=False, total=len(remaining_relations))
+        tqdm_bar.update(parallel_start_index)
+        max_workers = 8
+        logger.debug(
+            "Starting parallel load of %d table design file(s) on %d workers.",
+            len(remaining_relations[parallel_start_index:]),
+            max_workers,
+        )
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="load-parallel"
+        ) as executor:
+            executor.map(lambda relation: relation.load(tqdm_bar.update), remaining_relations[parallel_start_index:])
 
         tqdm_bar.close()
-        logger.info("Finished loading %d table design file(s) (%s)", len(remaining_relations), timer)
+        logger.info(
+            "Finished loading %d table design file(s) in %d threads (%s)", len(remaining_relations), max_workers, timer
+        )
 
     @property  # This property is lazily loaded.
     def table_design(self) -> Dict[str, Any]:

--- a/python/etl/sync.py
+++ b/python/etl/sync.py
@@ -15,14 +15,16 @@ configuration file by copying it up to S3.
 import concurrent.futures
 import logging
 import os.path
-from typing import List
+from typing import List, Sequence, Tuple
+
+from tqdm import tqdm
 
 import etl.config
 import etl.file_sets
 import etl.s3
+import etl.timer
 from etl.errors import ETLRuntimeError, MissingQueryError
 from etl.relation import RelationDescription
-from etl.timer import Timer
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -44,40 +46,59 @@ def upload_settings(config_files, bucket_name, prefix, dry_run=False) -> None:
         uploader(fullname, object_key)
 
 
-def sync_with_s3(relations: List[RelationDescription], bucket_name: str, prefix: str, dry_run: bool = False) -> None:
+def sync_with_s3(
+    relations: Sequence[RelationDescription], bucket_name: str, prefix: str, dry_run: bool = False
+) -> None:
     """Copy (validated) table design and SQL files from local directory to S3 bucket."""
     logger.info("Validating %d table design(s) before upload", len(relations))
     RelationDescription.load_in_parallel(relations)
 
-    files = []  # typing: List[Tuple[str, str]]
+    # Collect list of (local file, remote file) pairs to send to the uploader.
+    files: List[Tuple[str, str]] = []
     for relation in relations:
-        relation_files = [relation.design_file_name]
         if relation.is_transformation:
-            if relation.sql_file_name:
-                relation_files.append(relation.sql_file_name)
-            else:
-                raise MissingQueryError("Missing matching SQL file for '%s'" % relation.design_file_name)
+            if relation.sql_file_name is None:
+                raise MissingQueryError("missing matching SQL file for '%s'" % relation.design_file_name)
+            relation_files = [relation.design_file_name, relation.sql_file_name]
+        else:
+            relation_files = [relation.design_file_name]
+
         for file_name in relation_files:
             local_filename = relation.norm_path(file_name)
             remote_filename = os.path.join(prefix, local_filename)
             files.append((local_filename, remote_filename))
 
-    uploader = etl.s3.S3Uploader(bucket_name, dry_run=dry_run)
-    with Timer() as timer:
-        futures = []  # typing: List[concurrent.futures.Future]
-        # TODO With Python 3.6, we should pass in a thread_name_prefix
-        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
-            for local_filename, remote_filename in files:
-                futures.append(executor.submit(uploader.__call__, local_filename, remote_filename))
-        errors = 0
-        for future in concurrent.futures.as_completed(futures):
-            exception = future.exception()
-            if exception is not None:
-                logger.error("Failed to upload file: %s", exception)
-                errors += 1
-    if not dry_run:
+    timer = etl.timer.Timer()
+    tqdm_bar = tqdm(desc="Upoading files to S3", disable=None, leave=False, total=len(files))
+
+    uploader = etl.s3.S3Uploader(bucket_name, callback=tqdm_bar.update, dry_run=dry_run)
+    max_workers = 8
+
+    # We break out the futures to be able to easily tally up errors.
+    futures: List[concurrent.futures.Future] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="sync-parallel") as executor:
+        for local_filename, remote_filename in files:
+            futures.append(executor.submit(uploader.__call__, local_filename, remote_filename))
+
+    errors = 0
+    for future in concurrent.futures.as_completed(futures):
+        exception = future.exception()
+        if exception is not None:
+            logger.error("Failed to upload file: %s", exception)
+            errors += 1
+
+    tqdm_bar.close()
+    if dry_run:
+        logger.info("Dry-run: Skipped uploading %d file(s) to 's3://%s/%s (%s)", len(files), bucket_name, prefix, timer)
+    else:
         logger.info(
-            "Uploaded %d of %d file(s) to 's3://%s/%s (%s)", len(files) - errors, len(files), bucket_name, prefix, timer
+            "Uploaded %d of %d file(s) to 's3://%s/%s' in %d threads (%s)",
+            len(files) - errors,
+            len(files),
+            bucket_name,
+            prefix,
+            max_workers,
+            timer,
         )
     if errors:
         raise ETLRuntimeError("There were {:d} error(s) during upload".format(errors))


### PR DESCRIPTION
This PR improves the speed with which we load the table design files by:
* Switching to `libyaml` when possible to load YAML files
* Caching the validated schema itself
* Skipping the initial validation that was needed for old versions of table design files.

This brings the load speed back to under **8s** for 800-ish files for local files, and under **15s** for files in S3.

We also add a cute progress bar during the load so load time is a bit more bearable, and for symmetry, also add a progress bar  to `sync`.

* Starting point:
```
2021-02-28 14:09:39 - INFO - Finished loading 778 table design file(s) (25.53s)
```
* After caching schema of table design (and validating it once instead of 778 times):
```
2021-02-28 14:12:58 - INFO - Finished loading 778 table design file(s) (18.64s)
```
* After dropping the duplicate validation (to support old schema designs):
```
2021-02-28 14:20:55 - INFO - Finished loading 778 table design file(s) (13.70s)
```
* After switching to `CSafeLoader` which uses `libyaml`:
```
2021-02-28 14:28:01 - INFO - Finished loading 777 table design file(s) (6.43s)
```

In order to satisfy `pre-commit` hooks, some type annotations had to be updated.