### PR TITLE
Long-lived shared cluster support and expression-based partitioning

### DIFF
--- a/bin/long_lived_bootstrap.sh
+++ b/bin/long_lived_bootstrap.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# MIT License
+# 
+# Copyright (c) 2016 Harry's, Inc.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Setup the environment to run Arthur on an EC2 instance.
+# Make sure to keep this in sync with our Dockerfile.
+
+PROJ_NAME="redshift_etl"
+PROJ_PACKAGES="aws-cli gcc jq libyaml-devel tmux"
+
+PROJ_TEMP="/home/hadoop/${PROJ_NAME}"  # Should be rendered from arthur_settings.etl_temp_dir
+
+show_usage_and_exit () {
+	
+	cat <<EOF
+Usage: `basename $0` <bucket_name> <environment>
+
+Download files from the S3 bucket into $PROJ_TEMP on this instance
+and install the Python code in a virtual environment.
+We will also try to set tags for this instance.
+EOF
+	exit ${1-0}
+}
+
+log () {
+	set +o xtrace
+	echo "`date '+%Y-%m-%d %H:%M:%S %Z'`: $*"
+}
+
+if [[ ${1-"-h"} = "-h" ]]; then
+	show_usage_and_exit
+fi
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+	echo "Missing arguments!" 1>&2
+	show_usage_and_exit 1
+fi
+
+# Fail if any install step fails or variables are not set before use.
+set -o errexit -o nounset
+
+BUCKET_NAME="$1"
+ENVIRONMENT="$2"
+log "Starting $PROJ_NAME bootstrap from bucket \"$BUCKET_NAME\" and prefix \"$ENVIRONMENT\""
+
+set -o xtrace
+
+sudo yum install --assumeyes $PROJ_PACKAGES
+
+# Set creation mask to: u=rwx,g=rx,o=
+umask 0027
+
+# Download code config to all nodes. This includes Python code and its requirements.txt
+log "Downloading files from s3://$BUCKET_NAME/$ENVIRONMENT/ to $PROJ_TEMP"
+test -d "$PROJ_TEMP" || mkdir -p "$PROJ_TEMP"
+cd "$PROJ_TEMP"
+
+aws s3 cp --only-show-errors --recursive "s3://$BUCKET_NAME/$ENVIRONMENT/config/" ./config/
+aws s3 cp --only-show-errors --recursive "s3://$BUCKET_NAME/$ENVIRONMENT/jars/" ./jars/
+aws s3 cp --only-show-errors --recursive \
+	--exclude '*' --include bootstrap.sh --include send_health_check.sh --include sync_env.sh \
+	"s3://$BUCKET_NAME/$ENVIRONMENT/bin/" ./bin/
+chmod +x ./bin/*.sh
+
+log "Creating virtual environment in \"$PROJ_TEMP/venv\""
+test -x deactivate && deactivate || echo "Already outside virtual environment"
+
+virtualenv --python=python3 venv
+
+# Work around this error: "_OLD_VIRTUAL_PATH: unbound variable"
+set +o nounset
+source venv/bin/activate
+set -o nounset
+
+pip3 install --upgrade pip --disable-pip-version-check
+pip3 install --requirement ./jars/requirements.txt
+
+# This trick with sed transforms project-<dotted version>.tar.gz into project.<dotted_version>.tar.gz
+# so that the sort command can split correctly on '.' with the -t option.
+# We then use the major (3), minor (4) and patch (5) version to sort numerically in reverse order.
+LATEST_TAR_FILE=`
+ls -1 ./jars/ |
+sed -n "s:${PROJ_NAME}-:${PROJ_NAME}.:p" |
+sort -t. -n -r -k 3,3 -k 4,4 -k 5,5 |
+sed "s:${PROJ_NAME}\.:${PROJ_NAME}-:" |
+head -1`
+pip3 install --upgrade "./jars/$LATEST_TAR_FILE"

--- a/bin/upload_env.sh
+++ b/bin/upload_env.sh
@@ -8,7 +8,7 @@
 # Example:
 #   AWS_PROFILE=my-prof bin/upload_env.sh my-warehouse-bucket my-env
 
-set -o errexit
+set -xo errexit
 
 USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -113,6 +113,7 @@ def run_arg_as_command(my_name="arthur.py"):
     if not args.func:
         parser.print_usage()
     elif args.cluster_id is not None:
+        etl.config.load_config(args.config)
         submit_step(args.cluster_id, args.sub_command)
     else:
         # We need to configure logging before running context because that context expects

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -134,7 +134,8 @@ def _build_config_map(settings):
 
 def etl_tmp_dir(path: str) -> str:
     """Return the absolute path within the ETL runtime directory for the selected path."""
-    return os.path.join(ETL_TMP_DIR, path)
+    tmp_dir = str(get_config_value("arthur_settings.etl_temp_dir", ETL_TMP_DIR))
+    return os.path.join(tmp_dir, path)
 
 
 def configure_logging(full_format: bool = False, log_level: str = None) -> None:

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -7,6 +7,7 @@
     "copy_data_retries": 3,
     "insert_data_retries": 3,
     "retriable_error_codes": "8001,15001,15005",
+    "concurrent_load_idle_termination_seconds": 3600,
     "redshift": {
       # Computing column encoding is turned off if all columns have a specified encoding.
       "relation_column_encoding": "ON"
@@ -22,7 +23,6 @@
     "owner": {
       "name": "dw",
       "group": "etl_rw"
-
     },
     "users": [
       {

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -37,12 +37,12 @@
             "uniqueItems": true,
             "minItems": 1
         },
-        "bucket_template" : {
+        "bucket_template": {
             "description": "'Templates' used in static sources to configure their bucket",
             "type": "string",
             "pattern": "^(([a-zA-Z0-9._$-]+)|(\\${[.\\w]+}))+$"
         },
-        "path_template" : {
+        "path_template": {
             "description": "'Templates' used in static sources to configure their effective prefix",
             "type": "string",
             "pattern": "^(([a-zA-Z0-9._$-]+/?)|(\\${[.\\w]+})/?)+$"
@@ -92,6 +92,19 @@
             },
             "additionalProperties": false
         },
+        "s3_acl": {
+            "description": "Access control policy setting for S3",
+            "type": "string",
+            "enum": [
+                    "private",
+                    "public-read",
+                    "public-read-write",
+                    "authenticated-read",
+                    "aws-exec-read",
+                    "bucket-owner-read",
+                    "bucket-owner-full-control"
+                ]
+        },
         "s3_data_format": {
             "description": "Description of data format found in S3 objects to be COPY'ed",
             "type": "object",
@@ -139,10 +152,24 @@
         "arthur_settings": {
             "type": "object",
             "properties": {
+                "etl_temp_dir": {
+                    "type": "string",
+                    "description": "Install directory in remote deployments (e.g. root of commands dispatched via arthur submit)"
+                },
                 "extract_retries": {
                     "description": "If an extract from an upstream source fails due to some transient error, retry the extract at most this many times. Zero disables retries",
                     "type": "integer",
                     "minimum": 0
+                },
+                "extract_jitter": {
+                    "description": "Maximum number of seconds to wait during extract startup. For each extract call, a sleep duration is chosen at runtime uniformly between 0 and this value.",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "concurrent_load_idle_termination_seconds": {
+                    "description": "Maximum number of seconds to wait during concurrent load for a new extract event.",
+                    "type": "integer",
+                    "minimum": 60
                 },
                 "copy_data_retries": {
                     "description": "If a COPY command fails with a database internal error (which we optimistically hope are transient), retry the COPY at most this many times. Zero disables retries",
@@ -274,7 +301,8 @@
                 "s3": {
                     "type": "object",
                     "properties": {
-                        "bucket_name": { "$ref": "#/definitions/identifier" }
+                        "bucket_name": { "$ref": "#/definitions/identifier" },
+                        "upload_acl": { "$ref": "#/definitions/s3_acl" }
                     },
                     "required": [ "bucket_name" ],
                     "additionalProperties": false

--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -211,7 +211,11 @@
                     "$ref": "#/definitions/expression",
                     "description": "Condition in SQL that will be part of the WHERE clause during extraction"
                 },
-                "split_by": { "$ref": "#/definitions/one_column_as_list" },
+                "split_by": { "oneOf": [
+                    { "$ref": "#/definitions/expression" },
+                    { "$ref": "#/definitions/one_column_as_list" }
+                ] },
+                "boundary_query": { "$ref": "#/definitions/expression" },
                 "num_partitions": {
                     "type": "integer",
                     "minimum": 1

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -55,9 +55,9 @@ def parse_connection_string(dsn: str) -> Dict[str, str]:
     # Now they have two problems.
     dsn_re = re.compile(
         r"""(?:jdbc:)?(?P<subprotocol>redshift|postgresql|postgres)://  # accept either type
-            (?:(?P<user>[-\w.%]+)(?::(?P<password>[-\w.%]+))?@)?  # optional user with password
-            (?P<host>[-\w.%]+)(:?:(?P<port>\d+))?/  # host and optional port information
-            (?P<database>[-\w.%]+)  # database (and not dbname)
+            (?:(?P<user>\w[.\w]*)(?::(?P<password>[-\w\!\$\&.%]+))?@)?  # optional user with password
+            (?P<host>\w[-.\w]*)(:?:(?P<port>\d+))?/  # host and optional port information
+            (?P<database>\w+)  # database (and not dbname)
             (?:\?sslmode=(?P<sslmode>\w+))?$""",  # sslmode is the only option currently supported
         re.ASCII | re.VERBOSE,
     )

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -205,7 +205,10 @@ def validate_semantics_of_table(table_design):
                 "upstream table '{}' has unexpected {} constraint".format(table_design["name"], constraint_type)
             )
 
-    [split_by_name] = table_design.get("extract_settings", {}).get("split_by", [None])
+    split_by_settings = table_design.get("extract_settings", {}).get("split_by", [None])
+    if isinstance(split_by_settings, str):
+        return  # Not validating split_by expressions
+    [split_by_name] = split_by_settings
     if split_by_name:
         split_by_column = fy.first(fy.where(table_design["columns"], name=split_by_name))
         if split_by_column.get("skipped", False):

--- a/python/etl/extract/extractor.py
+++ b/python/etl/extract/extractor.py
@@ -5,6 +5,8 @@ Extractors leave usable (ie, COPY-ready) manifests on S3 that reference data fil
 """
 import concurrent.futures
 import logging
+import random
+import time
 from itertools import groupby
 from operator import attrgetter
 from typing import Dict, List, Set
@@ -123,6 +125,11 @@ class Extractor:
         This will return a list of tables that failed to extract or raise an exception
         if there was just one relation failing, it was required, and "keep going" was not active.
         """
+        extract_jitter = etl.config.get_config_int("arthur_settings.extract_jitter")
+        if extract_jitter:
+            jitter_sleep_duration = random.randint(0, extract_jitter)
+            self.logger.info("Sleeping %d seconds to jitter extraction startup.", jitter_sleep_duration)
+            time.sleep(jitter_sleep_duration)
         self.logger.info("Extracting %d relation(s) from source '%s'", len(relations), source.name)
         failed_tables = []
         with Timer() as timer:

--- a/python/etl/extract/sqoop.py
+++ b/python/etl/extract/sqoop.py
@@ -148,7 +148,7 @@ class SqoopExtractor(DatabaseExtractor):
             r"'\\N'",
             # NOTE Does not work with s3n:  "--delete-target-dir",
             "--target-dir",
-            '"s3n://{}/{}"'.format(relation.bucket_name, relation.data_directory()),
+            '"s3a://{}/{}"'.format(relation.bucket_name, relation.data_directory()),
             # NOTE Quoting the select statement breaks the select in an unSQLy way.
             "--query",
             select_statement,
@@ -176,12 +176,19 @@ class SqoopExtractor(DatabaseExtractor):
         self, relation: RelationDescription, partition_key: Optional[str], table_size: int
     ) -> List[str]:
         """Build the partitioning-related arguments for Sqoop."""
+        # Use 1 mapper if either there is no partition key, or if the partitioner returns only one partition
+        num_mappers = 1
+        partition_options = []
         if partition_key:
             column = fy.first(fy.where(relation.table_design["columns"], name=partition_key))
-            if column["type"] in ("date", "timestamp"):
+            if column is not None and column["type"] in ("date", "timestamp"):
                 quoted_key_arg = """CAST(DATE_PART('epoch', "{}") AS BIGINT)""".format(partition_key)
             else:
                 quoted_key_arg = '"{}"'.format(partition_key)
+            partition_options += ["--split-by", quoted_key_arg]
+
+            if relation.partition_boundary_query:
+                partition_options += ["--boundary-query", '"{}"'.format(relation.partition_boundary_query)]
 
             if relation.num_partitions:
                 # num_partitions explicitly set in the design file overrides dynamic determination.
@@ -189,12 +196,8 @@ class SqoopExtractor(DatabaseExtractor):
             else:
                 num_mappers = self.maximize_partitions(table_size)
 
-            if num_mappers > 1:
-                return ["--split-by", quoted_key_arg, "--num-mappers", str(num_mappers)]
-
-        # Use single mapper if either there is no partition key, or if the partitioner returns
-        # only one partition.
-        return ["--num-mappers", "1"]
+        partition_options += ["--num-mappers", str(num_mappers)]
+        return partition_options
 
     def write_options_file(self, args: List[str]) -> str:
         """Write options to a (temporary) file, return name of file created."""
@@ -224,7 +227,7 @@ class SqoopExtractor(DatabaseExtractor):
                 csv_prefix,
             )
         else:
-            etl.s3.delete_objects(relation.bucket_name, deletable, wait=True)
+            etl.s3.delete_objects(relation.bucket_name, deletable, wait=True, hdfs_wait=False)
 
     def run_sqoop(self, options_file_path: str):
         """Run Sqoop in a sub-process with the help of the given options file."""

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -748,7 +748,6 @@ def create_source_tables_when_ready(
     relations: Sequence[LoadableRelation],
     max_concurrency=1,
     look_back_minutes=15,
-    idle_termination_seconds=60 * 60,
     dry_run=False,
 ) -> None:
     """
@@ -761,6 +760,7 @@ def create_source_tables_when_ready(
     any relation from the full set of relations that depends on a source relation that failed
     to load.
     """
+    idle_termination_seconds = etl.config.get_config_int("arthur_settings.concurrent_load_idle_termination_seconds")
     source_relations = [relation for relation in relations if not relation.is_transformation]
     if not source_relations:
         logger.info("None of the relations are in source schemas")

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -374,6 +374,17 @@ class RelationDescription:
     def num_partitions(self):
         return self.table_design.get("extract_settings", {}).get("num_partitions")
 
+    @property
+    def partition_boundary_query(self) -> Union[str, None]:
+        """
+        Return the optional boundary query specified in relation extract settings.
+
+        Sqoop generates evenly-spaced buckets for map tasks in extraction. Users may provide
+        a separate query that returns the min and max values in that range. The query should select
+        one row with two fields; the first provides the lower bound, the second the upper bound.
+        """
+        return self.table_design.get("extract_settings", {}).get("boundary_query")
+
     def find_partition_key(self) -> Union[str, None]:
         """
         Return valid partition key for a relation.
@@ -391,7 +402,19 @@ class RelationDescription:
         """
         constraints = self.table_design.get("constraints", [])
         extract_settings = self.table_design.get("extract_settings", {})
-        [partition_key] = extract_settings.get("split_by", [None])
+        split_by_setting = extract_settings.get("split_by", [None])
+        if isinstance(split_by_setting, list):
+            [partition_key] = split_by_setting
+        elif isinstance(split_by_setting, str):
+            # Split by expression provided; return immediately
+            return split_by_setting
+        else:
+            # Should be impossible given json schema
+            raise ValueError(
+                "Unsupported type in split_by field of extract_settings in {self}: {split_by_setting}".format(
+                    self=self, split_by_setting=split_by_setting
+                )
+            )
 
         if not partition_key:
             try:


### PR DESCRIPTION
Makes installation more configurable to be outside of /tmp
Accept configuration in EMR submit
Jitter retries (in case of master node memory limitations)
Check data dir deletion confirmation with EMR workers

Sqoop support for 'boundary query' and split by expressions.

------

This is a bit of a 'kitchen sink' PR; many small things have accumulated. Happy to switch back things like `s3a` or `set -x`. Not totally clear on the implications of the password regex diff; it changed upstream after I changed in our branch. There's probably a role for templating in DRYing up the two bootstrap files (and setting install dir from config as I note in comment) but I haven't really dug into the templating features.

Comment away and I'll try to make it acceptable.