### PR TITLE
Add --include-immediate-views and ---into-schema to upgrade

### DIFF
--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -390,9 +390,13 @@ class TableSelector:
         >>> ts = TableSelector()
         >>> str(ts)
         "['*.*']"
+        >>> len(ts)
+        0
         >>> ts = TableSelector(["finance", "www"])
         >>> str(ts)
         "['finance.*', 'www.*']"
+        >>> len(ts)
+        2
         >>> ts = TableSelector(["www.orders*"])
         >>> str(ts)
         "['www.orders*']"
@@ -459,7 +463,10 @@ class TableSelector:
             if not found:
                 raise ValueError("bad pattern (no match against base schemas): {}".format(pattern.identifier))
 
-    def __str__(self):
+    def __len__(self) -> int:
+        return len(self._patterns)
+
+    def __str__(self) -> str:
         # See __init__ for tests
         if len(self._patterns) == 0:
             return "['*.*']"

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -658,6 +658,7 @@ def select_in_execution_order(
     relations: List[RelationDescription],
     selector: TableSelector,
     include_dependents=False,
+    include_immediate_views=False,
     continue_from: Optional[str] = None,
 ) -> List[RelationDescription]:
     """
@@ -689,6 +690,10 @@ def select_in_execution_order(
     if include_dependents:
         dependents = find_dependents(execution_order, selected)
         combined = frozenset(selected).union(dependents)
+        selected = [relation for relation in execution_order if relation in combined]
+    elif include_immediate_views:
+        immediate_views = find_immediate_dependencies(execution_order, selector)
+        combined = frozenset(selected).union(immediate_views)
         selected = [relation for relation in execution_order if relation in combined]
 
     if continue_from is None or continue_from == "*":


### PR DESCRIPTION
To make testing and QA'ing tables easier, this PR adds two options to the `upgrade` command and speeds up the execution when "only selected" relations are run.

* With the new option `--include-immediate-views` users can have views be pulled into the selected relations for views which would otherwise be dropped during the upgrade. (Upgrade of a relation runs a `DROP ... CASCADE`.)  This option is only meant to be used together with `--only-selected` if at all.
* If views are dropped during the upgrade but are themselves not part of the upgrade, there is now a warning that lists those views that previously went silently missing.
* With the new option `--into-schema` users can override the normal target schema of a relation with that option. So the following command will build `tom.fact_order` instead of modifying `dw.fact_order`.
```
arthur.py upgrade --into-schema tom --only-selected dw.fact_order
```
* ~When "only selected" is active, we no longer load all relation descriptions but only those that are selected. This speeds up the development cycle of:~
```
arthur.py bootstrap_transformations update dw.fact_order
arthur.py sync dw.fact_order
arthur.py upgrade --only dw.fact_order
```