### PR TITLE
Release candidate for v1.41.0

### DIFF
--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -152,10 +152,10 @@ case "$action" in
         set -o xtrace
         # shellcheck disable=SC2086
         docker run --rm --tty \
-            --volume "$data_warehouse_path":/opt/data-warehouse \
-            --volume ~/.aws:/home/arthur/.aws \
-            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
             --env ARTHUR_DEFAULT_PREFIX="$target_env" \
+            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
+            --volume ~/.aws:/home/arthur/.aws \
+            --volume "$data_warehouse_path":/opt/data-warehouse \
             $profile_arg \
             "arthur-redshift-etl:$tag" \
             arthur.py sync --force --deploy
@@ -164,13 +164,16 @@ case "$action" in
         set -o xtrace
         # shellcheck disable=SC2086
         docker run --rm --interactive --tty \
-            $publish_arg \
-            --volume "$data_warehouse_path":/opt/data-warehouse \
-            --volume "$(pwd):/opt/src/arthur-redshift-etl" \
+            --env ARTHUR_DEFAULT_PREFIX="$target_env" \
+            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
+            --sysctl net.ipv4.tcp_keepalive_time=300 \
+            --sysctl net.ipv4.tcp_keepalive_intvl=60 \
+            --sysctl net.ipv4.tcp_keepalive_probes=9 \
             --volume ~/.aws:/home/arthur/.aws \
             --volume ~/.ssh:/home/arthur/.ssh:ro \
-            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
-            --env ARTHUR_DEFAULT_PREFIX="$target_env" \
+            --volume "$data_warehouse_path:/opt/data-warehouse" \
+            --volume "$(pwd):/opt/src/arthur-redshift-etl" \
+            $publish_arg \
             $profile_arg \
             "arthur-redshift-etl:$tag"
         ;;
@@ -178,12 +181,15 @@ case "$action" in
         set -o xtrace
         # shellcheck disable=SC2086
         docker run --rm --interactive --tty \
-            $publish_arg \
-            --volume "$data_warehouse_path":/opt/data-warehouse \
+            --env ARTHUR_DEFAULT_PREFIX="$target_env" \
+            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
+            --sysctl net.ipv4.tcp_keepalive_time=300 \
+            --sysctl net.ipv4.tcp_keepalive_intvl=60 \
+            --sysctl net.ipv4.tcp_keepalive_probes=9 \
             --volume ~/.aws:/home/arthur/.aws \
             --volume ~/.ssh:/home/arthur/.ssh:ro \
-            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
-            --env ARTHUR_DEFAULT_PREFIX="$target_env" \
+            --volume "$data_warehouse_path:/opt/data-warehouse" \
+            $publish_arg \
             $profile_arg \
             "arthur-redshift-etl:$tag"
         ;;
@@ -191,10 +197,10 @@ case "$action" in
         set -o xtrace
         # shellcheck disable=SC2086
         docker run --rm --tty \
-            --volume "$data_warehouse_path":/opt/data-warehouse \
-            --volume ~/.aws:/home/arthur/.aws \
-            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
             --env ARTHUR_DEFAULT_PREFIX="$target_env" \
+            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
+            --volume ~/.aws:/home/arthur/.aws \
+            --volume "$data_warehouse_path:/opt/data-warehouse" \
             $profile_arg \
             "arthur-redshift-etl:$tag" \
             upload_env.sh -y
@@ -203,10 +209,10 @@ case "$action" in
         set -o xtrace
         # shellcheck disable=SC2086
         docker run --rm --tty \
-            --volume "$data_warehouse_path":/opt/data-warehouse \
-            --volume ~/.aws:/home/arthur/.aws \
-            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
             --env ARTHUR_DEFAULT_PREFIX="$target_env" \
+            --env DATA_WAREHOUSE_CONFIG="/opt/data-warehouse/$config_path" \
+            --volume ~/.aws:/home/arthur/.aws \
+            --volume "$data_warehouse_path":/opt/data-warehouse \
             $profile_arg \
             "arthur-redshift-etl:$tag" \
             install_validation_pipeline.sh

--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -17,6 +17,7 @@ _arthur_completion()
                 auto_design
                 bootstrap_sources
                 bootstrap_transformations
+                create_groups
                 create_index
                 create_schemas
                 create_user

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1451,7 +1451,13 @@ class QueryEventsCommand(SubCommand):
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["prefix"])
-        parser.add_argument("--columns", help="comma-separated list of output columns")
+        parser.add_argument(
+            "--column",
+            action="append",
+            choices=["step", "event", "elapsed", "rowcount"],
+            help="select output column (in addition to target and timestamp),"
+            " use multiple times so add more columns",
+        )
         parser.add_argument("etl_id", help="pick particular ETL from the past", nargs="?")
 
     def callback(self, args, config):
@@ -1460,7 +1466,7 @@ class QueryEventsCommand(SubCommand):
             # Going back two days should cover at least one complete and one running rebuild ETL.
             etl.monitor.query_for_etl_ids(days_ago=2)
         else:
-            etl.monitor.scan_etl_events(args.etl_id, args.columns)
+            etl.monitor.scan_etl_events(args.etl_id, args.column)
 
 
 class SummarizeEventsCommand(SubCommand):

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -293,6 +293,7 @@ def build_full_parser(prog_name):
         # Commands to deal with data warehouse as admin:
         InitializeSetupCommand,
         ShowRandomPassword,
+        CreateGroupsCommand,
         CreateUserCommand,
         UpdateUserCommand,
         # Commands to help with table designs and uploading them
@@ -574,6 +575,25 @@ class ShowRandomPassword(SubCommand):
         random_password = uuid.uuid4().hex
         example_password = random_password[:16].upper() + random_password[16:].lower()
         print(example_password)
