### PR TITLE
Deploy config by default, use tqdm for delete

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -136,7 +136,7 @@ def run_arg_as_command(my_name="arthur.py"):
 
                 # Create name used as prefix for resources, like DynamoDB tables or SNS topics
                 base_env = etl.config.get_config_value("resources.VPC.name").replace("dw-vpc-", "dw-etl-", 1)
-                etl.config.set_safe_config_value("resource_prefix", "{}-{}".format(base_env, args.prefix))
+                etl.config.set_safe_config_value("resource_prefix", f"{base_env}-{args.prefix}")
 
                 if getattr(args, "use_monitor"):
                     etl.monitor.start_monitors(args.prefix)
@@ -192,6 +192,14 @@ def submit_step(cluster_id, sub_command):
         croak(exc, 1)
 
 
+class WideHelpFormatter(argparse.RawTextHelpFormatter):
+    """Help formatter for argument parser that sets a wider max for help position."""
+
+    # This boldly ignores the message: "Only the name of this class is considered a public API."
+    def __init__(self, prog, indent_increment=2, max_help_position=30, width=None) -> None:
+        super().__init__(prog, indent_increment, max_help_position, width)
+
+
 class FancyArgumentParser(argparse.ArgumentParser):
     """
     Fancier version of the argument parser supporting "@file".
@@ -211,8 +219,9 @@ class FancyArgumentParser(argparse.ArgumentParser):
     """
 
     def __init__(self, **kwargs) -> None:
+        formatter_class = kwargs.pop("formatter_class", WideHelpFormatter)
         fromfile_prefix_chars = kwargs.pop("fromfile_prefix_chars", "@")
-        super().__init__(fromfile_prefix_chars=fromfile_prefix_chars, **kwargs)
+        super().__init__(formatter_class=formatter_class, fromfile_prefix_chars=fromfile_prefix_chars, **kwargs)
 
     def convert_arg_line_to_args(self, arg_line: str) -> List[str]:
         """
@@ -286,7 +295,7 @@ def build_full_parser(prog_name):
     parser = build_basic_parser(prog_name, description="This command allows to drive the ETL steps.")
 
     package = etl.config.package_version()
-    parser.add_argument("-V", "--version", action="version", version="%(prog)s ({})".format(package))
+    parser.add_argument("-V", "--version", action="version", version=f"%(prog)s ({package})")
 
     # Details for sub-commands lives with sub-classes of sub-commands.
     # Hungry? Get yourself a sub-way.
@@ -770,37 +779,52 @@ class SyncWithS3Command(SubCommand):
         super().__init__(
             "sync",
             "copy table design files to S3",
-            "Copy table design files from local directory to S3."
-            " If using the '--force' option, this will delete schema and *data* files."
-            " If using the '--deploy' option, this will also upload files with warehouse settings"
+            "Copy table design files from your local directory to S3."
+            " By default, this also copies configuration files"
             " (*.yaml or *.sh files in config directories, excluding credentials*.sh).",
         )
 
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["pattern", "prefix", "dry-run"])
         parser.add_argument(
-            "-f",
-            "--force",
-            help="force sync (deletes all matching files first, including data)",
-            default=False,
-            action="store_true",
-        )
-        parser.add_argument(
             "-d",
             "--deploy-config",
-            help="sync local settings files (*.yaml, *.sh) to <prefix>/config folder",
-            default=False,
             action="store_true",
+            default=True,
+            help="sync local settings files (*.yaml, *.sh) to <prefix>/config folder (default)",
+        )
+        parser.add_argument(
+            "--without-deploy-config",
+            action="store_false",
+            dest="deploy_config",
+            help="do not sync local settings files (*.yaml, *.sh) to <prefix>/config folder",
+        )
+        parser.add_argument(
+            "--delete",
+            action="store_true",
+            default=False,
+            help="delete matching table design and SQL files to make sure target has no extraneous files",
+        )
+        parser.add_argument(
+            "-f",
+            "--force",
+            action="store_true",
+            default=False,
+            help="force sync which deletes all matching files, including data",
         )
 
     def callback(self, args):
-        if args.deploy_config:
-            etl.sync.upload_settings(args.config, args.bucket_name, args.prefix, dry_run=args.dry_run)
-        if args.force:
-            etl.file_sets.delete_files_in_s3(args.bucket_name, args.prefix, args.pattern, dry_run=args.dry_run)
-
         relations = self.find_relation_descriptions(args, default_scheme="file")
-        etl.sync.sync_with_s3(relations, args.bucket_name, args.prefix, dry_run=args.dry_run)
+        etl.sync.sync_with_s3(
+            relations,
+            args.config,
+            args.bucket_name,
+            args.prefix,
+            deploy_config=args.deploy_config,
+            delete_schemas_pattern=args.pattern if args.delete or args.force else None,
+            delete_data_pattern=args.pattern if args.force else None,
+            dry_run=args.dry_run,
+        )
 
 
 class ExtractToS3Command(MonitoredSubCommand):
@@ -1652,7 +1676,7 @@ class ShowHelpCommand(SubCommand):
         parser.add_argument("topic", help="select topic", choices=self.topics)
 
     def callback(self, args):
-        print(sys.modules["etl." + args.topic].__doc__.strip())
+        print(sys.modules["etl." + args.topic].__doc__.strip() + "\n")
 
 
 class SelfTestCommand(SubCommand):

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -16,7 +16,7 @@ import re
 import sys
 from collections import OrderedDict
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, List, Optional, Set
 
 import jsonschema
 import pkg_resources
@@ -228,7 +228,7 @@ def get_release_info() -> str:
     return "Release information: " + release_info
 
 
-def yield_config_files(config_files: Sequence[str], default_file: str = None) -> Iterable[str]:
+def yield_config_files(config_files: Iterable[str], default_file: str = None) -> Iterable[str]:
     """
     Generate filenames from the list of files or directories in config_files and default_file.
 
