### PR TITLE
Move unload into etl.dialect.redshift

### DIFF
--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional
 
 import psycopg2
 import psycopg2.extensions
-from psycopg2.extensions import connection  # only for type annotation
+from psycopg2.extensions import connection as Connection  # only for type annotation
 
 import etl.config
 import etl.db
@@ -282,7 +282,7 @@ def determine_data_format_parameters(data_format, format_option, file_compressio
 
 
 def copy_using_manifest(
-    conn: connection,
+    conn: Connection,
     table_name: TableName,
     column_list: List[str],
     s3_uri: str,
@@ -333,7 +333,7 @@ def copy_using_manifest(
                 raise TransientETLError(exc) from exc
 
 
-def query_load_commits(conn: connection, table_name: TableName, s3_uri: str, dry_run=False) -> None:
+def query_load_commits(conn: Connection, table_name: TableName, s3_uri: str, dry_run=False) -> None:
     stmt = """
         SELECT TRIM(filename) AS filename
              , lines_scanned
@@ -351,7 +351,7 @@ def query_load_commits(conn: connection, table_name: TableName, s3_uri: str, dry
         )
 
 
-def query_load_summary(conn: connection, table_name: TableName, dry_run=False) -> None:
+def query_load_summary(conn: Connection, table_name: TableName, dry_run=False) -> None:
     # This query is not guarded by "dry_run" so that we have a copy_id for the other query.
     [[copy_count, copy_id]] = etl.db.query(conn, "SELECT pg_last_copy_count(), pg_last_copy_id()")
 
@@ -383,7 +383,7 @@ def query_load_summary(conn: connection, table_name: TableName, dry_run=False) -
 
 
 def copy_from_uri(
-    conn: connection,
+    conn: Connection,
     table_name: TableName,
     column_list: List[str],
     s3_uri: str,
@@ -410,7 +410,7 @@ def copy_from_uri(
 
 
 def insert_from_query(
-    conn: connection, table_name: TableName, column_list: List[str], query_stmt: str, dry_run=False
+    conn: Connection, table_name: TableName, column_list: List[str], query_stmt: str, dry_run=False
 ) -> None:
     """Load data into table in the data warehouse using the INSERT INTO command."""
     retriable_error_codes = etl.config.get_config_list("arthur_settings.retriable_error_codes")
@@ -429,3 +429,38 @@ def insert_from_query(
             else:
                 logger.warning("Unretriable SQL Error: pgcode=%s, pgerror=%s", exc.pgcode, exc.pgerror)
                 raise
+
+
+def unload(
+    conn: Connection,
+    table_name: TableName,
+    columns: List[str],
+    unload_path: str,
+    aws_iam_role: str,
+    allow_overwrite=False,
+) -> None:
+    """
+    Execute the UNLOAD command for the given relation (via a select statement).
+
+    Optionally allow users to overwrite previously unloaded data within the same keyspace.
+    """
+    credentials = f"aws_iam_role={aws_iam_role}"
+    # TODO(tom): Need to review why we can't use r"\N"
+    null_string = "\\\\N"
+    unload_statement = """
+        UNLOAD ('
+            SELECT {}
+            FROM {}
+        ')
+        TO '{}'
+        CREDENTIALS '{}' MANIFEST
+        DELIMITER ',' ESCAPE ADDQUOTES GZIP NULL AS '{}'
+        """.format(
+        "\n                 , ".join(columns), table_name, unload_path, credentials, null_string
+    )
+    if allow_overwrite:
+        unload_statement += "ALLOWOVERWRITE"
+
+    logger.info("Unloading data from '%s' to '%s'", table_name.identifier, unload_path)
+    with etl.db.log_error():
+        etl.db.execute(conn, unload_statement)


### PR DESCRIPTION
This moves this Redshift-specific code from the unload into `etl.dialect.redshift`.
There's also some code cleanup related to `Connection` type annotation and leveraging `f`-strings.
Finally, the error message will announce the number of errors in case the unload had errors and
the `--keep-going` option was in effect.