### PR TITLE
Move create_index to etl.relation, remove config from callbacks

### DIFF
--- a/bin/build_virtual_env
+++ b/bin/build_virtual_env
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+
+set -o errexit -o nounset
+
+ARTHUR_VENV="${1-arthur_venv}"
+
+case "$ARTHUR_VENV" in
+    -h|--help|help)
+        cat <<USAGE
+Usage: $0 [virtual_env]
+
+Builds or updates your virtual environment (by default: 'arthur_venv').
+USAGE
+        exit
+        ;;
+esac
+
+echo "Creating or upating virutal environment in $ARTHUR_VENV"
+python3 -m venv "$ARTHUR_VENV"
+source "$ARTHUR_VENV/bin/activate"
+
+echo "Creating or upating packages using pip..."
+python3 -m pip install --upgrade pip==20.3.4 --disable-pip-version-check
+python3 -m pip install --upgrade --requirement ./requirements-dev.txt --disable-pip-version-check
+
+echo "# To use this setup, you need to run:"
+echo "source '$ARTHUR_VENV/bin/activate'"

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1246,18 +1246,14 @@ class CreateIndexCommand(SubCommand):
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern"])
-        parser.add_argument("--group", action="append", default=[], help="filter by reader group (repeat as needed)")
+        parser.add_argument("--group", help="filter by reader group")
 
     def callback(self, args):
-        dw_config = etl.config.get_dw_config()
         local_files = etl.file_sets.find_file_sets(self.location(args, "file"), args.pattern)
         descriptions = [
             etl.relation.RelationDescription(file_set) for file_set in local_files if file_set.design_file_name
         ]
-        unknown = frozenset(args.group).difference(dw_config.groups)
-        if unknown:
-            raise InvalidArgumentError(f"unknown group(s): {join_with_single_quotes(unknown)}")
-        etl.relation.create_index(descriptions, args.group)
+        etl.relation.create_index(descriptions, group=args.group)
 
 
 class ListFilesCommand(SubCommand):

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -148,8 +148,7 @@ def run_arg_as_command(my_name="arthur.py"):
             if isinstance(getattr(args, "pattern", None), etl.names.TableSelector):
                 args.pattern.base_schemas = [schema.name for schema in dw_config.schemas]
 
-            # TODO(tom): Remove dw_config and let sub-commands handle it!
-            args.func(args, dw_config)
+            args.func(args)
 
 
 def submit_step(cluster_id, sub_command):
@@ -519,7 +518,7 @@ class SubCommand:
 
         return descriptions
 
-    def callback(self, args, config):
+    def callback(self, args):
         """Override this method for sub-classes."""
         raise NotImplementedError("Instance of {} has no proper callback".format(self.__class__.__name__))
 
@@ -561,10 +560,11 @@ class InitializeSetupCommand(SubCommand):
             action="store_true",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         with etl.db.log_error():
             etl.data_warehouse.initial_setup(
-                config, with_user_creation=args.with_user_creation, force=args.force, dry_run=args.dry_run
+                dw_config, with_user_creation=args.with_user_creation, force=args.force, dry_run=args.dry_run
             )
 
 
@@ -579,7 +579,7 @@ class ShowRandomPassword(SubCommand):
     def add_arguments(self, parser):
         parser.set_defaults(log_level="CRITICAL")
 
-    def callback(self, args, config):
+    def callback(self, args):
         random_password = uuid.uuid4().hex
         example_password = random_password[:16].upper() + random_password[16:].lower()
         print(example_password)
@@ -624,7 +624,7 @@ class CreateUserCommand(SubCommand):
         )
         parser.add_argument("username", help="name for new user")
 
-    def callback(self, args, config):
+    def callback(self, args):
         with etl.db.log_error():
             etl.data_warehouse.create_new_user(
                 args.username, group=args.group, add_user_schema=args.add_user_schema, dry_run=args.dry_run
@@ -651,7 +651,7 @@ class UpdateUserCommand(SubCommand):
         )
         parser.add_argument("username", help="name of existing user")
 
