### PR TITLE
Set AWS_REGION based on VPC region

### DIFF
--- a/etc/.bash_history
+++ b/etc/.bash_history
@@ -1,5 +1,6 @@
 develop
 arthur.py bootstrap_sources
+arthur.py show_pipelines
 arthur.py sync --deploy
 arthur.py validate -nskq
 arthur.py settings

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -135,7 +135,7 @@ def run_arg_as_command(my_name="arthur.py"):
                     etl.monitor.start_monitors(args.prefix)
 
             # The region must be set for most boto3 calls to succeed.
-            os.environ["AWS_REGION"] = etl.config.get_config_value("resources.VPC.region")
+            os.environ["AWS_DEFAULT_REGION"] = etl.config.get_config_value("resources.VPC.region")
 
             dw_config = etl.config.get_dw_config()
             if isinstance(getattr(args, "pattern", None), etl.names.TableSelector):

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -33,8 +33,8 @@ logger.addHandler(logging.NullHandler())
 
 
 # Global config objects - always use accessors!
-_dw_config = None  # type: Optional[DataWarehouseConfig]
-_mapped_config = None  # type: Optional[Dict[str, str]]
+_dw_config: Optional[DataWarehouseConfig] = None
+_mapped_config: Optional[Dict[str, str]] = None
 
 # Local temp directory used for bootstrap, temp files, etc.
 # TODO(tom): This is a misnomer -- it's also the install dir on EC2 hosts.
@@ -258,7 +258,7 @@ def load_config(config_files: Sequence[str], default_file: str = "default_settin
 
     The settings are validated against their schema.
     """
-    settings = dict()  # type: Dict[str, Any]
+    settings: Dict[str, Any] = dict()
     count_settings = 0
     for filename in yield_config_files(config_files, default_file):
         if filename.endswith(".sh"):
@@ -271,7 +271,7 @@ def load_config(config_files: Sequence[str], default_file: str = "default_settin
 
     # Need to load at least the defaults and some installation specific file:
     if count_settings < 2:
-        raise ETLRuntimeError("Failed to find enough configuration files (need at least default and local config)")
+        raise ETLRuntimeError("failed to find enough configuration files (need at least default and local config)")
 
     validate_with_schema(settings, "settings.schema")
 
@@ -321,7 +321,7 @@ def gather_setting_files(config_files: Sequence[str]) -> List[str]:
     settings files in separate directories that have the same filename.
     So trying '-c hello/world.yaml -c hola/world.yaml' triggers an exception.
     """
-    settings_found = set()  # type: Set[str]
+    settings_found: Set[str] = set()
     settings_with_path = []
 
     for fullname in yield_config_files(config_files):

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -91,14 +91,20 @@ class DataPipelineObject:
 
 
 class DataPipeline:
-    def __init__(self, description) -> None:
+    def __init__(self, client, description) -> None:
+        """
+        Initialize an instance that describes a Data Pipeline in AWS.
+
+        We keep a reference to the client here so that we can pull more information
+        from AWS as needed.
+        """
         self.name = description["name"]
         self.pipeline_id = description["pipelineId"]
         self.string_values = {
             field["key"]: field["stringValue"] for field in description["fields"] if "stringValue" in field
         }
         self.tags = description["tags"]
-        self.client = boto3.client("datapipeline")
+        self.client = client
 
     def delete_pipeline(self) -> str:
         response = self.client.delete_pipeline(pipelineId=self.pipeline_id)
@@ -250,7 +256,7 @@ def list_pipelines(selection: List[str]) -> List[DataPipeline]:
     for description in DataPipeline.describe_pipelines(client, selected_pipeline_ids):
         for tag in description["tags"]:
             if tag["key"] == "user:project" and tag["value"] == "data-warehouse":
-                pipelines.append(DataPipeline(description))
+                pipelines.append(DataPipeline(client, description))
                 break
     return sorted(pipelines, key=attrgetter("name"))
 

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -362,13 +362,12 @@ def _show_pipeline_details(pipeline) -> None:
             max_column_width=80,
         )
     )
-    for i, attempt in enumerate(attempts_with_errors):
-        if i == 0:
-            print()
+    for attempt in attempts_with_errors:
+        print()
         print(f"*** {attempt.name}: {attempt.status} ***")
         if attempt.error_stack_trace:
             print(textwrap.indent(attempt.error_stack_trace, "|  ", lambda line: True))
-        print(f"Command: {attempt.command}")
+        print(f"Command: {attempt.command or 'N/A'}")
         print(f"Log location: {attempt.log_location}")
 
 


### PR DESCRIPTION
Data Pipeline, unlike, say, Lambda, doesn't set the region for resources that it starts. So we're missing this information and trying to get a client errors out. This PR sets the `AWS_DEFAULT_REGION` based on `resources.VPC.region`.

This is the bugfix for:
```
|  botocore.exceptions.NoRegionError: You must specify a region.
```

Other changes:
* Update the type declarations