### PR TITLE
Organize templates and config code

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -9,7 +9,6 @@ We use the term "config" files to refer to all files that may reside in the "con
 
 import datetime
 import logging
-import logging.config
 import os
 import os.path
 import re
@@ -25,7 +24,6 @@ import yaml
 from simplejson.errors import JSONDecodeError
 
 import etl.config.dw
-import etl.monitor
 from etl.config.dw import DataWarehouseConfig
 from etl.errors import ETLRuntimeError, InvalidArgumentError, SchemaInvalidError, SchemaValidationError
 
@@ -38,7 +36,7 @@ _dw_config: Optional[DataWarehouseConfig] = None
 _mapped_config: Optional[Dict[str, str]] = None
 
 # Local temp directory used for bootstrap, temp files, etc.
-# TODO(tom): This is a misnomer -- it's also the install dir on EC2 hosts.
+# TODO(tom): This is a misnomer -- it's also the install directory on EC2 hosts.
 ETL_TMP_DIR = "/tmp/redshift_etl"
 
 
@@ -135,30 +133,6 @@ def _build_config_map(settings):
 def etl_tmp_dir(path: str) -> str:
     """Return the absolute path within the ETL runtime directory for the selected path."""
     return os.path.join(ETL_TMP_DIR, path)
-
-
-def configure_logging(full_format: bool = False, log_level: str = None) -> None:
-    """
-    Set up logging to go to console and application log file.
-
-    If full_format is True, then use the terribly verbose format of
-    the application log file also for the console.  And log at the DEBUG level.
-    Otherwise, you can choose the log level by passing one in.
-    """
-    config = load_json("logging.json")
-    if full_format:
-        config["formatters"]["console"] = dict(config["formatters"]["file"])
-        config["handlers"]["console"]["level"] = logging.DEBUG
-    elif log_level:
-        config["handlers"]["console"]["level"] = log_level
-    logging.config.dictConfig(config)
-    # Ignored due to lack of stub in type checking library
-    logging.captureWarnings(True)  # type: ignore
-    logger.info("Starting log for %s with ETL ID %s", package_version(), etl.monitor.Monitor.etl_id)
-    logger.info('Command line: "%s"', " ".join(sys.argv))
-    logger.debug("Current working directory: '%s'", os.getcwd())
-    logger.info(get_release_info())
-    logger.debug(get_python_info())
 
 
 def load_environ_file(filename: str) -> None:

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -65,7 +65,7 @@
   # Type information from source (PostgreSQL) to target (Redshift)
   "type_maps": {
     # Types that may be used "as-is"
-    # See also # http://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
+    # See also http://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
     # The keys are regular expression (with escaped backslashes!) and the values are
     # serialization formats (logical types).
     "as_is_att_type": {

--- a/python/etl/config/dw.py
+++ b/python/etl/config/dw.py
@@ -5,7 +5,7 @@ from typing import Dict
 import etl.config.env
 import etl.db
 import etl.names
-import etl.render_template
+import etl.templates
 from etl.errors import ETLConfigError, InvalidEnvironmentError
 
 
@@ -97,21 +97,21 @@ class DataWarehouseSchema:
     @property
     def s3_bucket(self) -> str:
         """Render S3 Bucket name (if it references Arthur configuration, e.g., the data lake)."""
-        return etl.render_template.render_from_config(
+        return etl.templates.render_from_config(
             self._s3_bucket_template, context="s3_bucket of schema '{}'".format(self.name)
         )
 
     @property
     def s3_path_prefix(self) -> str:
         """Render S3 path prefix in particular wrt. prefix (environment) and dates."""
-        return etl.render_template.render_from_config(
+        return etl.templates.render_from_config(
             self._s3_path_template, context="s3_path_template of schema '{}'".format(self.name)
         )
 
     @property
     def s3_unload_path_prefix(self) -> str:
         """Render S3 unload path prefix in particular wrt. prefix (environment) and dates."""
-        return etl.render_template.render_from_config(
+        return etl.templates.render_from_config(
             self._s3_unload_path_template, context="s3_unload_path_template of schema '{}'".format(self.name)
         )
 

--- a/python/etl/config/log.py
+++ b/python/etl/config/log.py
@@ -1,0 +1,33 @@
+import logging
+import logging.config
+import os
+import sys
+
+import etl.monitor
+from etl.config import get_python_info, get_release_info, load_json, package_version
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+def configure_logging(full_format: bool = False, log_level: str = None) -> None:
+    """
+    Set up logging to go to console and application log file.
+
+    If full_format is True, then use the terribly verbose format of
+    the application log file also for the console.  And log at the DEBUG level.
+    Otherwise, you can choose the log level by passing one in.
+    """
+    config = load_json("logging.json")
+    if full_format:
+        config["formatters"]["console"] = dict(config["formatters"]["file"])
+        config["handlers"]["console"]["level"] = logging.DEBUG
+    elif log_level:
+        config["handlers"]["console"]["level"] = log_level
+    logging.config.dictConfig(config)
+    logging.captureWarnings(True)
+    logger.info("Starting log for %s with ETL ID %s", package_version(), etl.monitor.Monitor.etl_id)
+    logger.info('Command line: "%s"', " ".join(sys.argv))
+    logger.debug("Current working directory: '%s'", os.getcwd())
+    logger.info(get_release_info())
+    logger.debug(get_python_info())

--- a/python/etl/config/settings.py
+++ b/python/etl/config/settings.py
@@ -1,0 +1,45 @@
+import fnmatch
+from typing import List, Optional
+
+import etl.config
+import etl.text
+from etl.errors import InvalidArgumentError
+
+
+def show_value(name: str, default: Optional[str]) -> None:
+    """
+    Show value of a specific variable.
+
+    This fails if the variable is not set and no default is provided.
+
+    This is a callback for a command.
+    """
+    value = etl.config.get_config_value(name, default)
+    if value is None:
+        raise InvalidArgumentError("setting '{}' has no value".format(name))
+    print(value)
+
+
+def show_vars(names: List[str]) -> None:
+    """
+    List "variables" with values.
+
+    This shows all known configuration settings as "variables" with their values or just
+    the variables that are selected.
+
+    This is a callback for a command.
+    """
+    config_mapping = etl.config.get_config_map()
+    all_keys = sorted(config_mapping)
+    if not names:
+        keys = all_keys
+    else:
+        selected_keys = set()
+        for name in names:
+            matching_keys = [key for key in all_keys if fnmatch.fnmatch(key, name)]
+            if not matching_keys:
+                raise InvalidArgumentError("no matching setting for '{}'".format(name))
+            selected_keys.update(matching_keys)
+        keys = sorted(selected_keys)
+    values = [config_mapping[key] for key in keys]
+    print(etl.text.format_lines(zip(keys, values), header_row=["Name", "Value"]))

--- a/python/etl/pipeline.py
+++ b/python/etl/pipeline.py
@@ -1,9 +1,9 @@
 """
-Pipelines allow us to coordinate steps of the ETL by running steps.
+Pipelines allow us to coordinate the steps of an ETL.
 
 ETL steps can be run in series, as necessary, or in parallel, when possible,
 while also tracking failures, logs, etc.
-Pipelines are currently based on AWS Data pipeline.
+Pipelines are currently based on AWS Data Pipeline.
 
 Starting pipelines:
   Use one of the installation scripts to put a pipeline on a schedule. Usually, they run on a

--- a/python/etl/s3.py
+++ b/python/etl/s3.py
@@ -328,12 +328,12 @@ def test_object_creation(bucket_name: str, prefix: str) -> None:
 if __name__ == "__main__":
     import sys
 
-    import etl.config
+    import etl.config.log
 
     if len(sys.argv) != 3:
         print("Usage: {} bucket_name prefix".format(sys.argv[0]))
         print("This will create a test object under s3://[bucket_name]/[prefix] and delete afterwards.")
         sys.exit(1)
 
-    etl.config.configure_logging(log_level="DEBUG")
+    etl.config.log.configure_logging(log_level="DEBUG")
     test_object_creation(sys.argv[1], sys.argv[2])

--- a/python/etl/selftest.py
+++ b/python/etl/selftest.py
@@ -9,6 +9,8 @@ from typing import Optional
 # Skip etl.commands to avoid circular dependency
 import etl.config
 import etl.config.env
+import etl.config.log
+import etl.config.settings
 import etl.data_warehouse
 import etl.db
 import etl.design
@@ -25,9 +27,9 @@ import etl.monitor
 import etl.names
 import etl.pipeline
 import etl.relation
-import etl.render_template
 import etl.s3
 import etl.sync
+import etl.templates
 import etl.text
 import etl.timer
 import etl.unload

--- a/python/etl/templates/__init__.py
+++ b/python/etl/templates/__init__.py
@@ -10,12 +10,11 @@ There are two families of templates: text and sql [*].
 
 [*] We play both flavors of music here, Country and Western.
 """
-import fnmatch
 import logging
 import os.path
 import string
 from collections import OrderedDict
-from typing import Dict, List, Optional
+from typing import Dict
 
 import pkg_resources
 import simplejson as json
@@ -117,38 +116,3 @@ def render_sql(template_name: str) -> str:
     """Return SQL query after filling in template."""
     stmt = render_string(template_name, "sql")
     return etl.text.whitespace_cleanup(stmt).rstrip(";")
-
-
-def show_value(name: str, default: Optional[str]) -> None:
-    """
-    Show value of a specific variable.
-
-    This fails if the variable is not set and no default is provided.
-    """
-    value = etl.config.get_config_value(name, default)
-    if value is None:
-        raise InvalidArgumentError("setting '{}' has no value".format(name))
-    print(value)
-
-
-def show_vars(names: List[str]) -> None:
-    """
-    List "variables" with values.
-
-    This shows all known configuration settings as "variables" with their values or just
-    the variables that are selected.
-    """
-    config_mapping = etl.config.get_config_map()
-    all_keys = sorted(config_mapping)
-    if not names:
-        keys = all_keys
-    else:
-        selected_keys = set()
-        for name in names:
-            matching_keys = [key for key in all_keys if fnmatch.fnmatch(key, name)]
-            if not matching_keys:
-                raise InvalidArgumentError("no matching setting for '{}'".format(name))
-            selected_keys.update(matching_keys)
-        keys = sorted(selected_keys)
-    values = [config_mapping[key] for key in keys]
-    print(etl.text.format_lines(zip(keys, values), header_row=["Name", "Value"]))


### PR DESCRIPTION
Code tweaks to make it easier to maintain and easier to find stuff:
* Move `show_value` and `show_vars` into `etl.config.settings` and out of rendering templates since these are about settings though they were introduced in the context of template rendering.
* Move `render_template.py` to `templates/__init__.py` so that the code lives where you'd expect to find it. So use `etl.templates.render` now instead of `etl.render_template.render`.
* Move configuration of logging into `etl.config.log` so that `etl.config` doesn't depend on `etl.monitor` and is lighter-weight to include anywhere.

Additional changes to logging configuration, e.g. to add sending logs to CloudWatch can now be contained within `etl.config.log`.