### PR TITLE
Cleanup monitor commands

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -132,6 +132,7 @@ def run_arg_as_command(my_name="arthur.py"):
     if args.cluster_id is not None:
         submit_step(args.cluster_id, args.sub_command)
         return
+<<<<<<< HEAD
 
     # We need to configure logging before running context because that context expects
     # logging to be setup.
@@ -146,12 +147,28 @@ def run_arg_as_command(my_name="arthur.py"):
 
         # The region must be set for most boto3 calls to succeed.
         os.environ["AWS_DEFAULT_REGION"] = etl.config.get_config_value("resources.VPC.region")
+=======
+
+    # We need to configure logging before running context because that context expects
+    # logging to be setup.
+    try:
+        etl.config.configure_logging(args.prolix, args.log_level)
+    except Exception as exc:
+        croak(exc, 1)
+
+    with execute_or_bail():
+        etl.config.load_config(args.config)
+>>>>>>> Simplify logic with early returns
 
         if hasattr(args, "prefix"):
             # Any command where we can select the "prefix" also needs the bucket.
             # TODO(tom): Need to differentiate between object store (schemas) and data lake
             #     (extracted or unloaded data)
+<<<<<<< HEAD
             args.bucket_name = etl.config.get_config_value("object_store.s3.bucket_name")
+=======
+            setattr(args, "bucket_name", etl.config.get_config_value("object_store.s3.bucket_name"))
+>>>>>>> Simplify logic with early returns
             etl.config.set_config_value("object_store.s3.prefix", args.prefix)
             etl.config.set_config_value("data_lake.s3.prefix", args.prefix)
 
@@ -534,10 +551,9 @@ class SubCommand(abc.ABC):
         scheme = getattr(args, "scheme", default_scheme)
         if scheme == "file":
             return scheme, "localhost", args.table_design_dir
-        elif scheme == "s3":
+        if scheme == "s3":
             return scheme, args.bucket_name, args.prefix
-        else:
-            raise ETLSystemError("scheme invalid")
+        raise ETLSystemError("scheme invalid")
 
     def find_relation_descriptions(
         self, args, default_scheme=None, required_relation_selector=None, return_all=False

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -165,7 +165,7 @@ def run_arg_as_command(my_name="arthur.py"):
             prefix = etl.config.get_config_value("object_store.s3.prefix")
             etl.logs.cloudwatch.add_cloudwatch_logging(prefix)
 
-        if getattr(args, "use_monitor", False):
+        if getattr(args.func, "uses_monitor", False):
             etl.monitor.start_monitors(args.prefix)
             logger.debug("Setting marker in events table for start of '%s' step", args.sub_command)
             etl.monitor.Monitor.marker_payload(args.sub_command).emit(dry_run=args.dry_run)
@@ -581,19 +581,6 @@ class SubCommand(abc.ABC):
         ...
 
 
-class MonitoredSubCommand(SubCommand):
-    """
-    A sub-command that will also use monitors to update some event table.
-
-    All sub-command classes must have prefix and dry-run in their arguments.
-    """
-
-    def add_to_parser(self, parent_parser) -> argparse.ArgumentParser:
-        parser = super().add_to_parser(parent_parser)
-        parser.set_defaults(use_monitor=True)
-        return parser
-
-
 class InitializeSetupCommand(SubCommand):
     def __init__(self):
         super().__init__(
@@ -917,7 +904,7 @@ class SyncWithS3Command(SubCommand):
         )
 
 
-class ExtractToS3Command(MonitoredSubCommand):
+class ExtractToS3Command(SubCommand):
     def __init__(self):
         super().__init__(
             "extract",
@@ -1009,8 +996,10 @@ class ExtractToS3Command(MonitoredSubCommand):
             dry_run=args.dry_run,
         )
 
+    setattr(callback, "uses_monitor", True)
 
-class LoadDataWarehouseCommand(MonitoredSubCommand):
+
+class LoadDataWarehouseCommand(SubCommand):
     def __init__(self):
         super().__init__(
             "load",
@@ -1072,8 +1061,10 @@ class LoadDataWarehouseCommand(MonitoredSubCommand):
             dry_run=args.dry_run,
         )
 
+    setattr(callback, "uses_monitor", True)
 
-class UpgradeDataWarehouseCommand(MonitoredSubCommand):
+
+class UpgradeDataWarehouseCommand(SubCommand):
     def __init__(self):
         super().__init__(
             "upgrade",
@@ -1159,8 +1150,10 @@ class UpgradeDataWarehouseCommand(MonitoredSubCommand):
             dry_run=args.dry_run,
         )
 
+    setattr(callback, "uses_monitor", True)
 
-class UpdateDataWarehouseCommand(MonitoredSubCommand):
+
+class UpdateDataWarehouseCommand(SubCommand):
     def __init__(self):
         super().__init__(
             "update",
@@ -1208,8 +1201,10 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
             dry_run=args.dry_run,
         )
 
+    setattr(callback, "uses_monitor", True)
 
-class UnloadDataToS3Command(MonitoredSubCommand):
+
+class UnloadDataToS3Command(SubCommand):
     def __init__(self):
         super().__init__(
             "unload",
@@ -1238,6 +1233,8 @@ class UnloadDataToS3Command(MonitoredSubCommand):
         etl.unload.unload_to_s3(
             descriptions, allow_overwrite=args.force, keep_going=args.keep_going, dry_run=args.dry_run
         )
+
+    setattr(callback, "uses_monitor", True)
 
 
 class CreateSchemasCommand(SubCommand):

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -290,7 +290,7 @@ class MonitorPayload:
             if not payload[key]:
                 del payload[key]
 
-        compact_text = json.dumps(payload, sort_keys=True, separators=(",", ":"), cls=FancyJsonEncoder)
+        compact_text = json.dumps(payload, cls=FancyJsonEncoder, separators=(",", ":"), sort_keys=True)
         if dry_run:
             logger.debug("Dry-run: payload = %s", compact_text)
             return
@@ -564,16 +564,15 @@ def start_monitors(environment):
 def _format_output_column(key: str, value: str) -> str:
     if value is None:
         return "---"
-    elif key == "timestamp":
+    if key == "timestamp":
         # Make timestamp readable by turning epoch seconds into a date.
         return datetime.utcfromtimestamp(float(value)).replace(microsecond=0).isoformat()
-    elif key == "elapsed":
+    if key == "elapsed":
         # Reduce number of decimals to 2.
         return "{:6.2f}".format(float(value))
-    elif key == "rowcount":
+    if key == "rowcount":
         return "{:9d}".format(int(value))
-    else:
-        return value
+    return value
 
 
 def _query_for_etls(step=None, hours_ago=0, days_ago=0) -> List[dict]:


### PR DESCRIPTION
Only internal changes to simplify the code.
* Leverage abstract base class
* Move the default attribute for `uses_monitor` (as `False`) into that class.

### Testing

Start container with exposing port 8086.
```
bin/run_arthur.sh -w
```
Start the demo in the container:
```
python -m etl.monitor
```

And then follow along: http://localhost:8086/

### Monitor events

Make sure that the ETL events are still sent to the DynamoDB events table for extract, load, update, upgrade, and unload.