+
+
+class CreateGroupsCommand(SubCommand):
+    def __init__(self):
+        super().__init__(
+            "create_groups",
+            "create all groups from the configuration",
+            "Make sure that all groups mentioned in the configuration file actually exist."
+            " (This allows to specify a group (as reader or writer) on a schema when that"
+            " group does not appear with a user and thus may not have been previously"
+            " created using a 'create_user' call.)",
+        )
+
+    def add_arguments(self, parser):
+        add_standard_arguments(parser, ["dry-run"])
+
+    def callback(self, args, config):
+        with etl.db.log_error():
+            etl.data_warehouse.create_groups(dry_run=args.dry_run)
 
 
 class CreateUserCommand(SubCommand):

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -399,8 +399,9 @@ def add_standard_arguments(parser, options):
         parser.add_argument(
             "--continue-from",
             help="skip forward in execution until the specified relation, then work forward from it"
-            " (the special token '*' is allowed to signify continuing from the first relation;"
-            " use ':transformations' as the argument to continue from the first transformation)",
+            " (the special token '*' is allowed to signify continuing from the first relation,"
+            " use ':transformations' as the argument to continue from the first transformation,)"
+            " otherwise specify an exact relation or source name)",
         )
     if "pattern" in options:
         parser.add_argument(

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -101,7 +101,7 @@
       "json": ["varchar(65535)", "%s::varchar(65535)", "string"],
       # N.B. This requires a PostgreSQL version of 9.3 or better.
       "hstore": ["varchar(65535)", "public.hstore_to_json(%s)::varchar(65535)", "string"],
-      "uuid": ["varchar(36)", "%s::varchar(36)", "string"],
+      "uuid": ["varchar(36)", "%s::varchar(36)", "uuid"],
       # The numeric data type without precision and scale should not be used upstream!
       "numeric": ["decimal(18,4)", "%s::decimal(18,4)", "string"],
       # The bytea data type is probably not useful, but we'll try to pull it in base64 format.

--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -39,14 +39,15 @@
             "description": "Generic type modeled loosely after Avro and Hive with easy mapping to those",
             "enum": [
                 "boolean",
+                "date",
+                "decimal",
+                "double",
+                "float",
                 "int",
                 "long",
-                "float",
-                "double",
-                "decimal",
                 "string",
                 "timestamp",
-                "date"
+                "uuid"
             ]
         },
         "compression_encoding": {

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -21,6 +21,7 @@ from urllib.parse import unquote
 
 import pgpasslib
 import psycopg2
+import psycopg2.extensions
 import psycopg2.extras
 import psycopg2.pool
 from psycopg2.extensions import connection as Connection  # only used for typing
@@ -31,6 +32,9 @@ from etl.timer import Timer
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+# Allow Ctrl-C to interrupt a query. See https://www.psycopg.org/docs/faq.html#faq-interrupt-query
+psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
 
 
 def parse_connection_string(dsn: str) -> Dict[str, str]:

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -81,8 +81,21 @@ def _dsn_connection_values(dsn_dict: Dict[str, str], application_name: str) -> d
 
     This includes popping "subprotocol" from our dictionary of parameters extracted
     from the connection string, which is not expected by psycopg2.connect().
+
+    We also set some basic connection parameters here, including connection timeout and
+    keepalives settings.
     """
-    dsn_values = dict(dsn_dict, application_name=application_name, cursor_factory=psycopg2.extras.DictCursor)
+    # See https://www.postgresql.org/docs/10/libpq-connect.html for the keepalive* args.
+    # and https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-firewall-guidance.html
+    dsn_values = dict(
+        application_name=application_name,
+        connect_timeout=30,
+        cursor_factory=psycopg2.extras.DictCursor,
+        keepalives=1,
+        keepalives_idle=30,
+        keepalives_interval=60,
+    )
+    dsn_values.update(dsn_dict)
     dsn_values.pop("subprotocol", None)
     return dsn_values
 
@@ -99,7 +112,6 @@ def connection(dsn_dict: Dict[str, str], application_name=psycopg2.__name__, aut
     """
     dsn_values = _dsn_connection_values(dsn_dict, application_name)
     logger.info("Connecting to: %s", unparse_connection(dsn_values))
-    dsn_values.update(keepalives=1, keepalives_idle=30)
     cx = psycopg2.connect(**dsn_values)
     cx.set_session(autocommit=autocommit, readonly=readonly)
     logger.debug(

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -16,7 +16,7 @@ import etl.relation
 import etl.s3
 from etl.config.dw import DataWarehouseSchema
 from etl.design import Attribute, ColumnDefinition
-from etl.names import TableName, TableSelector, join_with_quotes
+from etl.names import TableName, TableSelector, join_with_single_quotes
 from etl.relation import RelationDescription
 
 logger = logging.getLogger(__name__)
@@ -480,10 +480,14 @@ def create_table_designs_from_source(source, selector, local_dir, local_files, d
     upstream = frozenset(name.identifier for name in source_tables)
     not_found = upstream.difference(existent)
     if not_found:
-        logger.warning("New table(s) in source '%s' without local design: %s", source.name, join_with_quotes(not_found))
+        logger.warning(
+            "New table(s) in source '%s' without local design: %s", source.name, join_with_single_quotes(not_found)
+        )
     too_many = existent.difference(upstream)
     if too_many:
-        logger.error("Local table design(s) without table in source '%s': %s", source.name, join_with_quotes(too_many))
+        logger.error(
+            "Local table design(s) without table in source '%s': %s", source.name, join_with_single_quotes(too_many)
+        )
 
     return len(source_tables)
 

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -20,7 +20,7 @@ import etl.db
 import etl.file_sets
 import etl.s3
 from etl.errors import SchemaValidationError, TableDesignParseError, TableDesignSemanticError, TableDesignSyntaxError
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -139,7 +139,7 @@ def validate_column_references(table_design):
             cols = [col for constraint in constraints for col in constraint.get(key, [])]
         else:  # 'attributes'
             cols = table_design.get(obj, {}).get(key, [])
-        unknown = join_with_quotes(frozenset(cols).difference(valid_columns))
+        unknown = join_with_single_quotes(frozenset(cols).difference(valid_columns))
         if unknown:
             raise TableDesignSemanticError(
                 "{key} columns in {obj} contain unknown column(s): {unknown}".format(obj=obj, key=key, unknown=unknown)

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -14,6 +14,11 @@ import funcy as fy
 import yaml
 import yaml.parser
 
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader  # type: ignore
+
 import etl
 import etl.config
 import etl.db
@@ -33,11 +38,9 @@ def load_table_design(stream, table_name):
     The table design is validated before being returned.
     """
     try:
-        table_design = yaml.safe_load(stream)
+        table_design = yaml.load(stream, Loader=SafeLoader)
     except yaml.parser.ParserError as exc:
         raise TableDesignParseError(exc) from exc
-
-    etl.config.validate_with_schema(table_design, "table_design.schema")
 
     # We used to specify constraints using an object (before v0.24.0) and then switched to using
     # an array of objects (with v0.24.0). This rewrites the constraints into the new format

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -1,4 +1,4 @@
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 
 class ETLError(Exception):
@@ -147,7 +147,7 @@ class MissingExtractEventError(RelationDataError):
         missing_relations = [relation for relation in source_relations if relation.identifier not in extracted_targets]
         self.message = (
             "Some source relations did not have extract events after the step start time: "
-            + join_with_quotes(missing_relations)
+            + join_with_single_quotes(missing_relations)
         )
 
     def __str__(self):
@@ -172,7 +172,7 @@ class FailedConstraintError(RelationDataError):
 
 class RequiredRelationLoadError(ETLRuntimeError):
     def __init__(self, failed_relations, bad_apple=None):
-        self.message = "required relation(s) with failure: " + join_with_quotes(failed_relations)
+        self.message = "required relation(s) with failure: " + join_with_single_quotes(failed_relations)
         if bad_apple:
             self.message += ", triggered by load failure of '{}'".format(bad_apple)
 

--- a/python/etl/extract/__init__.py
+++ b/python/etl/extract/__init__.py
@@ -36,7 +36,7 @@ from etl.extract.spark import SparkExtractor
 from etl.extract.sqoop import SqoopExtractor
 from etl.extract.static import StaticExtractor
 from etl.relation import RelationDescription
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -105,5 +105,5 @@ def filter_relations_for_sources(
     selected = [relation for relation in relations if relation.source_name in source_lookup]
     if selected:
         sources = frozenset(relation.source_name for relation in selected)
-        logger.info("Selected %d relation(s) from source(s): %s", len(selected), join_with_quotes(sources))
+        logger.info("Selected %d relation(s) from source(s): %s", len(selected), join_with_single_quotes(sources))
     return selected

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -17,7 +17,7 @@ import etl.s3
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import DataExtractError, ETLRuntimeError, MissingCsvFilesError
 from etl.relation import RelationDescription
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 from etl.timer import Timer
 from etl.util.retry import call_with_retry
 
@@ -156,7 +156,9 @@ class Extractor:
             else:
                 done, not_done = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_EXCEPTION)
         if self.failed_sources:
-            self.logger.error("Failed to extract from these source(s): %s", join_with_quotes(self.failed_sources))
+            self.logger.error(
+                "Failed to extract from these source(s): %s", join_with_single_quotes(self.failed_sources)
+            )
 
         # Note that iterating over result of futures may raise an exception which surfaces
         # exceptions from threads. This happens when there is (at least) one required table
@@ -169,7 +171,7 @@ class Extractor:
             self.logger.warning(
                 "Failed to extract %d relation(s): %s",
                 len(missing_tables),
-                join_with_quotes(missing_tables),
+                join_with_single_quotes(missing_tables),
             )
         if not_done:
             raise DataExtractError("Extract failed to complete for {:d} source(s)".format(len(not_done)))

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1095,6 +1095,7 @@ def load_data_warehouse(
         tx_info = etl.data_warehouse.list_open_transactions(conn)
         etl.db.print_result("List of sessions that have open transactions:", tx_info)
 
+    etl.data_warehouse.create_groups(dry_run=dry_run)
     create_schemas_for_rebuild(traversed_schemas, use_staging=use_staging, dry_run=dry_run)
     try:
         create_relations(

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -76,7 +76,7 @@ from etl.errors import (
 )
 from etl.names import TableName, TableSelector, TempTableName
 from etl.relation import RelationDescription
-from etl.text import join_column_list, join_with_quotes
+from etl.text import join_with_double_quotes, join_with_single_quotes
 from etl.timer import Timer
 from etl.util.retry import call_with_retry
 
@@ -203,7 +203,9 @@ class LoadableRelation:
         identifiers = [dependent.identifier for dependent in dependents]
         if identifiers:
             logger.warning(
-                "Continuing while leaving %d relation(s) empty: %s", len(identifiers), join_with_quotes(identifiers)
+                "Continuing while leaving %d relation(s) empty: %s",
+                len(identifiers),
+                join_with_single_quotes(identifiers),
             )
 
     @property
@@ -359,11 +361,11 @@ def grant_access(conn: connection, relation: LoadableRelation, dry_run=False):
         if dry_run:
             logger.info(
                 "Dry-run: Skipping granting of select access on {:x} to {}".format(
-                    relation, join_with_quotes(reader_groups)
+                    relation, join_with_single_quotes(reader_groups)
                 )
             )
         else:
-            logger.info("Granting select access on {:x} to {}".format(relation, join_with_quotes(reader_groups)))
+            logger.info("Granting select access on {:x} to {}".format(relation, join_with_single_quotes(reader_groups)))
             for reader in reader_groups:
                 etl.db.grant_select(conn, target.schema, target.table, reader)
 
@@ -371,11 +373,11 @@ def grant_access(conn: connection, relation: LoadableRelation, dry_run=False):
         if dry_run:
             logger.info(
                 "Dry-run: Skipping granting of write access on {:x} to {}".format(
-                    relation, join_with_quotes(writer_groups)
+                    relation, join_with_single_quotes(writer_groups)
                 )
             )
         else:
-            logger.info("Granting write access on {:x} to {}".format(relation, join_with_quotes(writer_groups)))
+            logger.info("Granting write access on {:x} to {}".format(relation, join_with_single_quotes(writer_groups)))
             for writer in writer_groups:
                 etl.db.grant_select_and_write(conn, target.schema, target.table, writer)
 
@@ -507,7 +509,7 @@ def load_ctas_using_temp_table(conn: connection, relation: LoadableRelation, dry
         ]
         insert_from_query(conn, relation, table_name=temp_name, columns=temp_columns, dry_run=dry_run)
 
-        inner_stmt = "SELECT {} FROM {}".format(join_column_list(relation.unquoted_columns), temp_name)
+        inner_stmt = "SELECT {} FROM {}".format(join_with_double_quotes(relation.unquoted_columns), temp_name)
         if relation.target_table_name.table.startswith("dim_"):
             missing_dimension = create_missing_dimension_row(relation.table_design["columns"])
             inner_stmt += "\nUNION ALL SELECT {}".format(", ".join(missing_dimension))
@@ -559,7 +561,7 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
 
     for constraint in constraints:
         [[constraint_type, columns]] = constraint.items()  # There will always be exactly one item.
-        quoted_columns = join_column_list(columns)
+        quoted_columns = join_with_double_quotes(columns)
         if constraint_type == "unique":
             condition = " AND ".join('"{}" IS NOT NULL'.format(name) for name in columns)
         else:
@@ -569,14 +571,14 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
         if dry_run:
             logger.info(
                 "Dry-run: Skipping check of {} constraint in {:x} on column(s): {}".format(
-                    constraint_type, relation, join_with_quotes(columns)
+                    constraint_type, relation, join_with_single_quotes(columns)
                 )
             )
             etl.db.skip_query(conn, statement)
         else:
             logger.info(
                 "Checking {} constraint in {:x} on column(s): {}".format(
-                    constraint_type, relation, join_with_quotes(columns)
+                    constraint_type, relation, join_with_single_quotes(columns)
                 )
             )
             results = etl.db.query(conn, statement)
@@ -917,7 +919,7 @@ def create_source_tables_when_ready(
 
     failed = [relation.identifier for relation in source_relations if relation.failed]
     if failed:
-        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_quotes(failed))
+        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_single_quotes(failed))
     logger.info("Finished with %d relation(s) in source schemas (%s)", len(source_relations), timer)
 
 
@@ -976,7 +978,7 @@ def create_source_tables_in_parallel(relations: List[LoadableRelation], max_conc
 
     failed = [relation.identifier for relation in source_relations if relation.failed]
     if failed:
-        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_quotes(failed))
+        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_single_quotes(failed))
     logger.info("Finished with %d relation(s) in source schemas (%s)", len(source_relations), timer)
 
 
@@ -1013,12 +1015,12 @@ def create_transformations_sequentially(relations: List[LoadableRelation], wlm_q
 
     failed = [relation.identifier for relation in transformations if relation.failed]
     if failed:
-        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_quotes(failed))
+        logger.error("These %d relation(s) failed to build: %s", len(failed), join_with_single_quotes(failed))
     skipped = [
         relation.identifier for relation in transformations if relation.skip_copy and not relation.is_view_relation
     ]
     if 0 < len(skipped) < len(transformations):
-        logger.warning("These %d relation(s) were left empty: %s", len(skipped), join_with_quotes(skipped))
+        logger.warning("These %d relation(s) were left empty: %s", len(skipped), join_with_single_quotes(skipped))
     logger.info("Finished with %d relation(s) in transformation schemas (%s)", len(transformations), timer)
 
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -210,10 +210,12 @@ class LoadableRelation:
     def query_stmt(self) -> str:
         stmt = self._relation_description.query_stmt
         if self.use_staging:
-            # Rewrite the query to use staging schemas:
+            # Rewrite the query to use staging schemas by changing identifiers to their staging
+            # version. This requires all tables to be fully qualified. There is a small chance
+            # that we're too aggressive and change a table name inside a string.
             for dependency in self.dependencies:
                 staging_dependency = dependency.as_staging_table_name()
-                stmt = re.sub(r"\b" + dependency.identifier + r"\b", staging_dependency.identifier, stmt)
+                stmt = re.sub(dependency.identifier_as_re, staging_dependency.identifier, stmt)
         return stmt
 
     @property

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -27,18 +27,19 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from http import HTTPStatus
 from operator import itemgetter
-from typing import Dict, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 import boto3
 import botocore.exceptions
 import funcy as fy
 import simplejson as json
+from boto3.dynamodb.types import TypeDeserializer
 from tqdm import tqdm
 
 import etl.assets
 import etl.config
 import etl.text
-from etl.errors import ETLRuntimeError, InvalidArgumentError
+from etl.errors import ETLRuntimeError
 from etl.json_encoder import FancyJsonEncoder
 from etl.timer import Timer, elapsed_seconds, utc_now
 
@@ -570,30 +571,6 @@ def _format_output_column(key: str, value: str) -> str:
         return value
 
 
-def _flatten_scan_result(result: dict) -> dict:
-    """
-    Remove type annotation from a scan result.
-
-    Careful, this only works for a specific subset of types that DynamoDB may send back.
-
-    >>> result = _flatten_scan_result(
-    ...     {'step': {'S': 'load'}, 'extra': {'M': {'rowcount': {'N': '100'}}}})
-    >>> sorted(result)
-    ['extra', 'step']
-    >>> result['extra']['rowcount']
-    '100'
-    """
-    flat = {}
-    for key, value in result.items():
-        if "S" in value:
-            flat[key] = value["S"]
-        elif "N" in value:
-            flat[key] = value["N"]
-        elif "M" in value:
-            flat[key] = _flatten_scan_result(value["M"])
-    return flat
-
-
 def _query_for_etls(step=None, hours_ago=0, days_ago=0) -> List[dict]:
     """Search for ETLs by looking for the "marker" event at the start of an ETL command."""
     start_time = datetime.utcnow() - timedelta(days=days_ago, hours=hours_ago)
@@ -641,21 +618,21 @@ def query_for_etl_ids(hours_ago=0, days_ago=0) -> None:
     print(etl.text.format_lines(rows, header_row=keys))
 
 
-def scan_etl_events(etl_id, comma_separated_columns) -> None:
-    """Scan for all events belonging to a specific ETL."""
+def scan_etl_events(etl_id, selected_columns: Optional[Iterable[str]] = None) -> None:
+    """
+    Scan for all events belonging to a specific ETL.
+
+    If a list of columns is provided, then the output is limited to those columns.
+    But note that the target (schema.table) and the event are always present.
+    """
     ddb = DynamoDBStorage.factory()
     table = ddb.get_table(create_if_not_exists=False)
-    all_keys = ["target", "step", "event", "timestamp", "elapsed", "rowcount"]
-    if comma_separated_columns:
-        selected_columns = comma_separated_columns.split(",")
-        invalid_columns = [key for key in selected_columns if key not in all_keys]
-        if invalid_columns:
-            raise InvalidArgumentError("invalid column(s): {}".format(",".join(invalid_columns)))
-        # We will always select "target" and "event" to have a meaningful output.
-        selected_columns = frozenset(selected_columns).union(["target", "event"])
-        keys = [key for key in all_keys if key in selected_columns]
-    else:
-        keys = all_keys
+    available_columns = ["target", "step", "event", "timestamp", "elapsed", "rowcount"]
+    if selected_columns is None:
+        selected_columns = available_columns
+    # We will always select "target" and "event" to have a meaningful output.
+    columns = list(fy.filter(frozenset(selected_columns).union(["target", "event"]), available_columns))
+    keys = ["extra.rowcount" if column == "rowcount" else column for column in columns]
 
     # We need to scan here since the events are stored by "target" and not by "etl_id".
     # TODO Try to find all the "known" relations and query on them with a filter on the etl_id.
@@ -677,22 +654,28 @@ def scan_etl_events(etl_id, comma_separated_columns) -> None:
         #     "PageSize": 100
         # }
     )
-    logger.info("Scanning events table for elapsed times")
+    logger.info("Scanning events table '%s' for elapsed times", table.name)
     consumed_capacity = 0.0
     scanned_count = 0
     rows: List[List[str]] = []
+    deserialize = TypeDeserializer().deserialize
+
     for response in response_iterator:
         consumed_capacity += response["ConsumedCapacity"]["CapacityUnits"]
         scanned_count += response["ScannedCount"]
-        items = [_flatten_scan_result(item) for item in response["Items"]]
-        items = [{key: fy.get_in(item, key.split(".")) for key in keys} for item in items]
+        # We need to turn something like "'event': {'S': 'finish'}" into "'event': 'finish'".
+        deserialized = [{key: deserialize(value) for key, value in item.items()} for item in response["Items"]]
+        # Lookup "elapsed" or "extra.rowcount" (the latter as ["extra", "rowcount"]).
+        items = [{key: fy.get_in(item, key.split(".")) for key in keys} for item in deserialized]
+        # Scope down to selected keys and format the columns.
         rows.extend([_format_output_column(key, item[key]) for key in keys] for item in items)
+
     logger.info("Scan result: scanned count = %d, consumed capacity = %f", scanned_count, consumed_capacity)
     if "timestamp" in keys:
         rows.sort(key=itemgetter(keys.index("timestamp")))
     else:
         rows.sort(key=itemgetter(keys.index("target")))
-    print(etl.text.format_lines(rows, header_row=keys))
+    print(etl.text.format_lines(rows, header_row=columns))
 
 
 class EventsQuery:
@@ -841,6 +824,7 @@ def summarize_events(relations, step: Optional[str] = None) -> None:
     for relation in tqdm(relations):
         event = query(table, relation.identifier, latest_start)
         if event:
+            # Make the column for row counts easier to read by dropping "extra.".
             event["rowcount"] = event.pop("extra.rowcount")
             events.append(dict(event, kind=relation.kind))
             schema = relation.target_table_name.schema

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -9,6 +9,7 @@ by a pattern from the command line.
 """
 
 import fnmatch
+import re
 import uuid
 from typing import List, Optional
 
@@ -151,6 +152,22 @@ class TableName:
         'hello.world'
         """
         return "{}.{}".format(*self.to_tuple())
+
+    @property
+    def identifier_as_re(self) -> str:
+        r"""
+        Return a regular expression that would look for the (unquoted) identifier.
+
+        >>> tn = TableName("dw", "fact")
+        >>> tn.identifier_as_re
+        '\\bdw\\.fact\\b'
+        >>> import re
+        >>> re.match(tn.identifier_as_re, "dw.fact") is not None
+        True
+        >>> re.match(tn.identifier_as_re, "dw_fact") is None
+        True
+        """
+        return r"\b{}\b".format(re.escape(self.identifier))
 
     @property
     def is_managed(self) -> bool:

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 
 import etl.config
 from etl.errors import ETLSystemError
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 
 def as_staging_name(name):
@@ -463,7 +463,7 @@ class TableSelector:
         if len(self._patterns) == 0:
             return "['*.*']"
         else:
-            return "[{}]".format(join_with_quotes(p.identifier for p in self._patterns))
+            return "[{}]".format(join_with_single_quotes(p.identifier for p in self._patterns))
 
     def match_schema(self, schema) -> bool:
         """

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -12,7 +12,7 @@ import funcy
 import simplejson as json
 
 import etl.text
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -287,12 +287,12 @@ def show_pipelines(selection: List[str], as_json=False) -> None:
             logger.warning("Selection matched more than one pipeline")
         logger.info(
             "Currently selected pipelines: %s",
-            join_with_quotes(pipeline.pipeline_id for pipeline in pipelines),
+            join_with_single_quotes(pipeline.pipeline_id for pipeline in pipelines),
         )
     else:
         logger.info(
             "Available pipelines: %s",
-            join_with_quotes(pipeline.pipeline_id for pipeline in pipelines),
+            join_with_single_quotes(pipeline.pipeline_id for pipeline in pipelines),
         )
     if as_json:
         print(DataPipeline.as_json(pipelines))

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -39,7 +39,7 @@ import etl.timer
 from etl.config.dw import DataWarehouseSchema
 from etl.errors import CyclicDependencyError, ETLRuntimeError, MissingQueryError
 from etl.names import TableName, TableSelector, TempTableName
-from etl.text import join_with_quotes
+from etl.text import join_with_single_quotes
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -290,7 +290,9 @@ class RelationDescription:
             if file_set.design_file_name is not None:
                 relations.append(cls(file_set))
             else:
-                logger.warning("Found file(s) without matching table design: %s", join_with_quotes(file_set.files))
+                logger.warning(
+                    "Found file(s) without matching table design: %s", join_with_single_quotes(file_set.files)
+                )
 
         if required_relation_selector:
             set_required_relations(relations, required_relation_selector)
@@ -434,7 +436,7 @@ def _sanitize_dependencies(descriptions: List[SortableRelationDescription]) -> N
             logger.info(
                 "The following dependencies for relation '%s' are not managed by Arthur: %s",
                 description.identifier,
-                join_with_quotes([dep.identifier for dep in unmanaged_dependencies]),
+                join_with_single_quotes([dep.identifier for dep in unmanaged_dependencies]),
             )
         if pg_catalog_dependencies:
             has_pg_catalog_dependencies.add(description.target_table_name)
@@ -442,11 +444,11 @@ def _sanitize_dependencies(descriptions: List[SortableRelationDescription]) -> N
     if has_unknown_dependencies:
         logger.warning(
             "These relations were unknown during dependency ordering: %s",
-            join_with_quotes([dep.identifier for dep in known_unknowns]),
+            join_with_single_quotes([dep.identifier for dep in known_unknowns]),
         )
         logger.warning(
             "This caused these relations to have dependencies that are not known: %s",
-            join_with_quotes([dep.identifier for dep in has_unknown_dependencies]),
+            join_with_single_quotes([dep.identifier for dep in has_unknown_dependencies]),
         )
 
     # Make tables that depend on tables in pg_catalog depend on all our tables (except those

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -22,12 +22,12 @@ import logging
 import os.path
 from contextlib import closing, contextmanager
 from copy import deepcopy
-from functools import partial
 from operator import attrgetter
 from queue import PriorityQueue
-from typing import Any, Dict, FrozenSet, List, Optional, Tuple, Union
+from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Tuple, Union
 
 import funcy as fy
+from tqdm import tqdm
 
 import etl.config
 import etl.db
@@ -126,31 +126,70 @@ class RelationDescription:
         else:
             raise ValueError("unsupported format code '{}' passed to RelationDescription".format(code))
 
-    def load(self) -> None:
+    def load(self, callback=None) -> None:
         """
         Force a loading of the table design (which is normally loaded "on demand").
 
         Strictly speaking, this isn't thread-safe. But if you worry about thread safety here,
         rethink your code.
         """
-        if self._table_design is None:
-            if self.bucket_name:
-                loader = partial(etl.design.load.load_table_design_from_s3, self.bucket_name)
-            else:
-                loader = partial(etl.design.load.load_table_design_from_localfile)
-            self._table_design = loader(self.design_file_name, self.target_table_name)
+        if self._table_design is not None:
+            pass  # previously (pre-)loaded
+        elif self.scheme == "s3":
+            self._table_design = etl.design.load.load_table_design_from_s3(
+                self.bucket_name, self.design_file_name, self.target_table_name
+            )
+        else:
+            self._table_design = etl.design.load.load_table_design_from_localfile(
+                self.design_file_name, self.target_table_name
+            )
+        if callback is not None:
+            callback()
 
     @staticmethod
-    def load_in_parallel(relations: List["RelationDescription"]) -> None:
-        """Load all relations' table design file in parallel."""
+    def load_in_parallel(relations: Sequence["RelationDescription"]) -> None:
+        """
+        Load all relations' table design file in parallel.
+
+        If there no relation left which hasn't loaded the table design, do nothing.
+        If there is only one relation, then that one is loaded directly and without threads.
+        If there are only two relations, then both are loaded directly and without threads.
+        If there are more than two relations, then the first is loaded directly to validate
+        our setup (in particular the schemas of table designs) and then rest is actually
+        loaded in parallel using threads.
+        """
+        remaining_relations = [relation for relation in relations if relation._table_design is None]
+        if len(remaining_relations) == 0:
+            return
+
+        # This section loads threads directly up to the "parallel start index".
+        timer = etl.timer.Timer()
+        parallel_start_index = 2 if len(remaining_relations) == 2 else 1
+        for relation in remaining_relations[:parallel_start_index]:
+            relation.load()
+        if parallel_start_index == len(remaining_relations):
+            logger.info("Finished loading %d table design file(s) (%s)", len(remaining_relations), timer)
+            return
+
+        # This section loads the remaining relations from the "parallel start index" onwards
+        # and shows a pretty loading bar (but only if this goes to a terminal).
+        tqdm_bar = tqdm(desc="Loading table designs", disable=None, leave=False, total=len(remaining_relations))
+        tqdm_bar.update(parallel_start_index)
         max_workers = 8
-        logger.debug("Starting parallel load of %d table design file(s) on %d workers.", len(relations), max_workers)
-        with etl.timer.Timer() as timer:
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=max_workers, thread_name_prefix="load-parallel"
-            ) as executor:
-                executor.map(lambda relation: relation.load(), relations)
-        logger.info("Finished loading %d table design file(s) (%s)", len(relations), timer)
+        logger.debug(
+            "Starting parallel load of %d table design file(s) on %d workers.",
+            len(remaining_relations[parallel_start_index:]),
+            max_workers,
+        )
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="load-parallel"
+        ) as executor:
+            executor.map(lambda relation: relation.load(tqdm_bar.update), remaining_relations[parallel_start_index:])
+
+        tqdm_bar.close()
+        logger.info(
+            "Finished loading %d table design file(s) in %d threads (%s)", len(remaining_relations), max_workers, timer
+        )
 
     @property  # This property is lazily loaded.
     def table_design(self) -> Dict[str, Any]:

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -173,7 +173,9 @@ class RelationDescription:
 
         # This section loads the remaining relations from the "parallel start index" onwards
         # and shows a pretty loading bar (but only if this goes to a terminal).
-        tqdm_bar = tqdm(desc="Loading table designs", disable=None, leave=False, total=len(remaining_relations))
+        tqdm_bar = tqdm(
+            desc="Loading table designs", disable=None, leave=False, total=len(remaining_relations), unit="file"
+        )
         tqdm_bar.update(parallel_start_index)
         max_workers = 8
         logger.debug(

--- a/python/etl/selftest.py
+++ b/python/etl/selftest.py
@@ -45,7 +45,7 @@ def load_tests(loader, tests, pattern):
     See https://docs.python.org/3.5/library/unittest.html#load-tests-protocol
     """
     etl_modules = sorted(mod for mod in sys.modules if mod.startswith("etl"))
-    logger.info("Adding tests from %s", etl.names.join_with_quotes(etl_modules))
+    logger.info("Adding tests from %s", etl.names.join_with_single_quotes(etl_modules))
     for mod in etl_modules:
         tests.addTests(doctest.DocTestSuite(mod))
     return tests

--- a/python/etl/sync.py
+++ b/python/etl/sync.py
@@ -15,14 +15,16 @@ configuration file by copying it up to S3.
 import concurrent.futures
 import logging
 import os.path
-from typing import List
+from typing import List, Sequence, Tuple
+
+from tqdm import tqdm
 
 import etl.config
 import etl.file_sets
 import etl.s3
+import etl.timer
 from etl.errors import ETLRuntimeError, MissingQueryError
 from etl.relation import RelationDescription
-from etl.timer import Timer
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -44,40 +46,59 @@ def upload_settings(config_files, bucket_name, prefix, dry_run=False) -> None:
         uploader(fullname, object_key)
 
 
-def sync_with_s3(relations: List[RelationDescription], bucket_name: str, prefix: str, dry_run: bool = False) -> None:
+def sync_with_s3(
+    relations: Sequence[RelationDescription], bucket_name: str, prefix: str, dry_run: bool = False
+) -> None:
     """Copy (validated) table design and SQL files from local directory to S3 bucket."""
     logger.info("Validating %d table design(s) before upload", len(relations))
     RelationDescription.load_in_parallel(relations)
 
-    files = []  # typing: List[Tuple[str, str]]
+    # Collect list of (local file, remote file) pairs to send to the uploader.
+    files: List[Tuple[str, str]] = []
     for relation in relations:
-        relation_files = [relation.design_file_name]
         if relation.is_transformation:
-            if relation.sql_file_name:
-                relation_files.append(relation.sql_file_name)
-            else:
-                raise MissingQueryError("Missing matching SQL file for '%s'" % relation.design_file_name)
+            if relation.sql_file_name is None:
+                raise MissingQueryError("missing matching SQL file for '%s'" % relation.design_file_name)
+            relation_files = [relation.design_file_name, relation.sql_file_name]
+        else:
+            relation_files = [relation.design_file_name]
+
         for file_name in relation_files:
             local_filename = relation.norm_path(file_name)
             remote_filename = os.path.join(prefix, local_filename)
             files.append((local_filename, remote_filename))
 
-    uploader = etl.s3.S3Uploader(bucket_name, dry_run=dry_run)
-    with Timer() as timer:
-        futures = []  # typing: List[concurrent.futures.Future]
-        # TODO With Python 3.6, we should pass in a thread_name_prefix
-        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
-            for local_filename, remote_filename in files:
-                futures.append(executor.submit(uploader.__call__, local_filename, remote_filename))
-        errors = 0
-        for future in concurrent.futures.as_completed(futures):
-            exception = future.exception()
-            if exception is not None:
-                logger.error("Failed to upload file: %s", exception)
-                errors += 1
-    if not dry_run:
+    timer = etl.timer.Timer()
+    tqdm_bar = tqdm(desc="Upoading files to S3", disable=None, leave=False, total=len(files))
+
+    uploader = etl.s3.S3Uploader(bucket_name, callback=tqdm_bar.update, dry_run=dry_run)
+    max_workers = 8
+
+    # We break out the futures to be able to easily tally up errors.
+    futures: List[concurrent.futures.Future] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="sync-parallel") as executor:
+        for local_filename, remote_filename in files:
+            futures.append(executor.submit(uploader.__call__, local_filename, remote_filename))
+
+    errors = 0
+    for future in concurrent.futures.as_completed(futures):
+        exception = future.exception()
+        if exception is not None:
+            logger.error("Failed to upload file: %s", exception)
+            errors += 1
+
+    tqdm_bar.close()
+    if dry_run:
+        logger.info("Dry-run: Skipped uploading %d file(s) to 's3://%s/%s (%s)", len(files), bucket_name, prefix, timer)
+    else:
         logger.info(
-            "Uploaded %d of %d file(s) to 's3://%s/%s (%s)", len(files) - errors, len(files), bucket_name, prefix, timer
+            "Uploaded %d of %d file(s) to 's3://%s/%s' in %d threads (%s)",
+            len(files) - errors,
+            len(files),
+            bucket_name,
+            prefix,
+            max_workers,
+            timer,
         )
     if errors:
         raise ETLRuntimeError("There were {:d} error(s) during upload".format(errors))

--- a/python/etl/sync.py
+++ b/python/etl/sync.py
@@ -69,7 +69,7 @@ def sync_with_s3(
             files.append((local_filename, remote_filename))
 
     timer = etl.timer.Timer()
-    tqdm_bar = tqdm(desc="Upoading files to S3", disable=None, leave=False, total=len(files))
+    tqdm_bar = tqdm(desc="Uploading files to S3", disable=None, leave=False, total=len(files), unit="file")
 
     uploader = etl.s3.S3Uploader(bucket_name, callback=tqdm_bar.update, dry_run=dry_run)
     max_workers = 8

--- a/python/etl/text.py
+++ b/python/etl/text.py
@@ -1,11 +1,11 @@
 """
 Deal with text, mostly around iterables of texts which we want to pretty print.
 
-Should not import Arthur modules (so that etl.errors remains widely importable)
+Should not import other Arthur modules so that etl.text remains widely importable.
 """
 
 import textwrap
-from typing import List
+from typing import Iterable
 
 from tabulate import tabulate
 
@@ -45,7 +45,7 @@ def approx_pretty_size(total_bytes) -> str:
     return "{:d}{}".format(div, unit)
 
 
-def join_with_quotes(names):
+def join_with_single_quotes(names: Iterable[str]) -> str:
     """
     Individually wrap the names in quotes and return comma-separated names in a string.
 
@@ -53,22 +53,29 @@ def join_with_quotes(names):
     If the input is a list of names, the order of the list is respected.
     If the input is cheese, the order is for more red wine.
 
-    >>> join_with_quotes(["foo", "bar"])
+    >>> join_with_single_quotes(["foo", "bar"])
     "'foo', 'bar'"
-    >>> join_with_quotes({"foo", "bar"})
+    >>> join_with_single_quotes({"foo", "bar"})
     "'bar', 'foo'"
-    >>> join_with_quotes(frozenset(["foo", "bar"]))
+    >>> join_with_single_quotes(frozenset(["foo", "bar"]))
     "'bar', 'foo'"
     """
     if isinstance(names, (set, frozenset)):
         return ", ".join("'{}'".format(name) for name in sorted(names))
-    else:
-        return ", ".join("'{}'".format(name) for name in names)
+    return ", ".join("'{}'".format(name) for name in names)
 
 
-def join_column_list(columns: List[str], sep=", ") -> str:
-    """Return string with comma-separated, delimited column names."""
-    return sep.join('"{}"'.format(column) for column in columns)
+def join_with_double_quotes(names: Iterable[str], sep=", ", prefix="") -> str:
+    """
+    Return string with comma-separated, delimited names.
+
+    This step ensures that our identifiers are wrapped in double quotes.
+    >>> join_with_double_quotes(["foo", "bar"])
+    '"foo", "bar"'
+    >>> join_with_double_quotes(["foo", "bar"], sep=", USER ", prefix="USER ")
+    'USER "foo", USER "bar"'
+    """
+    return prefix + sep.join('"{}"'.format(name) for name in names)
 
 
 def whitespace_cleanup(value: str) -> str:


### PR DESCRIPTION
## Combined PRs
* Escape . from schema.table as schema[.]table #326
* Add sysctl to docker run #328
* Add UUID type #346
* Make sure to create all groups when loading warehouse #349
* Use extra.rowcount with query_events #350
* Grant and revoke for groups within one statement #352
* Allow to continue from specific source schema #358
* Improve load speed of table design files #360
* Obey Ctrl-C at last #369

## User-visible Changes
* It is possible to restart using a pizza pipeline for a specific upstream source.  So after fixing the upstream source and have re-extracted it, you can load that source and then start from the transformations:
```
install_pizza_pipeline.sh production www_app
```
* Ctrl-C will interrupt queries now.
* New command to create all groups (which also happens at start of `load`)
```
arthur.py create_groups
```
* Upstream UUID columns will keep the UUID type in table design files.
* For long-running queries change your host environment:
```
sudo sysctl net.inet.tcp.always_keepalive=1
```
* Connection attempts are aborted after 30s.
* Granting and revoking permissions is simplified.
* Load speed is faster after switching the implementation for the YAML loader.

## Internal API Changes

In `etl.text` some utility functions are renamed to make it easier to distinguish them and use them.

Old name | New name
---|---
`join_with_quotes`  | `join_with_single_quotes`
`join_column_list` | `join_with_double_quotes`

## Bug Fixes
* To use `compare_events.py`, the `query_events` command returns `rowcount` correctly again.
* CTEs that have similar names to sources or transformations are not accidentally substituted when using staging schemas.
* Ensure that all groups are created before we try to grant access to those groups. 