### PR TITLE
Obey Ctrl-C at last

### DIFF
--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -23,6 +23,7 @@ from urllib.parse import unquote
 
 import pgpasslib
 import psycopg2
+import psycopg2.extensions
 import psycopg2.extras
 import psycopg2.pool
 
@@ -32,6 +33,9 @@ from etl.timer import Timer
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+# Allow Ctrl-C to interrupt a query. See https://www.psycopg.org/docs/faq.html#faq-interrupt-query
+psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
 
 
 def parse_connection_string(dsn: str) -> Dict[str, str]:

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1208,7 +1208,7 @@ def update_data_warehouse(
 def run_query(relation: RelationDescription, limit=None):
     """Run the query for the relation (which must be a transformation, not a source)."""
     dsn_etl = etl.config.get_dw_config().dsn_etl
-    query_stmt = relation.query_stmt + "\nLIMIT %s"
+    query_stmt = f"-- run_query:{relation.identifier}\n" + relation.query_stmt + "\nLIMIT %s"
 
     with Timer() as timer, closing(etl.db.connection(dsn_etl, autocommit=True)) as conn:
         logger.info(

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1208,7 +1208,7 @@ def update_data_warehouse(
 def run_query(relation: RelationDescription, limit=None):
     """Run the query for the relation (which must be a transformation, not a source)."""
     dsn_etl = etl.config.get_dw_config().dsn_etl
-    query_stmt = f"-- run_query:{relation.identifier}\n" + relation.query_stmt + "\nLIMIT %s"
+    query_stmt = relation.query_stmt + "\nLIMIT %s"
 
     with Timer() as timer, closing(etl.db.connection(dsn_etl, autocommit=True)) as conn:
         logger.info(


### PR DESCRIPTION
This PR follows this example here: https://www.psycopg.org/docs/faq.html#faq-interrupt-query
and sets the callback such that a Ctrl-C on the keyboard during interactive work will actually interrupt the query.

When the query is interrupted, it shows up as "aborted" in the Redshift cluster's list of queries.

Until now, users had to pause the job using Ctrl-Z and then use job control with something like `kill %1` to stop the query.

Example output:
```
2021-03-07 01:57:03 - INFO - Running query underlying 'dw.fact_order' (with 'LIMIT 10')
^C2021-03-07 01:57:45 - CRITICAL - Something terrible happened:
Traceback (most recent call last):
  File "/opt/src/arthur-redshift-etl/python/etl/commands.py", line 76, in execute_or_bail
    yield
  File "/opt/src/arthur-redshift-etl/python/etl/commands.py", line 145, in run_arg_as_command
    args.func(args, dw_config)
  File "/opt/src/arthur-redshift-etl/python/etl/commands.py", line 1143, in callback
    etl.load.run_query(transformations[0], args.limit)
  File "/opt/src/arthur-redshift-etl/python/etl/load.py", line 1220, in run_query
    results = etl.db.query(conn, query_stmt, (limit,))
  File "/opt/src/arthur-redshift-etl/python/etl/db.py", line 184, in query
    return execute(cx, stmt, args, return_result=True)
  File "/opt/src/arthur-redshift-etl/python/etl/db.py", line 203, in execute
    cursor.execute(executable_statement)
  File "/opt/local/redshift_etl/venv/lib64/python3.7/site-packages/psycopg2/extras.py", line 146, in execute
    return super(DictCursor, self).execute(query, vars)
psycopg2.errors.QueryCanceled: Query (596937) cancelled on user's request

2021-03-07 01:57:45 - INFO - Ran for 42.03s before encountering disaster!
Bailing out: psycopg2.errors.QueryCanceled: Query (596937) cancelled on user's request
```

This PR also reduces the clutter from traceback when it is an "ETL" error.