### PR TITLE
Add option to skip loading sources (so "ELT" is "T" only)

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -438,7 +438,7 @@ def add_standard_arguments(parser, options):
         parser.add_argument(
             "-y",
             "--skip-copy",
-            help="skip the COPY and INSERT commands (leaves tables empty, used for validation)",
+            help="skip the COPY and INSERT commands (this leaves tables empty, used for validation)",
             action="store_true",
         )
     if "continue-from" in options:
@@ -1039,7 +1039,7 @@ class LoadDataWarehouseCommand(MonitoredSubCommand):
             "--skip-loading-sources",
             action="store_true",
             default=False,
-            help="Skip loading data from sources",
+            help="Skip loading data from sources (but still build the tables)",
         )
 
     def callback(self, args):

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1035,6 +1035,12 @@ class LoadDataWarehouseCommand(MonitoredSubCommand):
             action="store_false",
             dest="use_staging_schemas",
         )
+        parser.add_argument(
+            "--skip-loading-sources",
+            action="store_true",
+            default=False,
+            help="Skip loading data from sources",
+        )
 
     def callback(self, args):
         dw_config = etl.config.get_dw_config()
@@ -1063,6 +1069,7 @@ class LoadDataWarehouseCommand(MonitoredSubCommand):
             wlm_query_slots=wlm_query_slots,
             concurrent_extract=args.concurrent_extract,
             skip_copy=args.skip_copy,
+            skip_loading_sources=args.skip_loading_sources,
             use_staging=args.use_staging_schemas,
             dry_run=args.dry_run,
         )

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -209,7 +209,7 @@ def build_view_ddl(view_name: TableName, columns: List[str], query_stmt: str) ->
 
 def build_insert_ddl(table_name: TableName, column_list, query_stmt) -> str:
     """Assemble the statement to insert data based on a query."""
-    columns = join_with_double_quotes(column_list)
+    columns = join_with_double_quotes(column_list, sep=",\n            ")
     insert_stmt = """
         INSERT INTO {table} (
             {columns}

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -432,6 +432,9 @@ def insert_from_query(
         logger.info("Inserting data into '%s' from query", table_name.identifier)
         try:
             etl.db.execute(conn, stmt)
+        # TODO(tom) Ideally we'd retry these but initial testing ran into issues with closed connections.
+        # except psycopg2.OperationalError as exc:
+        #    raise TransientETLError(exc) from exc
         except psycopg2.InternalError as exc:
             if exc.pgcode in retriable_error_codes:
                 raise TransientETLError(exc) from exc

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -114,11 +114,10 @@ class LoadableRelation:
         """Grab everything from the contained relation. Fail if it's actually not available."""
         if hasattr(self._relation_description, name):
             return getattr(self._relation_description, name)
-        raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, name))
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
-    # This works although __str__ will get passed a 'LoadableRelation' object instead of a
-    # 'RelationDescription' object.
-    __str__ = RelationDescription.__str__  # type: ignore
+    def __str__(self) -> str:
+        return str(self.target_table_name)
 
     def __format__(self, code):
         r"""
@@ -148,13 +147,11 @@ class LoadableRelation:
         """
         if (not code) or (code == "s"):
             return str(self)
-        elif code == "x":
+        if code == "x":
             if self.use_staging:
                 return "'{:s}' (in staging)".format(self.identifier)
-            else:
-                return "'{:s}'".format(self.identifier)
-        else:
-            raise ValueError("unsupported format code '{}' passed to LoadableRelation".format(code))
+            return "'{:s}'".format(self.identifier)
+        raise ValueError("unsupported format code '{}' passed to LoadableRelation".format(code))
 
     def __init__(
         self,
@@ -168,7 +165,7 @@ class LoadableRelation:
         self._relation_description = relation
         self.info = info
         self.in_transaction = in_transaction
-        self.skip_copy = skip_copy or relation.is_view_relation
+        self.skip_copy = skip_copy
         self.use_staging = use_staging
         self.failed = False
 
@@ -252,6 +249,7 @@ class LoadableRelation:
         use_staging=False,
         target_schema: Optional[str] = None,
         skip_copy=False,
+        skip_loading_sources=False,
         in_transaction=False,
     ) -> List["LoadableRelation"]:
         """Build a list of "loadable" relations."""
@@ -260,8 +258,18 @@ class LoadableRelation:
         base_index = {"name": database, "current": 0, "final": len(relations)}
         base_destination = {"name": database}
 
+        managed = frozenset(relation.identifier for relation in relations)
+
         loadable = []
         for i, relation in enumerate(relations):
+            this_skip_copy = skip_copy
+            if skip_loading_sources:
+                # Only load transformations and only if no dependency is external.
+                if not relation.is_transformation or any(
+                    dependency.identifier not in managed for dependency in relation.dependencies
+                ):
+                    this_skip_copy = True
+
             target = relation.target_table_name
             source = {"bucket_name": relation.bucket_name}
             if relation.is_view_relation or relation.is_ctas_relation:
@@ -274,11 +282,11 @@ class LoadableRelation:
                 "step": command,
                 "source": source,
                 "destination": destination,
