### PR TITLE
Add compile_time query

### DIFF
--- a/python/etl/templates/sql/compile_time.sql
+++ b/python/etl/templates/sql/compile_time.sql
@@ -1,0 +1,13 @@
+-- Collect time spent on compiling queries within last 24 hours
+SELECT TRIM(u.usename) AS user_name
+     , CASE c.locus
+           WHEN 1 THEN 'compute'
+           WHEN 2 THEN 'leader'
+       END AS locus_name
+     , COUNT(DISTINCT c.query) AS total_queries
+     , SUM(DATEDIFF(MS, c.starttime, c.endtime)) AS total_compile_time_ms
+FROM svl_compile AS c
+JOIN pg_user AS u ON c.userid = u.usesysid
+WHERE c.compile = 1 AND DATEADD(DAY, -1, SYSDATE) < c.starttime
+GROUP BY u.usename, locus_name
+ORDER BY u.usename, locus_name


### PR DESCRIPTION
This PR adds a new SQL template that we can use to evaluate performance of the ETL.
The SQL script uses https://docs.aws.amazon.com/redshift/latest/dg/r_SVL_COMPILE.html
to sum up all the time that is spent in the ETL for compiling queries. We would normally
expect for most queries to be re-used throughout the week. But after maintenance is performed
on a cluster, the query cache is invalidated. Running this script after maintenance should tell us
how much time in the ETL is "lost" to query compilation.

```shell
arthur.py run_sql_template compile_time
```

Example output:
```
Running template: 'compile_time'
 user_name   | locus_name   |   total_queries |   total_compile_time_ms
-------------+--------------+-----------------+-------------------------
 etl         | compute      |             120 |                  804107
 etl         | leader       |               1 |                    3745
(2 rows)
```