@@ -249,7 +249,7 @@ def yield_config_files(config_files: Sequence[str], default_file: str = None) ->
             yield filename
 
 
-def load_config(config_files: Sequence[str], default_file: str = "default_settings.yaml") -> None:
+def load_config(config_files: Iterable[str], default_file: str = "default_settings.yaml") -> None:
     """
     Load settings and environment from config files and set our global settings.
 
@@ -311,7 +311,7 @@ def validate_with_schema(obj: dict, schema_name: str) -> None:
         raise SchemaValidationError("failed to validate against '%s'" % schema_name) from exc
 
 
-def gather_setting_files(config_files: Sequence[str]) -> List[str]:
+def gather_setting_files(config_files: Iterable[str]) -> List[str]:
     """
     Gather all settings files (*.yaml and *.sh files) that should be deployed together.
 
@@ -326,12 +326,12 @@ def gather_setting_files(config_files: Sequence[str]) -> List[str]:
         filename = os.path.basename(fullname)
         if filename.startswith("credentials") and filename.endswith(".sh"):
             continue
-        if filename.endswith((".yaml", ".yml", ".sh")):
-            if filename not in settings_found:
-                settings_found.add(filename)
-            else:
-                raise KeyError("found configuration file in multiple locations: '%s'" % filename)
-            settings_with_path.append(fullname)
+        if not filename.endswith((".yaml", ".yml", ".sh")):
+            continue
+        if filename in settings_found:
+            raise KeyError("found configuration file in multiple locations: '%s'" % filename)
+        settings_found.add(filename)
+        settings_with_path.append(fullname)
     return sorted(settings_with_path)
 
 

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -179,7 +179,7 @@ class RelationDescription:
             desc="Loading table designs", disable=None, leave=False, total=len(remaining_relations), unit="file"
         )
         tqdm_bar.update(parallel_start_index)
