### PR TITLE
Update pipeline usage info

### DIFF
--- a/python/scripts/install_extraction_pipeline.sh
+++ b/python/scripts/install_extraction_pipeline.sh
@@ -5,7 +5,7 @@ USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
 if [[ $# -lt 1 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Single-shot extraction pipeline. You get to pick the arguments to 'extract' command.
 
@@ -19,7 +19,7 @@ The environment defaults to "$DEFAULT_PREFIX".
 Example: $(basename "$0") dw
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -27,9 +27,9 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
 
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
@@ -43,9 +43,11 @@ EXTRACT_ARGUMENTS=$(join_by ',' "$@")
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
-    echo "and whether you have the correct access permissions."
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 
 set -o xtrace
@@ -72,9 +74,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +o xtrace
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \

--- a/python/scripts/install_extraction_pipeline.sh
+++ b/python/scripts/install_extraction_pipeline.sh
@@ -12,7 +12,8 @@ Single-shot extraction pipeline. You get to pick the arguments to 'extract' comm
 Usage: $(basename "$0") extract_arg [extract_arg ...]
 
 The commandline arguments will be passed to 'extract'.
-(So pass in schema names, table patterns, or options like '--keep-going'.)
+So pass in arguments like schema names, table glob patterns, or options like '--keep-going'.
+
 The environment defaults to "$DEFAULT_PREFIX".
 
 Example: $(basename "$0") dw
@@ -31,7 +32,6 @@ if [[ ! -d "$DEFAULT_CONFIG" ]]; then
     exit 1
 fi
 
-
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
 PROJ_ENVIRONMENT="$DEFAULT_PREFIX"
 START_DATE_TIME="$START_NOW"
@@ -40,10 +40,11 @@ START_DATE_TIME="$START_NOW"
 function join_by { local IFS="$1"; shift; echo "$*"; }
 EXTRACT_ARGUMENTS=$(join_by ',' "$@")
 
-# Verify that this bucket/environment pair is set up on s3
+# Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
+    echo "and whether you have the correct access permissions."
     exit 1
 fi
 
@@ -55,6 +56,7 @@ AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-et
 PIPELINE_NAME="Extraction Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
 # shellcheck disable=SC2064
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
@@ -70,7 +72,7 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +x
+    set +o xtrace
     echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
     exit 1
 fi
@@ -84,7 +86,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this extraction pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_pizza_load_pipeline.sh
+++ b/python/scripts/install_pizza_load_pipeline.sh
@@ -40,10 +40,11 @@ CONTINUE_FROM_RELATION="${2:-*}"
 START_DATE_TIME="$START_NOW"
 TIMEOUT="${3:-$DEFAULT_TIMEOUT}"
 
-# Verify that this bucket/environment pair is set up on s3
+# Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-  echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+  echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
+  echo "and whether you have the correct access permissions."
   exit 1
 fi
 
@@ -52,7 +53,7 @@ set -o xtrace
 # Note: "key" and "value" are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=pizza"
 
-PIPELINE_NAME="ETL Pizza Loader Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
+PIPELINE_NAME="ETL Pizza Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
 
@@ -86,7 +87,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this pizza pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_pizza_load_pipeline.sh
+++ b/python/scripts/install_pizza_load_pipeline.sh
@@ -43,8 +43,10 @@ TIMEOUT="${3:-$DEFAULT_TIMEOUT}"
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-  echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
-  echo "and whether you have the correct access permissions."
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
   exit 1
 fi
 
@@ -73,7 +75,7 @@ PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
   set +x
-  echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
   exit 1
 fi
 

--- a/python/scripts/install_pizza_pipeline.sh
+++ b/python/scripts/install_pizza_pipeline.sh
@@ -29,8 +29,8 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-  echo >&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
-  echo >&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
   exit 1
 fi
 
@@ -43,8 +43,10 @@ TIMEOUT="${3:-$DEFAULT_TIMEOUT}"
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-  echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
-  echo "and whether you have the correct access permissions."
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
   exit 1
 fi
 
@@ -73,7 +75,7 @@ PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
   set +o xtrace
-  echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
   exit 1
 fi
 

--- a/python/scripts/install_pizza_pipeline.sh
+++ b/python/scripts/install_pizza_pipeline.sh
@@ -40,10 +40,11 @@ CONTINUE_FROM_RELATION="${2:-*}"
 START_DATE_TIME="$START_NOW"
 TIMEOUT="${3:-$DEFAULT_TIMEOUT}"
 
-# Verify that this bucket/environment pair is set up on s3
+# Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-  echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+  echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
+  echo "and whether you have the correct access permissions."
   exit 1
 fi
 
@@ -52,7 +53,7 @@ set -o xtrace
 # Note: "key" and "value" are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=pizza"
 
-PIPELINE_NAME="ETL Pizza Loader Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
+PIPELINE_NAME="ETL Pizza Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
 
@@ -71,7 +72,7 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-  set +x
+  set +o xtrace
   echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
   exit 1
 fi
@@ -86,7 +87,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this pizza pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_rebuild_pipeline.sh
+++ b/python/scripts/install_rebuild_pipeline.sh
@@ -4,7 +4,7 @@ START_NOW=$(date -u +"%Y-%m-%dT%H:%M:%S")
 DEFAULT_TIMEOUT=6
 
 if [[ $# -lt 3 || $# -gt 4 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Rebuild ETL to extract, load (including transforms), and unload data.
 
@@ -14,7 +14,7 @@ Start time should be 'now' or take the ISO8601 format like: $START_NOW
 Optional timeout should be the number of hours pipeline is allowed to run. Defaults to $DEFAULT_TIMEOUT.
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -22,18 +22,18 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
 
 PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
 PROJ_ENVIRONMENT="$1"
 
 if [[ "$2" == "now" ]]; then
-    START_DATE_TIME="$START_NOW"
+  START_DATE_TIME="$START_NOW"
 else
-    START_DATE_TIME="$2"
+  START_DATE_TIME="$2"
 fi
 OCCURRENCES="$3"
 TIMEOUT="${4:-$DEFAULT_TIMEOUT}"
@@ -41,9 +41,11 @@ TIMEOUT="${4:-$DEFAULT_TIMEOUT}"
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
-    echo "and whether you have the correct access permissions."
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 
 set -o xtrace
@@ -70,9 +72,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +o xtrace
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \

--- a/python/scripts/install_refresh_pipeline.sh
+++ b/python/scripts/install_refresh_pipeline.sh
@@ -3,7 +3,7 @@
 START_NOW=$(date -u +"%Y-%m-%dT%H:%M:%S")
 
 if [[ $# -lt 4 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Refresh ETL to extract and update data.
 
@@ -13,7 +13,7 @@ Start time should be 'now' or take the ISO8601 format like: $START_NOW
 Specify source tables using space-delimited glob patterns.
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -21,9 +21,9 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
 
 function join_by { local IFS="$1"; shift; echo "$*"; }
@@ -32,9 +32,9 @@ PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
 PROJ_ENVIRONMENT="$1"
 
 if [[ "$2" == "now" ]]; then
-    START_DATE_TIME="$START_NOW"
+  START_DATE_TIME="$START_NOW"
 else
-    START_DATE_TIME="$2"
+  START_DATE_TIME="$2"
 fi
 OCCURRENCES="$3"
 
@@ -46,9 +46,11 @@ C_S_SELECTION=$(join_by ',' "$SELECTION")
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/current/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT/current\" exist"
-    echo "and whether you have the correct access permissions."
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT/current\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 
 set -o xtrace
@@ -75,9 +77,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +o xtrace
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \

--- a/python/scripts/install_refresh_pipeline.sh
+++ b/python/scripts/install_refresh_pipeline.sh
@@ -10,7 +10,7 @@ Refresh ETL to extract and update data.
 Usage: $(basename "$0") <environment> <startdatetime> <occurrences> <source table selection> [<source table selection> ...]
 
 Start time should be 'now' or take the ISO8601 format like: $START_NOW
-Specify source tables using space-delimited arthur pattern globs.
+Specify source tables using space-delimited glob patterns.
 
 USAGE
     exit 0
@@ -28,7 +28,7 @@ fi
 
 function join_by { local IFS="$1"; shift; echo "$*"; }
 
-PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
 PROJ_ENVIRONMENT="$1"
 
 if [[ "$2" == "now" ]]; then
@@ -39,13 +39,15 @@ fi
 OCCURRENCES="$3"
 
 shift 3
+# shellcheck disable=SC2124
 SELECTION="$@"
-C_S_SELECTION="$(join_by ',' $SELECTION)"
+C_S_SELECTION=$(join_by ',' "$SELECTION")
 
-# Verify that this bucket/environment pair is set up on s3
+# Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/current/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT/current\" exist!"
+    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT/current\" exist"
+    echo "and whether you have the correct access permissions."
     exit 1
 fi
 
@@ -57,6 +59,7 @@ AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-et
 PIPELINE_NAME="ETL Refresh Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
 # shellcheck disable=SC2064
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
@@ -72,7 +75,7 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +x
+    set +o xtrace
     echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
     exit 1
 fi
@@ -88,7 +91,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this refresh pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -11,7 +11,9 @@ Single-shot upgrade pipeline. You get to pick the arguments to 'upgrade' command
 
 Usage: $(basename "$0") upgrade_arg [upgrade_arg ...]
 
-The remaining arguments will be passed to 'upgrade'.
+The commandline arguments will be passed to 'upgrade'.
+So pass in arguments like schema names, table glob patterns or options like '--only-selected'.
+
 The environment defaults to "$DEFAULT_PREFIX".
 
 Example: $(basename "$0") --continue-from :transformations
@@ -30,16 +32,17 @@ if [[ ! -d "$DEFAULT_CONFIG" ]]; then
     exit 1
 fi
 
-PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
 PROJ_ENVIRONMENT="$DEFAULT_PREFIX"
-UPGRADE_ARGUMENTS="$*"
-
 START_DATE_TIME="$START_NOW"
+
+UPGRADE_ARGUMENTS="$*"
 
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
+    echo "and whether you have the correct access permissions."
     exit 1
 fi
 
@@ -51,6 +54,7 @@ AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-et
 PIPELINE_NAME="Upgrade Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
 # shellcheck disable=SC2064
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
@@ -80,7 +84,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this upgrade pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -5,7 +5,7 @@ USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
 if [[ $# -lt 1 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Single-shot upgrade pipeline. You get to pick the arguments to 'upgrade' command.
 
@@ -19,7 +19,7 @@ The environment defaults to "$DEFAULT_PREFIX".
 Example: $(basename "$0") --continue-from :transformations
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -27,9 +27,9 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
 
 PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
@@ -41,9 +41,11 @@ UPGRADE_ARGUMENTS="$*"
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
-    echo "and whether you have the correct access permissions."
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 
 set -o xtrace
@@ -70,9 +72,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +x
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -35,7 +35,8 @@ OCCURRENCES="${3:-1}"
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
+    echo "and whether you have the correct access permissions."
     exit 1
 fi
 # NOTE we don't test for the validation folder since that gets created automatically.
@@ -58,6 +59,7 @@ AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-et
 
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
 # shellcheck disable=SC2064
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
@@ -87,7 +89,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this validation pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -5,7 +5,7 @@ USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
 if [[ $# -gt 3 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Usage: $(basename "$0") [<environment> [<startdatetime> [<occurrences>]]]
 
@@ -14,7 +14,7 @@ Start time should take the ISO8601 format, defaults to "$START_NOW" (now).
 The number of occurrences defaults to 1.
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -22,9 +22,9 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
 
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
@@ -35,9 +35,11 @@ OCCURRENCES="${3:-1}"
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist"
-    echo "and whether you have the correct access permissions."
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 # NOTE we don't test for the validation folder since that gets created automatically.
 
@@ -47,11 +49,11 @@ set -o xtrace
 GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD 2>/dev/null || true)
 
 if [[ "$PROJ_ENVIRONMENT" =~ "production" ]]; then
-    PIPELINE_NAME="ETL Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+  PIPELINE_NAME="ETL Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 elif [[ -n "$GIT_BRANCH" ]]; then
-    PIPELINE_NAME="Validation Pipeline ($DEFAULT_PREFIX:$GIT_BRANCH $PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+  PIPELINE_NAME="Validation Pipeline ($DEFAULT_PREFIX:$GIT_BRANCH $PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 else
-    PIPELINE_NAME="Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+  PIPELINE_NAME="Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 fi
 
 # Note: "key" and "value" are lower-case keywords here.
@@ -75,9 +77,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +x
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \


### PR DESCRIPTION
This PR adds a hint in the install scripts to check whether permissions are correct. (So there may be many reasons that a bucket may appear to "not exist.")

As a minor update, this will now also show the Arthur sub command that was run when the summary line with the elapsed time is printed.

There are some cosmetic changes to reduce the diffs between the various install scripts.

Example error message with an incomplete installation:
```
Failed to access 's3://bucket/tom/bin/bootstrap.sh'!
Check whether the bucket "bucket" and folder "tom" exist
and whether you have the correct access permissions.
```
