### PR TITLE
Show parameters of refresh pipeline

### DIFF
--- a/python/etl/templates/pizza_pipeline.json
+++ b/python/etl/templates/pizza_pipeline.json
@@ -29,21 +29,21 @@
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
             "subject": "ETL Rebuild Success (Pizza): ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
-            "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
+            "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nContinue-from parameter: #{mySelection}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
             "subject": "ETL Rebuild Failure (Pizza): ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
-            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nContinue-from parameter: #{mySelection}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
         },
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
             "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
             "subject": "ETL Rebuild Failure (Pizza): ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
-            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nContinue-from parameter: #{mySelection}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
         },
         {
             "id": "ResourceParent",

--- a/python/etl/templates/refresh_pipeline.json
+++ b/python/etl/templates/refresh_pipeline.json
@@ -29,21 +29,21 @@
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
             "subject": "ETL Refresh Success: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
-            "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
+            "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nRefresh parameters: #{mySelection}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
             "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
-            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nRefresh parameters: #{mySelection}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
         },
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
             "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
             "subject": "ETL Refresh Failure: ${object_store.s3.prefix}/current at #{node.@scheduledStartTime}",
-            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nRefresh parameters: #{mySelection}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
         },
         {
             "id": "ResourceParent",


### PR DESCRIPTION
This PR adds the pipeline parameters (for selection of relations) to the success and failure notifications. This makes it easier to re-run refresh pipelines by looking up the parameter in the email, which is unlike today when we have to look up parameters in deployment notices or spreadsheets.
(Although the driver here is refresh, the parameter is also shown for the pizza pipeline.)

Example output in a message:
```
Last node: @Send Health Check After ETL (EC2)_2021-03-18T12:31:27_Attempt=1
PipelineId: df-08176362XEI8C3GGYA1D
Parameters: web_app.orders
Log directory: s3://harrys-data-warehouse-dev/_logs/tom/current/df-08176362XEI8C3GGYA1D
```