### PR TITLE
Filter the "AUTO" setting for column encoding

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -59,8 +59,7 @@ def get_config_value(name: str, default: Optional[str] = None) -> Optional[str]:
     assert _mapped_config is not None, "attempted to get config value before reading config map"
     if default is None:
         return _mapped_config.setdefault(name)
-    else:
-        return _mapped_config.setdefault(name, default)
+    return _mapped_config.setdefault(name, default)
 
 
 def get_config_int(name: str, default: Optional[int] = None) -> int:

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -403,11 +403,14 @@ def copy_data(conn: connection, relation: LoadableRelation, dry_run=False):
                 "relation '{}' is missing manifest file '{}'".format(relation.identifier, s3_uri)
             )
 
-    compupdate_setting = etl.config.get_config_value("arthur_settings.redshift.relation_column_encoding")
+    compupdate_setting = etl.config.get_config_value("arthur_settings.redshift.relation_column_encoding") or "ON"
     if not relation.is_missing_encoding:
         compupdate = "OFF"
+    elif compupdate_setting == "AUTO":
+        # Override the AUTO option which is allowed in the settings file but not fully implemented.
+        compupdate = "ON"
     else:
-        compupdate = compupdate_setting or "ON"
+        compupdate = compupdate_setting
 
     copy_func = partial(
         etl.dialect.redshift.copy_from_uri,


### PR DESCRIPTION
We currently allow the setting "AUTO" in a settings file to pick an automatic encoding of columns in Redshift tables. But that feature isn't complete. This PR prevents this setting from accidentally being called an breaking the `COPY` statement (with a  `COMPUPDATE AUTO`) by replacing `AUTO` with `ON` (which is ok in `COMPUPDATE ON`.
As before, if encodings are specified for all columns, "compupdate" is turned off.