-                "options": {"use_staging": use_staging, "skip_copy": skip_copy},
+                "options": {"use_staging": use_staging, "skip_copy": this_skip_copy},
                 "index": dict(base_index, current=i + 1),
             }
             loadable.append(
-                cls(relation, monitor_info, use_staging, target_schema, skip_copy, in_transaction)
+                cls(relation, monitor_info, use_staging, target_schema, this_skip_copy, in_transaction)
             )
 
         return loadable
@@ -700,27 +708,25 @@ def build_one_relation(conn: connection, relation: LoadableRelation, dry_run=Fal
         if relation.is_view_relation:
             pass
         elif relation.skip_copy:
-            logger.info("Skipping loading data into {:x} (skip copy is active)".format(relation))
+            logger.info(f"Skipping loading data into {relation:x} (skip copy is active)")
         elif relation.failed:
-            logger.info("Bypassing already failed relation {:x}".format(relation))
+            logger.info(f"Bypassing already failed relation {relation:x}")
         else:
             update_table(conn, relation, dry_run=dry_run)
             verify_constraints(conn, relation, dry_run=dry_run)
 
         # Step 3 -- log size of table
-        if not (relation.in_transaction or relation.is_view_relation or relation.failed):
-            rows = etl.db.run(
-                conn,
-                # TODO(tom): This should be logged at the DEBUG level.
-                "(Calculating row count for {:x})".format(relation),
-                "SELECT COUNT(*) AS rowcount FROM {}".format(relation),
-                return_result=True,
-                dry_run=dry_run,
-            )
-            if rows:
-                rowcount = rows[0]["rowcount"]
-                logger.info("Found {:d} row(s) in {:x}".format(rowcount, relation))
-                monitor.add_extra("rowcount", rowcount)
+        if relation.is_view_relation or relation.failed or relation.skip_copy:
+            return
+        stmt = f"SELECT COUNT(*) AS rowcount FROM {relation}"
+        if dry_run:
+            etl.db.skip_query(conn, stmt)
+            return
+        rows = etl.db.query(conn, stmt)
+        if rows:
+            rowcount = rows[0]["rowcount"]
+            logger.info(f"Found {rowcount:d} row(s) in {relation:x}")
+            monitor.add_extra("rowcount", rowcount)
 
 
 def build_one_relation_using_pool(pool, relation: LoadableRelation, dry_run=False) -> None:
@@ -748,13 +754,14 @@ def vacuum(relations: Sequence[RelationDescription], dry_run=False) -> None:
     This needs to open a new connection since it needs to happen outside a transaction.
     """
     dsn_etl = etl.config.get_dw_config().dsn_etl
-    with Timer() as timer, closing(etl.db.connection(dsn_etl, autocommit=True, readonly=dry_run)) as conn:
+    timer = Timer()
+    with closing(etl.db.connection(dsn_etl, autocommit=True, readonly=dry_run)) as conn:
         for relation in relations:
             etl.db.run(
                 conn, "Running vacuum on {:x}".format(relation), "VACUUM {}".format(relation), dry_run=dry_run
             )
-        if not dry_run:
-            logger.info("Ran vacuum for %d table(s) (%s)", len(relations), timer)
+    if not dry_run:
+        logger.info("Ran vacuum for %d table(s) (%s)", len(relations), timer)
 
 
 # --- Experimental Section: load during extract
@@ -1099,13 +1106,14 @@ def load_data_warehouse(
     wlm_query_slots=1,
     concurrent_extract=False,
     skip_copy=False,
+    skip_loading_sources=False,
     dry_run=False,
 ):
     """
     Fully "load" the data warehouse after creating a blank slate.
 
-    By default, we use staging positions of schemas to load and thus first
-    moving existing schemas out of the way.
+    By default, we use staging positions of schemas to load and thus wait with
+    moving existing schemas out of the way until the load is complete.
 
     This function allows only complete schemas as selection.
 
@@ -1132,7 +1140,11 @@ def load_data_warehouse(
         return
 
     relations = LoadableRelation.from_descriptions(
-        selected_relations, "load", skip_copy=skip_copy, use_staging=use_staging
+        selected_relations,
+        "load",
+        skip_copy=skip_copy,
+        skip_loading_sources=skip_loading_sources,
+        use_staging=use_staging,
     )
     traversed_schemas = find_traversed_schemas(relations)
     logger.info("Starting to load %d relation(s) in %d schema(s)", len(relations), len(traversed_schemas))


### PR DESCRIPTION
This PR adds the `--skip-loading-sources` option to the `load` command:
```
arthur.py load --skip-loading-sources
```

The goal here is to run all transformations on empty sources tables. This allows us to run through all the transformation queries, which thus get compiled before the full ELT needs them. 

Since we cannot leave external tables empty, which are controlled by AWS Glue Data catalog, we also skip transformations that depend on an external table. We can identify those by not being managed by Arthur.

* https://aws.amazon.com/about-aws/whats-new/2020/06/amazon-redshift-now-delivers-better-cold-query-performance/
* https://aws.amazon.com/blogs/big-data/fast-and-predictable-performance-with-serverless-compilation-using-amazon-redshift/