### PR TITLE
Patch run query to not stumble over '%'

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1160,6 +1160,7 @@ class RunQueryCommand(SubCommand):
             "-n",
             "--limit",
             help="limit the number of rows returned by the query",
+            type=int,
         )
 
     def callback(self, args, config):

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1162,13 +1162,20 @@ class RunQueryCommand(SubCommand):
             help="limit the number of rows returned by the query",
             type=int,
         )
+        parser.add_argument(
+            "--with-staging-schemas",
+            action="store_true",
+            default=False,
+            help="use the relations in staging schemas for the query",
+        )
 
     def callback(self, args, config):
         relations = self.find_relation_descriptions(args)
         transformations = [relation for relation in relations if relation.is_transformation]
         if len(transformations) != 1:
             raise InvalidArgumentError("selected %d transformations" % len(transformations))
-        etl.load.run_query(transformations[0], args.limit)
+        with etl.db.log_error():
+            etl.load.run_query(transformations[0], args.limit, args.with_staging_schemas)
 
 
 class ExplainQueryCommand(SubCommand):

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -55,7 +55,6 @@ from functools import partial
 from typing import Any, Dict, List, Optional, Set
 
 from psycopg2.extensions import connection  # only for type annotation
-from tabulate import tabulate
 
 import etl
 import etl.data_warehouse
@@ -76,7 +75,7 @@ from etl.errors import (
 )
 from etl.names import TableName, TableSelector, TempTableName
 from etl.relation import RelationDescription
-from etl.text import join_with_double_quotes, join_with_single_quotes
+from etl.text import format_lines, join_with_double_quotes, join_with_single_quotes
 from etl.timer import Timer
 from etl.util.retry import call_with_retry
 
@@ -1216,20 +1215,28 @@ def update_data_warehouse(
 def run_query(relation: RelationDescription, limit=None, use_staging=False) -> None:
     """Run the query for the relation (which must be a transformation, not a source)."""
     dsn_etl = etl.config.get_dw_config().dsn_etl
-
     loadable_relation = LoadableRelation(relation, {}, use_staging)
-    query_stmt = loadable_relation.query_stmt + "\nLIMIT %(limit)s"
+
+    # We cannot use psycopg2's '%s' with LIMIT since the query may contain
+    # arbitrary text, including "LIKE '%something%', which would break mogrify.
+    limit_clause = "LIMIT NULL" if limit is None else f"LIMIT {limit:d}"
+    query_stmt = loadable_relation.query_stmt + f"\n{limit_clause}\n"
 
     with Timer() as timer, closing(etl.db.connection(dsn_etl)) as conn:
         logger.info(
-            "Running query underlying '%s' (with 'LIMIT %s')",
+            "Running query underlying '%s' (with '%s')",
             relation.identifier,
-            limit if limit is not None else "NULL",
+            limit_clause,
         )
-        results = etl.db.query(conn, query_stmt, {"limit": limit})
+        results = etl.db.query(conn, query_stmt)
     logger.info("Ran query underlying '%s' and received %d row(s) (%s)", relation.identifier, len(results), timer)
 
-    print(tabulate(results, headers=relation.unquoted_columns, tablefmt="presto"))
+    # TODO(tom): This should grab the column names from the query to help with debugging.
+    if relation.has_identity_column:
+        columns = relation.unquoted_columns[1:]
+    else:
+        columns = relation.unquoted_columns
+    print(format_lines(results, header_row=columns))
 
 
 def show_downstream_dependents(

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1213,21 +1213,23 @@ def update_data_warehouse(
 # --- Section 5B: commands that provide information about relations
 
 
-def run_query(relation: RelationDescription, limit=None):
+def run_query(relation: RelationDescription, limit=None, use_staging=False) -> None:
     """Run the query for the relation (which must be a transformation, not a source)."""
     dsn_etl = etl.config.get_dw_config().dsn_etl
-    query_stmt = relation.query_stmt + "\nLIMIT %s"
 
-    with Timer() as timer, closing(etl.db.connection(dsn_etl, autocommit=True)) as conn:
+    loadable_relation = LoadableRelation(relation, {}, use_staging)
+    query_stmt = loadable_relation.query_stmt + "\nLIMIT %(limit)s"
+
+    with Timer() as timer, closing(etl.db.connection(dsn_etl)) as conn:
         logger.info(
             "Running query underlying '%s' (with 'LIMIT %s')",
             relation.identifier,
             limit if limit is not None else "NULL",
         )
-        results = etl.db.query(conn, query_stmt, (limit,))
+        results = etl.db.query(conn, query_stmt, {"limit": limit})
     logger.info("Ran query underlying '%s' and received %d row(s) (%s)", relation.identifier, len(results), timer)
 
-    print(tabulate(results, headers=relation.unquoted_columns, tablefmt="psql"))
+    print(tabulate(results, headers=relation.unquoted_columns, tablefmt="presto"))
 
 
 def show_downstream_dependents(


### PR DESCRIPTION
This PR fixes two bugs:
* We cannot use parameter evaluation of psycopg2 when pulling in transformations since arbitrary SQL code may confuse the parameter evaluation of psycopg2.
* The "identity" column which may be added in transformations is not part of the output of the query so we need to account for that in labeling the output.

And this PR adds a feature:
* If there's an ETL running and you have staging schemas, you can now run the query against staging schemas.

Not user-visible changes:
* The output of `run_query` is now sent through our standard `format_lines`.

How to test:
* Use `run_query` on a table with percent signs in the query
* Use `run_query` on a table with an identity column