### PR TITLE
Add "check_constraints" command

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -17,6 +17,7 @@ _arthur_completion()
                 auto_design
                 bootstrap_sources
                 bootstrap_transformations
+                check_constraints
                 create_groups
                 create_index
                 create_schemas
@@ -54,22 +55,27 @@ _arthur_completion()
                 upgrade
                 validate
                 "
+            # shellcheck disable=SC2207
             COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
             ;;
         "-c"|"--config")
             opts=$(find -L  . -maxdepth 2 -name '*.yaml' -or -name '*.sh' | sed -e 's:^\./::')
+            # shellcheck disable=SC2207
             COMPREPLY=( $(compgen -W "$opts" -d -- "$cur") )
             ;;
         "--submit"*)
+            # shellcheck disable=SC2207
             COMPREPLY=( $(compgen -A variable -P '$' -- "${cur#'$'}") )
             ;;
         "auto_design"|"bootstrap_transformations")
+            # shellcheck disable=SC2207
             COMPREPLY=( $(compgen -W "CTAS VIEW" -- "$cur") )
             ;;
         *)
             case "$cur" in
                 "@"*)
                     # compopt -o filenames
+                    # shellcheck disable=SC2207
                     COMPREPLY=( $(compgen -A file -P "@" -- "${cur#@}") )
                     ;;
                 *.*)
@@ -79,6 +85,7 @@ _arthur_completion()
                             sed -n -e 's:^schemas/\([^/]\{1,\}\)/\([^-]*-\)\{0,1\}\([^.]\{1,\}\)[.].*:\1.\3:p' |
                             sort -u
                     )
+                    # shellcheck disable=SC2207
                     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
                     ;;
                 *)
@@ -89,6 +96,7 @@ _arthur_completion()
                             sort -u
                     )
                     # compopt -o nospace
+                    # shellcheck disable=SC2207
                     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
                     ;;
             esac

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -309,6 +309,7 @@ def build_full_parser(prog_name):
         ValidateDesignsCommand,
         ExplainQueryCommand,
         RunQueryCommand,
+        CheckConstraintsCommand,
         ShowDdlCommand,
         CreateIndexCommand,
         SyncWithS3Command,
@@ -1233,6 +1234,29 @@ class RunQueryCommand(SubCommand):
             raise InvalidArgumentError("selected %d transformations" % len(transformations))
         with etl.db.log_error():
             etl.load.run_query(transformations[0], args.limit, args.with_staging_schemas)
+
+
+class CheckConstraintsCommand(SubCommand):
+    def __init__(self):
+        super().__init__(
+            "check_constraints",
+            "check constraints of selected relations",
+            "Run all the table constraints for the selected relations",
+        )
+
+    def add_arguments(self, parser):
+        add_standard_arguments(parser, ["pattern", "prefix", "scheme"])
+        parser.add_argument(
+            "--with-staging-schemas",
+            action="store_true",
+            default=False,
+            help="use the relations in staging schemas for the query",
+        )
+
+    def callback(self, args):
+        relations = self.find_relation_descriptions(args)
+        with etl.db.log_error():
+            etl.load.check_constraints(relations, args.with_staging_schemas)
 
 
 class ExplainQueryCommand(SubCommand):

--- a/python/etl/errors.py
+++ b/python/etl/errors.py
@@ -160,10 +160,9 @@ class FailedConstraintError(RelationDataError):
         self.constraint_type = constraint_type
         self.columns = columns
         self.example_string = ",\n  ".join(map(str, examples))
-        # TODO(tom): Include relation name in output
         self.message = (
-            "relation {0.identifier} violates {0.constraint_type} constraint.\n"
-            "Example duplicate values of {0.columns} are:\n  {0.example_string}".format(self)
+            f"relation '{self.identifier}' violates {self.constraint_type} constraint.\n"
+            f"Example duplicate values of {self.columns} are:\n  {self.example_string}"
         )
 
     def __str__(self):
