### PR TITLE
Add "vacuum" command

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -55,6 +55,7 @@ _arthur_completion()
                 update
                 update_user
                 upgrade
+                vacuum
                 validate
                 "
             # shellcheck disable=SC2207

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -152,7 +152,7 @@ class TableName:
         >>> tn.identifier
         'hello.world'
         """
-        return "{}.{}".format(*self.to_tuple())
+        return f"{self.schema}.{self.table}"
 
     @property
     def identifier_as_re(self) -> str:
@@ -208,7 +208,7 @@ class TableName:
         >>> str(tn.as_staging_table_name())
         '"etl_staging$hello"."world"'
         """
-        return '"{}"."{}"'.format(*self.to_tuple())
+        return f'"{self.schema}"."{self.table}"'
 
     def __format__(self, code):
         """
@@ -240,10 +240,9 @@ class TableName:
             raise ValueError("unknown format code '{}' for {}".format(code, self.__class__.__name__))
 
     def __eq__(self, other: object):
-        if isinstance(other, TableName):
-            return self.to_tuple() == other.to_tuple()
-        else:
+        if not isinstance(other, TableName):
             return False
+        return self.to_tuple() == other.to_tuple()
 
     def __hash__(self):
         return hash(self.to_tuple())


### PR DESCRIPTION
Adding a `vacuum` command to run on demand. 

The goal is to debug any issues around missing statistics. This is also a simple command to highlight how to add a command in Arthur.