-        max_workers = 8
+        max_workers = min(len(remaining_relations) - parallel_start_index, 8)
         logger.debug(
             "Starting parallel load of %d table design file(s) on %d workers.",
             len(remaining_relations[parallel_start_index:]),

--- a/python/etl/sync.py
+++ b/python/etl/sync.py
@@ -1,59 +1,79 @@
 """
-Sync publishes the data warehouse code (and optionally configuration).
+Sync publishes the data warehouse code and its configuration.
 
-While we copy data into S3, we'll validate the table design files to minimize
-chances of failing ETLs.  (It's still best to run the validate command!)
+Example usage:
+  arthur.py sync
+  arthur.py sync dw
+
+While we copy files into S3, we'll validate the table design files to minimize
+chances of failing ETLs. It's still best to run the validate command first.
+
+If you have removed files locally, you can cleanup the files in S3 using the
+delete option:
+  arthur.py sync --delete
 
 When the table design changes for a table extracted from an upstream data
-source, it is best to also delete the data.
+source, it is best to also delete the data.  This makes sure that new columns
+or modified column types do not prevent data from loading:
+  arthur.py sync --force
 
-And if you change the configuration for your data warehouse (like upstream
-source or additional schemas for transformations) you should "deploy" the
-configuration file by copying it up to S3.
+If you change the configuration for your data warehouse (like upstream
+source or additional schemas for transformations) you need to "deploy" the
+configuration files by copying them up to S3. This is done by default but
+you can also skip:
+  arthur.py sync --without-deploy-config
 """
 
-import concurrent.futures
 import logging
 import os.path
-from typing import List, Sequence, Tuple
-
-from tqdm import tqdm
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import etl.config
 import etl.file_sets
 import etl.s3
 import etl.timer
-from etl.errors import ETLRuntimeError, MissingQueryError
+from etl.errors import MissingQueryError
+from etl.names import TableSelector
 from etl.relation import RelationDescription
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def upload_settings(config_files, bucket_name, prefix, dry_run=False) -> None:
+def upload_settings(config_paths: Iterable[str], bucket_name: str, prefix: str, dry_run=False) -> None:
     """
     Upload warehouse configuration files (minus credentials) to target bucket/prefix's "config" dir.
 
-    It is an error to try to upload files with the same name (coming from different config
-    directories).
+    It is an error to try to upload files with the same name (which would be coming from different
+    config directories).
     """
-    settings_files = etl.config.gather_setting_files(config_files)
-    logger.info("Found %d settings file(s) to deploy", len(settings_files))
+    settings_files = etl.config.gather_setting_files(config_paths)
+    logger.info("Found %d settings file(s) to deploy to 's3://%s/%s/config'", len(settings_files), bucket_name, prefix)
 
-    uploader = etl.s3.S3Uploader(bucket_name, dry_run=dry_run)
-    for fullname in settings_files:
-        object_key = os.path.join(prefix, "config", os.path.basename(fullname))
-        uploader(fullname, object_key)
+    files = [(local_file, f"config/{os.path.basename(local_file)}") for local_file in settings_files]
+    etl.s3.upload_files(files, bucket_name, prefix, dry_run=dry_run)
 
 
 def sync_with_s3(
-    relations: Sequence[RelationDescription], bucket_name: str, prefix: str, dry_run: bool = False
+    relations: Sequence[RelationDescription],
+    config_paths: Iterable[str],
+    bucket_name: str,
+    prefix: str,
+    deploy_config: bool,
+    delete_schemas_pattern: Optional[TableSelector],
+    delete_data_pattern: Optional[TableSelector],
+    dry_run=False,
 ) -> None:
-    """Copy (validated) table design and SQL files from local directory to S3 bucket."""
+    """
+    Copy (validated) table design and SQL files from local directory to S3 bucket.
+
+    To make sure that we don't upload "bad" files or leave files in S3 in an incomplete state,
+    we first load to validate all table design files to be uploaded.
+    """
     logger.info("Validating %d table design(s) before upload", len(relations))
     RelationDescription.load_in_parallel(relations)
 
-    # Collect list of (local file, remote file) pairs to send to the uploader.
+    # Collect list of (local file, remote file) tuples to send to the uploader.
     files: List[Tuple[str, str]] = []
     for relation in relations:
         if relation.is_transformation:
@@ -64,41 +84,19 @@ def sync_with_s3(
             relation_files = [relation.design_file_name]
 
         for file_name in relation_files:
-            local_filename = relation.norm_path(file_name)
-            remote_filename = os.path.join(prefix, local_filename)
-            files.append((local_filename, remote_filename))
+            filename = relation.norm_path(file_name)
+            files.append((filename, filename))
 
-    timer = etl.timer.Timer()
-    tqdm_bar = tqdm(desc="Uploading files to S3", disable=None, leave=False, total=len(files), unit="file")
-
-    uploader = etl.s3.S3Uploader(bucket_name, callback=tqdm_bar.update, dry_run=dry_run)
-    max_workers = 8
-
-    # We break out the futures to be able to easily tally up errors.
-    futures: List[concurrent.futures.Future] = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="sync-parallel") as executor:
-        for local_filename, remote_filename in files:
-            futures.append(executor.submit(uploader.__call__, local_filename, remote_filename))
-
-    errors = 0
-    for future in concurrent.futures.as_completed(futures):
-        exception = future.exception()
-        if exception is not None:
-            logger.error("Failed to upload file: %s", exception)
-            errors += 1
-
-    tqdm_bar.close()
-    if dry_run:
-        logger.info("Dry-run: Skipped uploading %d file(s) to 's3://%s/%s (%s)", len(files), bucket_name, prefix, timer)
+    # OK. Things appear to have worked out so far. Now make actual uploads to S3.
+    if deploy_config:
+        upload_settings(config_paths, bucket_name, prefix, dry_run=dry_run)
     else:
-        logger.info(
-            "Uploaded %d of %d file(s) to 's3://%s/%s' using %d threads (%s)",
-            len(files) - errors,
-            len(files),
-            bucket_name,
-            prefix,
-            max_workers,
-            timer,
-        )
-    if errors:
-        raise ETLRuntimeError("There were {:d} error(s) during upload".format(errors))
+        logger.info("As you wish: Configuration files are not changed in S3")
+
+    if delete_data_pattern is not None:
+        etl.file_sets.delete_data_files_in_s3(bucket_name, prefix, delete_data_pattern, dry_run=dry_run)
+
+    if delete_schemas_pattern is not None:
+        etl.file_sets.delete_schemas_files_in_s3(bucket_name, prefix, delete_schemas_pattern, dry_run=dry_run)
+
+    etl.s3.upload_files(files, bucket_name, prefix, dry_run)


### PR DESCRIPTION
## User-facing Changes
* The `sync` command is changed to deploy configuration files by default. It is no longer necessary to specify `--deploy-config`. To override this behavior, use `--without-deploy-config`.
* The new option `--delete` allows to delete files in S3 before uploading new files. This is only needed when files change names or get deleted locally.
* The option `--force` remains and implies `--delete` to delete SQL and table design files along with data files.

Overall, when working on tables in a schema `s`, odds are good that `arthur.py sync s` will do the right thing.
If you have changed any filenames, run
```
arthur.py sync --delete s
```

Online help is updated:
```
arthur.py help sync
```

### Updates

* The help text from something like `arthur.py sync --help` ought to be nicer formatted after allowing more characters in the first column (which contains the arguments like `--delete`).
* There is now a progress bar when files are deleted.

## Internal Changes
* Slowly rolling through the code base to leverage `f`-strings.
* We don't claim to have started more threads than were actually necessary.