@@ -172,9 +171,9 @@ class FailedConstraintError(RelationDataError):
 
 class RequiredRelationLoadError(ETLRuntimeError):
     def __init__(self, failed_relations, bad_apple=None):
-        self.message = "required relation(s) with failure: " + join_with_single_quotes(failed_relations)
+        self.message = f"required relation(s) with failure: {join_with_single_quotes(failed_relations)}"
         if bad_apple:
-            self.message += ", triggered by load failure of '{}'".format(bad_apple)
+            self.message += f", triggered by load failure of '{bad_apple}'"
 
     def __str__(self):
         return self.message

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -52,7 +52,7 @@ from collections import defaultdict
 from contextlib import closing
 from datetime import datetime, timedelta
 from functools import partial
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Sequence, Set
 
 from psycopg2.extensions import connection  # only for type annotation
 
@@ -182,13 +182,13 @@ class LoadableRelation:
         else:
             return self._relation_description.target_table_name
 
-    def find_dependents(self, relations: List["LoadableRelation"]) -> List["LoadableRelation"]:
+    def find_dependents(self, relations: Sequence["LoadableRelation"]) -> List["LoadableRelation"]:
         unpacked = [r._relation_description for r in relations]  # do DAG operations in terms of RelationDescriptions
         dependent_relations = etl.relation.find_dependents(unpacked, [self._relation_description])
         dependent_relation_identifiers = {r.identifier for r in dependent_relations}
         return [loadable for loadable in relations if loadable.identifier in dependent_relation_identifiers]
 
-    def mark_failure(self, relations: List["LoadableRelation"], exc_info=True) -> None:
+    def mark_failure(self, relations: Sequence["LoadableRelation"], exc_info=True) -> None:
         """Mark this relation as failed and set dependents (stored in :relations) to skip_copy."""
         self.failed = True
         if self.is_required:
