### PR TITLE
Show latest and next run time (in humane format)

### DIFF
--- a/etc/.bash_history
+++ b/etc/.bash_history
@@ -1,5 +1,6 @@
 develop
 arthur.py bootstrap_sources
+arthur.py summarize_events
 arthur.py show_pipelines
 arthur.py sync --deploy
 arthur.py validate -nskq

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1592,7 +1592,7 @@ class TailEventsCommand(SubCommand):
 class ShowHelpCommand(SubCommand):
     def __init__(self):
         super().__init__("help", "show help by topic", "Show helpful information around selected topic.")
-        self.topics = ["extract", "load", "unload", "sync", "validate"]
+        self.topics = ["extract", "load", "unload", "sync", "validate", "pipeline"]
 
     def add_arguments(self, parser):
         parser.set_defaults(log_level="CRITICAL")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+arrow==1.0.2
 boto3==1.17.40
 botocore~=1.20
 funcy==1.15


### PR DESCRIPTION
This adds the topic `pipeline` so that we can show the AWS CLI steps related to our pipelines:
```
arthur.py help pipeline
```

This also adds the "next run time" column when listing pipelines:
```
arthur.py show_pipelines
...
 Pipeline ID             | Name                                                             | Health   | State     | Latest Run Time     | Next Run Time
-------------------------+------------------------------------------------------------------+----------+-----------+---------------------+---------------------
 df-056386333NEAJBBCRDBX | ETL Rebuild Pipeline (development @ 2021-01-24T23:30:00, N=1000) | HEALTHY  | SCHEDULED | 2021-03-29T23:30:00 | 2021-03-30T23:30:00
 df-00888888X0A5DQKL887F | Validation Pipeline (tom @ 2021-03-30T13:20:39, N=1)             | HEALTHY  | SCHEDULED | 20 minutes ago      | ---
```

Note that timestamps are translated to text when they are within 2 hours, like `20 minutes ago`.

Deltas that show the time elapsed in a pipeline action are also human:
```
 Instance Name                                    | Type                 | Status                  | Actual Start Time   | Actual End Time     | Elapsed
--------------------------------------------------+----------------------+-------------------------+---------------------+---------------------+-----------
 @Copy Startup Scripts (EC2)_2021-03-31T14:09:11  | ShellCommandActivity | FINISHED                | 2021-03-31T14:09:20 | 2021-03-31T14:11:28 | 2 minutes
```