-    def callback(self, args, config):
+    def callback(self, args):
         with etl.db.log_error():
             etl.data_warehouse.update_user(
                 args.username, group=args.group, add_user_schema=args.add_user_schema, dry_run=args.dry_run
@@ -671,10 +671,11 @@ class BootstrapSourcesCommand(SubCommand):
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern", "dry-run"])
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         local_files = etl.file_sets.find_file_sets(self.location(args, "file"), args.pattern, allow_empty=True)
         etl.design.bootstrap.bootstrap_sources(
-            config.schemas, args.pattern, args.table_design_dir, local_files, dry_run=args.dry_run
+            dw_config.schemas, args.pattern, args.table_design_dir, local_files, dry_run=args.dry_run
         )
 
 
@@ -705,11 +706,12 @@ class BootstrapTransformationsCommand(SubCommand):
         )
         add_standard_arguments(parser, ["pattern", "dry-run"])
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         local_files = etl.file_sets.find_file_sets(self.location(args, "file"), args.pattern)
         etl.design.bootstrap.bootstrap_transformations(
-            config.dsn_etl,
-            config.schemas,
+            dw_config.dsn_etl,
+            dw_config.schemas,
             args.table_design_dir,
             local_files,
             args.type == "VIEW",
@@ -747,7 +749,7 @@ class SyncWithS3Command(SubCommand):
             action="store_true",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
         if args.deploy_config:
             etl.sync.upload_settings(args.config, args.bucket_name, args.prefix, dry_run=args.dry_run)
         if args.force:
@@ -814,7 +816,8 @@ class ExtractToS3Command(MonitoredSubCommand):
             action="store_true",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         max_partitions = args.max_partitions or etl.config.get_config_int("resources.EMR.max_partitions")
         if max_partitions < 1:
             raise InvalidArgumentError("option for max partitions must be >= 1")
@@ -835,12 +838,12 @@ class ExtractToS3Command(MonitoredSubCommand):
             sys.exit(1)
 
         descriptions = self.find_relation_descriptions(
-            args, default_scheme="s3", required_relation_selector=config.required_in_full_load_selector
+            args, default_scheme="s3", required_relation_selector=dw_config.required_in_full_load_selector
         )
         etl.monitor.Monitor.marker_payload("extract").emit(dry_run=args.dry_run)
         etl.extract.extract_upstream_sources(
             args.extractor,
-            config.schemas,
+            dw_config.schemas,
             descriptions,
             max_partitions=max_partitions,
             use_sampling=args.use_sampling,
@@ -879,14 +882,18 @@ class LoadDataWarehouseCommand(MonitoredSubCommand):
             dest="use_staging_schemas",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         try:
             args.pattern.selected_schemas()
         except ValueError as exc:
             raise InvalidArgumentError(exc) from exc
 
         relations = self.find_relation_descriptions(
-            args, default_scheme="s3", required_relation_selector=config.required_in_full_load_selector, return_all=True
+            args,
+            default_scheme="s3",
+            required_relation_selector=dw_config.required_in_full_load_selector,
+            return_all=True,
         )
         etl.monitor.Monitor.marker_payload("load").emit(dry_run=args.dry_run)
         max_concurrency = args.max_concurrency or etl.config.get_config_int(
@@ -937,9 +944,13 @@ class UpgradeDataWarehouseCommand(MonitoredSubCommand):
             dest="use_staging_schemas",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         relations = self.find_relation_descriptions(
-            args, default_scheme="s3", required_relation_selector=config.required_in_full_load_selector, return_all=True
+            args,
+            default_scheme="s3",
+            required_relation_selector=dw_config.required_in_full_load_selector,
+            return_all=True,
         )
         etl.monitor.Monitor.marker_payload("upgrade").emit(dry_run=args.dry_run)
         max_concurrency = args.max_concurrency or etl.config.get_config_int(
@@ -994,7 +1005,7 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
             action="store_true",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
         relations = self.find_relation_descriptions(args, default_scheme="s3", return_all=True)
         etl.monitor.Monitor.marker_payload("update").emit(dry_run=args.dry_run)
         wlm_query_slots = args.wlm_query_slots or etl.config.get_config_int(
@@ -1035,11 +1046,12 @@ class UnloadDataToS3Command(MonitoredSubCommand):
             action="store_true",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         descriptions = self.find_relation_descriptions(args, default_scheme="s3")
         etl.monitor.Monitor.marker_payload("unload").emit(dry_run=args.dry_run)
         etl.unload.unload_to_s3(
-            config, descriptions, allow_overwrite=args.force, keep_going=args.keep_going, dry_run=args.dry_run
+            dw_config, descriptions, allow_overwrite=args.force, keep_going=args.keep_going, dry_run=args.dry_run
         )
 
 
@@ -1063,9 +1075,10 @@ class CreateSchemasCommand(SubCommand):
             "--with-staging", help="create schemas in staging position", default=False, action="store_true"
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         schema_names = args.pattern.selected_schemas()
-        schemas = [schema for schema in config.schemas if schema.name in schema_names]
+        schemas = [schema for schema in dw_config.schemas if schema.name in schema_names]
         with etl.db.log_error():
             if args.with_backup:
                 etl.data_warehouse.backup_schemas(schemas, dry_run=args.dry_run)
@@ -1092,9 +1105,10 @@ class PromoteSchemasCommand(SubCommand):
             required=True,
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         schema_names = args.pattern.selected_schemas()
-        schemas = [schema for schema in config.schemas if schema.name in schema_names]
+        schemas = [schema for schema in dw_config.schemas if schema.name in schema_names]
         with etl.db.log_error():
             if args.from_position == "staging":
                 etl.data_warehouse.publish_schemas(schemas, dry_run=args.dry_run)
@@ -1135,11 +1149,12 @@ class ValidateDesignsCommand(SubCommand):
             action="store_true",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         # This does not pick up all designs to speed things up but that may lead to false positives.
         descriptions = self.find_relation_descriptions(args)
         etl.validate.validate_designs(
-            config,
+            dw_config,
             descriptions,
             keep_going=args.keep_going,
             skip_sources=args.skip_sources_check,
@@ -1170,7 +1185,7 @@ class RunQueryCommand(SubCommand):
             help="use the relations in staging schemas for the query",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
         relations = self.find_relation_descriptions(args)
         transformations = [relation for relation in relations if relation.is_transformation]
         if len(transformations) != 1:
@@ -1190,7 +1205,8 @@ class ExplainQueryCommand(SubCommand):
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern", "prefix", "scheme"])
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         if args.scheme == "file":
             # When running locally, we accept that there be only a SQL file.
             local_files = etl.file_sets.find_file_sets(self.location(args, "file"), args.pattern)
@@ -1201,7 +1217,7 @@ class ExplainQueryCommand(SubCommand):
             # When running with S3, we expect full sets of files (SQL plus table design)
             descriptions = self.find_relation_descriptions(args)
         with etl.db.log_error():
-            etl.explain.explain_queries(config.dsn_etl, descriptions)
+            etl.explain.explain_queries(dw_config.dsn_etl, descriptions)
 
 
 class ShowDdlCommand(SubCommand):
@@ -1215,7 +1231,7 @@ class ShowDdlCommand(SubCommand):
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern"])
 
-    def callback(self, args, config):
+    def callback(self, args):
         local_files = etl.file_sets.find_file_sets(self.location(args, "file"), args.pattern)
         descriptions = [
             etl.relation.RelationDescription(file_set) for file_set in local_files if file_set.design_file_name
@@ -1234,14 +1250,18 @@ class CreateIndexCommand(SubCommand):
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern"])
-        parser.add_argument("--group", help="filter by reader group")
+        parser.add_argument("--group", action="append", default=[], help="filter by reader group (repeat as needed)")
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         local_files = etl.file_sets.find_file_sets(self.location(args, "file"), args.pattern)
         descriptions = [
             etl.relation.RelationDescription(file_set) for file_set in local_files if file_set.design_file_name
         ]
-        etl.design.create_index(descriptions, group=args.group)
+        unknown = frozenset(args.group).difference(dw_config.groups)
+        if unknown:
+            raise InvalidArgumentError(f"unknown group(s): {', '.join(sorted(unknown))}")
+        etl.relation.create_index(descriptions, args.group)
 
 
 class ListFilesCommand(SubCommand):
@@ -1263,7 +1283,7 @@ class ListFilesCommand(SubCommand):
             "-t", "--sort-by-time", help="sort files by timestamp (and list in single column)", action="store_true"
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
         file_sets = etl.file_sets.find_file_sets(self.location(args), args.pattern)
         etl.file_sets.list_files(file_sets, long_format=args.long_format, sort_by_time=args.sort_by_time)
 
@@ -1291,9 +1311,10 @@ class PingCommand(SubCommand):
             nargs="+",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         if args.for_schema is None:
-            dsns = [config.dsn_admin if args.use_admin else config.dsn_etl]
+            dsns = [dw_config.dsn_admin if args.use_admin else dw_config.dsn_etl]
         else:
             try:
                 args.for_schema.base_schemas = [schema.name for schema in config.schemas if schema.is_database_source]
@@ -1322,7 +1343,7 @@ class TerminateSessionsCommand(SubCommand):
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["dry-run"])
 
-    def callback(self, args, config):
+    def callback(self, args):
         with etl.db.log_error():
             etl.data_warehouse.terminate_sessions(dry_run=args.dry_run)
 
@@ -1352,9 +1373,10 @@ class ShowDownstreamDependentsCommand(SubCommand):
             "--with-dependents", help="show list of dependents (upstream) for every relation", action="store_true"
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         relations = self.find_relation_descriptions(
-            args, required_relation_selector=config.required_in_full_load_selector, return_all=True
+            args, required_relation_selector=dw_config.required_in_full_load_selector, return_all=True
         )
         etl.load.show_downstream_dependents(
             relations,
@@ -1377,9 +1399,10 @@ class ShowUpstreamDependenciesCommand(SubCommand):
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern", "prefix", "scheme"])
 
-    def callback(self, args, config):
+    def callback(self, args):
+        dw_config = etl.config.get_dw_config()
         relations = self.find_relation_descriptions(
-            args, required_relation_selector=config.required_in_full_load_selector, return_all=True
+            args, required_relation_selector=dw_config.required_in_full_load_selector, return_all=True
         )
         etl.load.show_upstream_dependencies(relations, args.pattern)
 
@@ -1401,7 +1424,7 @@ class RenderTemplateCommand(SubCommand):
         group.add_argument("template", help="name of template", nargs="?")
         parser.add_argument("-t", "--compact", help="produce compact output", action="store_true")
 
-    def callback(self, args, config):
+    def callback(self, args):
         if args.list:
             etl.render_template.list_templates(compact=args.compact)
         elif args.template:
@@ -1420,7 +1443,7 @@ class ShowValueCommand(SubCommand):
         parser.add_argument("name", help="print the value for the chosen setting")
         parser.add_argument("default", nargs="?", help="set default in case the setting is unset")
 
-    def callback(self, args, config):
+    def callback(self, args):
         etl.render_template.show_value(args.name, args.default)
 
 
@@ -1439,7 +1462,7 @@ class ShowVarsCommand(SubCommand):
         add_standard_arguments(parser, ["prefix"])
         parser.add_argument("name", help="print just the value for the chosen setting", nargs="*")
 
-    def callback(self, args, config):
+    def callback(self, args):
         etl.render_template.show_vars(args.name)
 
 
@@ -1456,7 +1479,7 @@ class ShowPipelinesCommand(SubCommand):
         parser.add_argument("-j", "--as-json", help="write output in JSON format", action="store_true", default=False)
         parser.add_argument("selection", help="pick pipelines using a glob pattern", nargs="*")
 
-    def callback(self, args, config):
+    def callback(self, args):
         etl.pipeline.show_pipelines(args.selection, as_json=args.as_json)
 
 
@@ -1472,7 +1495,7 @@ class DeleteFinishedPipelinesCommand(SubCommand):
         add_standard_arguments(parser, ["dry-run"])
         parser.add_argument("selection", help="pick specific pipelines", nargs="*")
 
-    def callback(self, args, config):
+    def callback(self, args):
         etl.pipeline.delete_finished_pipelines(args.selection, dry_run=args.dry_run)
 
 
@@ -1497,7 +1520,7 @@ class QueryEventsCommand(SubCommand):
         )
         parser.add_argument("etl_id", help="pick particular ETL from the past", nargs="?")
 
-    def callback(self, args, config):
+    def callback(self, args):
         # TODO(tom): This is starting to become awkward: make finding latest ETL a separate command.
         if args.etl_id is None:
             # Going back two days should cover at least one complete and one running rebuild ETL.
@@ -1523,7 +1546,7 @@ class SummarizeEventsCommand(SubCommand):
             help="pick which step to summarize",
         )
 
-    def callback(self, args, config):
+    def callback(self, args):
         relations = self.find_relation_descriptions(args)
         etl.monitor.summarize_events(relations, args.step)
 
@@ -1550,7 +1573,7 @@ class TailEventsCommand(SubCommand):
         )
         parser.add_argument("-f", "--follow", help="keep checking for events", default=False, action="store_true")
 
-    def callback(self, args, config):
+    def callback(self, args):
         start_time = args.start_time or (datetime.utcnow() - timedelta(seconds=15 * 60))
         if args.follow:
             update_interval = 30
@@ -1583,7 +1606,7 @@ class ShowHelpCommand(SubCommand):
         parser.set_defaults(log_level="CRITICAL")
         parser.add_argument("topic", help="select topic", choices=self.topics)
 
-    def callback(self, args, config):
+    def callback(self, args):
         print(sys.modules["etl." + args.topic].__doc__.strip())
 
 
@@ -1596,7 +1619,7 @@ class SelfTestCommand(SubCommand):
         # doesn't mix with test output.
         parser.set_defaults(log_level="CRITICAL")
 
-    def callback(self, args, config):
+    def callback(self, args):
         etl.selftest.run_doctest("etl", args.log_level)
 
 

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -228,7 +228,7 @@ def _update_search_path(conn, user, dry_run=False):
         etl.db.alter_search_path(conn, user.name, search_path)
 
 
-def initial_setup(config, with_user_creation=False, force=False, dry_run=False):
+def initial_setup(with_user_creation=False, force=False, dry_run=False):
     """
     Place named data warehouse database into initial state.
 
@@ -237,6 +237,7 @@ def initial_setup(config, with_user_creation=False, force=False, dry_run=False):
 
     Optionally use `with_user_creation` flag to create users and groups.
     """
+    config = etl.config.get_dw_config()
     try:
         database_name = config.dsn_etl["database"]
     except (KeyError, ValueError) as exc:

--- a/python/etl/design/__init__.py
+++ b/python/etl/design/__init__.py
@@ -1,11 +1,5 @@
 import logging
 import re
-from collections import OrderedDict
-from typing import Dict, List, Optional
-
-from tabulate import tabulate
-
-from etl.relation import RelationDescription
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -86,31 +80,3 @@ class ColumnDefinition:
             mapping_type,
             attribute.not_null,
         )
-
-
-def create_index(relations: List[RelationDescription], group: Optional[str]) -> None:
-    """
-    Create an "index" pages with Markdown that lists all schemas and their tables.
-
-    The parameter group, when used, filters schemas to those that can be accessed
-    by that group.
-    """
-    # TODO(tom): Make sure that group is valid group if passed in.
-    schemas: Dict[str, dict] = OrderedDict()
-    for relation in relations:
-        if not group or group in relation.schema_config.reader_groups:
-            schema = relation.target_table_name.schema
-            if schema not in schemas:
-                schemas[schema] = {"description": relation.schema_config.description or "", "tables": []}
-            schemas[schema]["tables"].append(
-                (relation.target_table_name.table, relation.table_design.get("description") or "")
-            )
-    if schemas:
-        print("# List Of Tables By Schema\n")
-
-    for i, (schema_name, schema_info) in enumerate(schemas.items()):
-        if i:
-            print()
-        print(f"## {schema_name}\n\n{schema_info['description']}\n")
-
-        print(tabulate(schema_info["tables"], headers=("Table", "Description"), tablefmt="pipe"))

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -821,7 +821,7 @@ def summarize_events(relations, step: Optional[str] = None) -> None:
 
     events = []
     schema_events: Dict[str, Dict[str, Union[str, Decimal]]] = {}
-    for relation in tqdm(relations):
+    for relation in tqdm(desc="Querying for events", disable=None, iterable=relations, leave=False, unit="table"):
         event = query(table, relation.identifier, latest_start)
         if event:
             # Make the column for row counts easier to read by dropping "extra.".

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -192,7 +192,10 @@ class RelationDescription:
 
         tqdm_bar.close()
         logger.info(
-            "Finished loading %d table design file(s) in %d threads (%s)", len(remaining_relations), max_workers, timer
+            "Finished loading %d table design file(s) using %d threads (%s)",
+            len(remaining_relations),
+            max_workers,
+            timer,
         )
 
     @property  # This property is lazily loaded.

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -25,7 +25,7 @@ from contextlib import closing, contextmanager
 from copy import deepcopy
 from operator import attrgetter
 from queue import PriorityQueue
-from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Tuple, Union
 
 import funcy as fy
 from tabulate import tabulate
@@ -723,17 +723,17 @@ def select_in_execution_order(
     raise InvalidArgumentError("found no matching relations to continue from")
 
 
-def create_index(relations: List[RelationDescription], groups: Iterable[str]) -> None:
+def create_index(relations: List[RelationDescription], group: Optional[str]) -> None:
     """
     Create an "index" page with Markdown that lists all schemas and their tables.
 
     The parameter group, when used, filters schemas to those that can be accessed
     by that group.
     """
-    group_set = frozenset(groups)
+    # TODO(tom): Make sure that group is valid group if passed in.
     schemas: Dict[str, dict] = OrderedDict()
     for relation in relations:
-        if not group_set or group_set.intersection(relation.schema_config.reader_groups):
+        if not group or group in relation.schema_config.reader_groups:
             schema = relation.target_table_name.schema
             if schema not in schemas:
                 schemas[schema] = {"description": relation.schema_config.description or "", "tables": []}
@@ -741,12 +741,10 @@ def create_index(relations: List[RelationDescription], groups: Iterable[str]) ->
                 (relation.target_table_name.table, relation.table_design.get("description") or "")
             )
     if schemas:
-        print("# List Of Tables By Schema\n")
+        print("# List Of Tables By Schema")
 
-    for i, (schema_name, schema_info) in enumerate(schemas.items()):
-        if i:
-            print()
-        print(f"## {schema_name}\n")
+    for schema_name, schema_info in schemas.items():
+        print(f"\n## {schema_name}\n")
         if schema_info["description"]:
             print(f"{schema_info['description']}\n")
 

--- a/python/etl/sync.py
+++ b/python/etl/sync.py
@@ -92,7 +92,7 @@ def sync_with_s3(
         logger.info("Dry-run: Skipped uploading %d file(s) to 's3://%s/%s (%s)", len(files), bucket_name, prefix, timer)
     else:
         logger.info(
-            "Uploaded %d of %d file(s) to 's3://%s/%s' in %d threads (%s)",
+            "Uploaded %d of %d file(s) to 's3://%s/%s' using %d threads (%s)",
             len(files) - errors,
             len(files),
             bucket_name,


### PR DESCRIPTION
## User-facing changes

There is a new script `bin/build_virtual_env` to help manage virtual environments outside the Docker
image to make it easier to run linters or build docs.

## Internal changes

### Remove the data-warehouse config from the callback calls:
```diff
-            args.func(args, dw_config)
+            args.func(args)
```
The value of `dw_config` wasn't always used. Removing the extra arg simplifies code.

### Move `create_index` into `etl.relation`
This prevents cyclic imports in future code changes.