@@ -236,7 +236,7 @@ class LoadableRelation:
     @classmethod
     def from_descriptions(
         cls,
-        relations: List[RelationDescription],
+        relations: Sequence[RelationDescription],
         command: str,
         use_staging=False,
         skip_copy=False,
@@ -438,7 +438,7 @@ def insert_from_query(
     conn: connection,
     relation: LoadableRelation,
     table_name: Optional[TableName] = None,
-    columns: Optional[List[str]] = None,
+    columns: Optional[Sequence[str]] = None,
     query_stmt: Optional[str] = None,
     dry_run=False,
 ) -> None:
@@ -473,7 +473,7 @@ def load_ctas_directly(conn: connection, relation: LoadableRelation, dry_run=Fal
     insert_from_query(conn, relation, dry_run=dry_run)
 
 
-def create_missing_dimension_row(columns: List[dict]) -> List[str]:
+def create_missing_dimension_row(columns: Sequence[dict]) -> List[str]:
     """Return row that represents missing dimension values."""
     na_values_row = []
     for column in columns:
@@ -594,7 +594,7 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
 # --- Section 2: Functions that work on schemas
 
 
-def find_traversed_schemas(relations: List[LoadableRelation]) -> List[DataWarehouseSchema]:
+def find_traversed_schemas(relations: Sequence[LoadableRelation]) -> List[DataWarehouseSchema]:
     """Return schemas traversed when refreshing relations (in order that they are needed)."""
     got_it: Set[str] = set()
     traversed_in_order = []
@@ -606,7 +606,7 @@ def find_traversed_schemas(relations: List[LoadableRelation]) -> List[DataWareho
     return traversed_in_order
 
 
-def create_schemas_for_rebuild(schemas: List[DataWarehouseSchema], use_staging: bool, dry_run=False) -> None:
+def create_schemas_for_rebuild(schemas: Sequence[DataWarehouseSchema], use_staging: bool, dry_run=False) -> None:
     """
     Create schemas necessary for a full rebuild of data warehouse.
 
@@ -719,7 +719,7 @@ def build_one_relation_using_pool(pool, relation: LoadableRelation, dry_run=Fals
         pool.putconn(conn, close=False)
 
 
-def vacuum(relations: List[RelationDescription], dry_run=False) -> None:
+def vacuum(relations: Sequence[RelationDescription], dry_run=False) -> None:
     """
     Tidy up the warehouse before guests come over.
 
@@ -737,7 +737,7 @@ def vacuum(relations: List[RelationDescription], dry_run=False) -> None:
 
 
 def create_source_tables_when_ready(
-    relations: List[LoadableRelation],
+    relations: Sequence[LoadableRelation],
     max_concurrency=1,
     look_back_minutes=15,
     idle_termination_seconds=60 * 60,
@@ -925,7 +925,7 @@ def create_source_tables_when_ready(
 # --- Section 4: Functions related to control flow
 
 
-def create_source_tables_in_parallel(relations: List[LoadableRelation], max_concurrency=1, dry_run=False) -> None:
+def create_source_tables_in_parallel(relations: Sequence[LoadableRelation], max_concurrency=1, dry_run=False) -> None:
     """
     Create relations in parallel, using a connection pool, a thread pool, and a kiddie pool.
 
@@ -981,7 +981,9 @@ def create_source_tables_in_parallel(relations: List[LoadableRelation], max_conc
     logger.info("Finished with %d relation(s) in source schemas (%s)", len(source_relations), timer)
 
 
-def create_transformations_sequentially(relations: List[LoadableRelation], wlm_query_slots: int, dry_run=False) -> None:
+def create_transformations_sequentially(
+    relations: Sequence[LoadableRelation], wlm_query_slots: int, dry_run=False
+) -> None:
     """
     Create relations one-by-one.
 
@@ -1033,7 +1035,7 @@ def set_redshift_wlm_slots(conn: connection, slots: int, dry_run: bool) -> None:
 
 
 def create_relations(
-    relations: List[LoadableRelation], max_concurrency=1, wlm_query_slots=1, concurrent_extract=False, dry_run=False
+    relations: Sequence[LoadableRelation], max_concurrency=1, wlm_query_slots=1, concurrent_extract=False, dry_run=False
 ) -> None:
     """Build relations by creating them, granting access, and loading them (if they hold data)."""
     if concurrent_extract:
@@ -1050,7 +1052,7 @@ def create_relations(
 
 
 def load_data_warehouse(
-    all_relations: List[RelationDescription],
+    all_relations: Sequence[RelationDescription],
     selector: TableSelector,
     use_staging=True,
     max_concurrency=1,
@@ -1080,6 +1082,8 @@ def load_data_warehouse(
 
     N.B. If arthur gets interrupted (eg. because the instance is inadvertently shut down),
     then there will be an incomplete state.
+
+    This is a callback of a command.
     """
     selected_relations = etl.relation.select_in_execution_order(all_relations, selector, include_dependents=True)
     if not selected_relations:
@@ -1114,7 +1118,7 @@ def load_data_warehouse(
 
 
 def upgrade_data_warehouse(
-    all_relations: List[RelationDescription],
+    all_relations: Sequence[RelationDescription],
     selector: TableSelector,
     max_concurrency=1,
     wlm_query_slots=1,
@@ -1137,6 +1141,8 @@ def upgrade_data_warehouse(
         3 Unless skip_copy is true (else leave tables empty):
             3.1 Load data into tables
             3.2 Verify constraints
+
+    This is a callback of a command.
     """
     selected_relations = etl.relation.select_in_execution_order(
         all_relations, selector, include_dependents=not only_selected, continue_from=continue_from
@@ -1156,7 +1162,7 @@ def upgrade_data_warehouse(
 
 
 def update_data_warehouse(
-    all_relations: List[RelationDescription],
+    all_relations: Sequence[RelationDescription],
     selector: TableSelector,
     wlm_query_slots=1,
     start_time: Optional[datetime] = None,
@@ -1175,6 +1181,8 @@ def update_data_warehouse(
 
     Note that a failure will rollback the transaction -- there is no distinction between required or not-required.
     Finally, if elected, run vacuum (in new connection) for all tables that were modified.
+
+    This is a callback of a command.
     """
     selected_relations = etl.relation.select_in_execution_order(
         all_relations, selector, include_dependents=not only_selected
@@ -1213,16 +1221,21 @@ def update_data_warehouse(
 
 
 def run_query(relation: RelationDescription, limit=None, use_staging=False) -> None:
-    """Run the query for the relation (which must be a transformation, not a source)."""
+    """
+    Run the query for the relation (which must be a transformation, not a source).
+
+    This is a callback of a command.
+    """
     dsn_etl = etl.config.get_dw_config().dsn_etl
     loadable_relation = LoadableRelation(relation, {}, use_staging)
+    timer = Timer()
 
     # We cannot use psycopg2's '%s' with LIMIT since the query may contain
     # arbitrary text, including "LIKE '%something%', which would break mogrify.
     limit_clause = "LIMIT NULL" if limit is None else f"LIMIT {limit:d}"
     query_stmt = loadable_relation.query_stmt + f"\n{limit_clause}\n"
 
-    with Timer() as timer, closing(etl.db.connection(dsn_etl)) as conn:
+    with closing(etl.db.connection(dsn_etl)) as conn:
         logger.info(
             "Running query underlying '%s' (with '%s')",
             relation.identifier,
@@ -1239,8 +1252,25 @@ def run_query(relation: RelationDescription, limit=None, use_staging=False) -> N
     print(format_lines(results, header_row=columns))
 
 
+def check_constraints(relations: Sequence[RelationDescription], use_staging=False) -> None:
+    """
+    Check the table constraints of selected relations.
+
+    This is a callback of a command.
+    """
+    dsn_etl = etl.config.get_dw_config().dsn_etl
+    loadable_relations = [LoadableRelation(relation, {}, use_staging) for relation in relations]
+    timer = Timer()
+
+    with closing(etl.db.connection(dsn_etl)) as conn:
+        for relation in loadable_relations:
+            logger.info("Checking table constraints of '%s'", relation.identifier)
+            verify_constraints(conn, relation)
+    logger.info("Checked table constraints of %d relation(s) (%s)", len(loadable_relations), timer)
+
+
 def show_downstream_dependents(
-    relations: List[RelationDescription],
+    relations: Sequence[RelationDescription],
     selector: TableSelector,
     continue_from: Optional[str] = None,
     with_dependencies: Optional[bool] = False,
@@ -1252,6 +1282,8 @@ def show_downstream_dependents(
     Relations are marked based on whether they were directly selected or selected as
     part of the propagation of new data.
     They are also marked whether they'd lead to a fatal error since they're required for full load.
+
+    This is a callback of a command.
     """
     # Relations are directly selected by pattern or by being somewhere downstream of a selected one.
     selected_relations = etl.relation.select_in_execution_order(
@@ -1350,8 +1382,12 @@ def show_downstream_dependents(
                 )
 
 
-def show_upstream_dependencies(relations: List[RelationDescription], selector: TableSelector):
-    """List the relations upstream (towards sources) from the selected ones in execution order."""
+def show_upstream_dependencies(relations: Sequence[RelationDescription], selector: TableSelector):
+    """
+    List the relations upstream (towards sources) from the selected ones in execution order.
+
+    This is a callback of a command.
+    """
     execution_order = etl.relation.order_by_dependencies(relations)
     selected_relations = etl.relation.find_matches(execution_order, selector)
     if len(selected_relations) == 0:

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -460,7 +460,7 @@ class SortableRelationDescription:
         self.level: Optional[int] = None
 
 
-def _sanitize_dependencies(descriptions: List[SortableRelationDescription]) -> None:
+def _sanitize_dependencies(descriptions: Sequence[SortableRelationDescription]) -> None:
     """
     Pass 1 of ordering -- make sure to drop unknown dependencies.
 
@@ -508,7 +508,7 @@ def _sanitize_dependencies(descriptions: List[SortableRelationDescription]) -> N
             description.dependencies.update(has_no_internal_dependencies)
 
 
-def _sort_by_dependencies(descriptions: List[SortableRelationDescription]) -> None:
+def _sort_by_dependencies(descriptions: Sequence[SortableRelationDescription]) -> None:
     """
     Pass 2 of ordering -- sort such that dependencies are built before the relation itself is built.
 
@@ -544,7 +544,7 @@ def _sort_by_dependencies(descriptions: List[SortableRelationDescription]) -> No
             queue.put((max(latest_order, minimum_order) + 1, tie_breaker, description))
 
 
-def order_by_dependencies(relation_descriptions: List[RelationDescription]) -> List[RelationDescription]:
+def order_by_dependencies(relation_descriptions: Sequence[RelationDescription]) -> List[RelationDescription]:
     """
     Sort the relations such that any dependents surely are loaded afterwards.
 
@@ -580,7 +580,7 @@ def order_by_dependencies(relation_descriptions: List[RelationDescription]) -> L
     return [description for description in sorted(relation_descriptions, key=attrgetter("execution_order"))]
 
 
-def set_required_relations(relations: List[RelationDescription], required_selector: TableSelector) -> None:
+def set_required_relations(relations: Sequence[RelationDescription], required_selector: TableSelector) -> None:
     """
     Set the "required" property based on the selector.
 
@@ -609,13 +609,13 @@ def set_required_relations(relations: List[RelationDescription], required_select
     logger.info("Marked %d relation(s) as required based on selector: %s", len(required_relations), required_selector)
 
 
-def find_matches(relations: List[RelationDescription], selector: TableSelector):
+def find_matches(relations: Sequence[RelationDescription], selector: TableSelector):
     """Return list of matching relations."""
     return [relation for relation in relations if selector.match(relation.target_table_name)]
 
 
 def find_dependents(
-    relations: List[RelationDescription], seed_relations: List[RelationDescription]
+    relations: Sequence[RelationDescription], seed_relations: Sequence[RelationDescription]
 ) -> List[RelationDescription]:
     """
     Return list of relations that depend on the seed relations (directly or transitively).
@@ -632,7 +632,7 @@ def find_dependents(
 
 
 def find_immediate_dependencies(
-    relations: List[RelationDescription], selector: TableSelector
+    relations: Sequence[RelationDescription], selector: TableSelector
 ) -> List[RelationDescription]:
     """
     Return list of VIEW relations that directly (or chained) hang off the selected relations.
@@ -655,7 +655,7 @@ def find_immediate_dependencies(
 
 
 def select_in_execution_order(
-    relations: List[RelationDescription],
+    relations: Sequence[RelationDescription],
     selector: TableSelector,
     include_dependents=False,
     continue_from: Optional[str] = None,
@@ -727,7 +727,7 @@ def select_in_execution_order(
     raise InvalidArgumentError("found no matching relations to continue from")
 
 
-def create_index(relations: List[RelationDescription], groups: Iterable[str], with_columns: Optional[bool]) -> None:
+def create_index(relations: Sequence[RelationDescription], groups: Iterable[str], with_columns: Optional[bool]) -> None:
     """
     Create an "index" page with Markdown that lists all schemas and their tables.
 


### PR DESCRIPTION
This adds the command `check_constraints` which allows to verify whether constraints are ok before running an `upgrade`.
The idea is that a new relation can be built locally before trying a full upgrade. Assuming that you already have `schemas/dw/dim_something.sql`, then:
```
arthur.py bootstrap_transformations CTAS dw.dim_something
arthur.py run_query dw.dim_something
# Add constraints as applicable, e.g. for uniqueness, then:
arthur.py check_constraints dw.dim_something
```