### PR TITLE
Add encoding of columns automatically

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -8,7 +8,6 @@
     "insert_data_retries": 3,
     "retriable_error_codes": "8001,15001,15005",
     "redshift": {
-      # Computing column encoding is turned off if all columns have a specified encoding.
       "relation_column_encoding": "ON"
     }
   },
@@ -22,7 +21,6 @@
     "owner": {
       "name": "dw",
       "group": "etl_rw"
-
     },
     "users": [
       {

--- a/python/etl/design/__init__.py
+++ b/python/etl/design/__init__.py
@@ -30,17 +30,21 @@ class ColumnDefinition:
     These are ready to be sent to a table design or come from a table design file.
     """
 
-    __slots__ = ("name", "type", "sql_type", "source_sql_type", "expression", "not_null")
+    __slots__ = ("name", "type", "sql_type", "source_sql_type", "expression", "not_null", "identity", "encoding")
 
-    def __init__(self, name, source_sql_type, sql_type, expression, type_, not_null):
+    def __init__(
+        self, name, source_sql_type, sql_type, expression, type_, not_null, identity=False, encoding=None
+    ) -> None:
         self.name = name
         self.source_sql_type = source_sql_type
         self.sql_type = sql_type
         self.expression = expression
         self.type = type_
         self.not_null = not_null
+        self.identity = identity
+        self.encoding = encoding
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         d = dict(name=self.name, sql_type=self.sql_type, type=self.type)
         if self.expression is not None:
             d["expression"] = self.expression
@@ -49,6 +53,19 @@ class ColumnDefinition:
         if self.not_null:
             d["not_null"] = self.not_null
         return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ColumnDefinition":
+        return cls(
+            name=d["name"],
+            source_sql_type=d.get("source_sql_type"),
+            sql_type=d.get("sql_type"),
+            expression=d.get("expression"),
+            type_=d.get("type"),
+            not_null=d.get("not_null"),
+            identity=d.get("identity"),
+            encoding=d.get("encoding"),
+        )
 
     @staticmethod
     def from_attribute(attribute, as_is_att_type, cast_needed_att_type, default_att_type):

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -76,7 +76,7 @@ def fetch_tables(cx: Connection, source: DataWarehouseSchema, selector: TableSel
 
 
 def fetch_attributes(cx: Connection, table_name: TableName) -> List[Attribute]:
-    """Retrieve table definition (column names and types)."""
+    """Retrieve attribute definition (column names and types)."""
     # Make sure to turn on "User Parameters" in the Database settings of PyCharm so that `%s`
     # works in the editor.
     if isinstance(table_name, TempTableName) and table_name.is_late_binding_view:
@@ -92,7 +92,8 @@ def fetch_attributes(cx: Connection, table_name: TableName) -> List[Attribute]:
                      , col_num int)
              WHERE view_schema LIKE %s
                AND view_name = %s
-             ORDER BY col_num"""
+             ORDER BY col_num
+            """
     else:
         stmt = """
             SELECT a.attname AS "name"
@@ -106,7 +107,8 @@ def fetch_attributes(cx: Connection, table_name: TableName) -> List[Attribute]:
                AND NOT a.attisdropped
                AND ns.nspname LIKE %s
                AND cls.relname = %s
-             ORDER BY a.attnum"""
+             ORDER BY a.attnum
+            """
     attributes = etl.db.query(cx, stmt, (table_name.schema, table_name.table))
     return [Attribute(**att) for att in attributes]
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -414,15 +414,6 @@ def copy_data(conn: connection, relation: LoadableRelation, dry_run=False):
                 "relation '{}' is missing manifest file '{}'".format(relation.identifier, s3_uri)
             )
 
-    compupdate_setting = etl.config.get_config_value("arthur_settings.redshift.relation_column_encoding") or "ON"
-    if not relation.is_missing_encoding:
-        compupdate = "OFF"
-    elif compupdate_setting == "AUTO":
-        # Override the AUTO option which is allowed in the settings file but not fully implemented.
-        compupdate = "ON"
-    else:
-        compupdate = compupdate_setting
-
     copy_func = partial(
         etl.dialect.redshift.copy_from_uri,
         conn,
@@ -433,7 +424,6 @@ def copy_data(conn: connection, relation: LoadableRelation, dry_run=False):
         data_format=relation.schema_config.s3_data_format.format,
         format_option=relation.schema_config.s3_data_format.format_option,
         file_compression=relation.schema_config.s3_data_format.compression,
-        compupdate=compupdate,
         dry_run=dry_run,
     )
     if relation.in_transaction:

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -269,7 +269,7 @@ class RelationDescription:
                     query_stmt = f.read()
 
             self._query_stmt = query_stmt.strip().rstrip(";")
-        return str(self._query_stmt)  # The str(...) shuts up the type checker.
+        return self._query_stmt
 
     @property
     def dependencies(self) -> FrozenSet[TableName]:
@@ -316,11 +316,6 @@ class RelationDescription:
         (Should only ever be possible for CTAS, see validation code).
         """
         return any(column.get("identity") for column in self.table_design["columns"])
-
-    @property
-    def is_missing_encoding(self) -> bool:
-        """Return whether any column doesn't have encoding specified."""
-        return any(not column.get("encoding") for column in self.table_design["columns"] if not column.get("skipped"))
 
     @classmethod
     def from_file_sets(cls, file_sets, required_relation_selector=None) -> List["RelationDescription"]:


### PR DESCRIPTION
This changes the ETL so that during a `COPY` statement, we can avoid having the database guess a best encoding of a column based on values it sees. Instead, we pass in the appropriate encodings. This mostly follows what `PRESET` would do except that we also allow to override a default in the table design file. 

Compare with https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-load.html#copy-compupdate.

Defaults:
* Columns used as distribution, sort or foreign keys: `RAW`  (includes "identity" columns)
* Columns that are boolean, double or float: `RAW`
* Columns that are integers (big or small), numeric, dates or timestamps: `AZ64`
* Else: `ZSTD`

Any values set in the table design file will override the default.

Note that you can observe the chosen encoding by:
* Setting `relation_column_encoding` to `AUTO`. You can do this by creating a new config file with this content:
```yaml
{
  "arthur_settings": {
    "redshift": {
       "relation_column_encoding": "AUTO"
    }
  }
}
```
* Running `arthur.py show_ddl` on a table.