### PR TITLE
Allow "auto" as sortkey

### DIFF
--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -192,11 +192,16 @@
             "properties": {
                 "distribution": {
                     "oneOf": [
-                        { "enum": [ "all", "even", "auto" ] },
+                        { "enum": [ "all", "auto", "even", "ALL", "AUTO", "EVEN" ] },
                         { "$ref": "#/definitions/one_column_as_list" }
                     ]
                 },
-                "compound_sort": { "$ref": "#/definitions/column_list" },
+                "compound_sort": {
+                    "oneOf": [
+                        { "enum": [ "auto", "AUTO" ] },
+                        { "$ref": "#/definitions/column_list" }
+                    ]
+                },
                 "interleaved_sort": { "$ref": "#/definitions/column_list" }
             },
             "not": {

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -69,7 +69,7 @@ def load_table_design_from_localfile(local_filename, table_name):
         with open(local_filename) as f:
             table_design = load_table_design(f, table_name)
     except Exception:
-        logger.error("Failed to load table design from '%s'", local_filename)
+        logger.warning("Failed to load table design from '%s'", local_filename)
         raise
     return table_design
 

--- a/python/etl/dialect/__init__.py
+++ b/python/etl/dialect/__init__.py
@@ -16,5 +16,4 @@ def show_ddl(relations: List[RelationDescription]) -> None:
             )
         else:
             ddl_stmt = build_table_ddl(relation.target_table_name, relation.table_design)
-        print("-- arthur.target: {table}".format(table=relation.target_table_name.identifier))
         print(ddl_stmt + "\n;")

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -186,6 +186,9 @@ def build_table_ddl(table_name: TableName, table_design: dict, is_temp=False) ->
     columns = build_columns(table_design["columns"], is_temp=is_temp)
     constraints = build_table_constraints(table_design)
     attributes = build_table_attributes(table_design)
+    # Exclude temp tables from snapshots.
+    if is_temp:
+        attributes.append("BACKUP NO")
 
     ddl = """
         CREATE TABLE {table_name} (

--- a/python/etl/templates/sql/table_attributes.sql
+++ b/python/etl/templates/sql/table_attributes.sql
@@ -1,0 +1,23 @@
+-- Lookup actual table attributes for sorting columns and distribution styles.
+-- This query needs admin privileges.
+-- Args: selected_schemas
+WITH table_info AS (
+    SELECT "schema" AS schema_name
+         , "table" AS table_name
+         , encoded
+         , diststyle AS distribution_style
+         , sortkey1 AS first_sort_column
+         , sortkey_num AS total_sort_columns
+         , unsorted AS percentage_unsorted
+    FROM pg_catalog.svv_table_info
+)
+SELECT schema_name
+     , table_name
+     , encoded
+     , distribution_style
+     , first_sort_column
+     , total_sort_columns
+     , percentage_unsorted
+FROM table_info
+WHERE schema_name IN %(selected_schemas)s
+ORDER BY schema_name, table_name


### PR DESCRIPTION
## Changes

### Enable "SORTKEY AUTO" and use as default
This allows to explicitly use `AUTO` as the sort key. This way we can now specify the defaults in Redshift for sort and distribution keys.

See:
* https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html
* https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-best-dist-key.html

### Add SQL template to review table attributes

Run the template to retrieve actual sort and distribution information:
```
arthur.py run_sql_template -a table_attributes dw
```
(where `dw` is an example schema name!)

### Other changes

* Temporary tables are excluded from (backup) snapshots now.
* Constraints are sorted now (so `PRIMARY_KEY` always precedes `UNIQUE` etc.)

## Testing

Use the `show_ddl` command to see how the table design is transformed into the DDL. If no distribution key or sort key is specified in the table design, you should see something ending in:
```
)
DISTSTYLE AUTO
SORTKEY AUTO
;
```