### PR TITLE
Update JSON formatter

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -69,7 +69,7 @@ def croak(error, exit_code):
 
 
 @contextmanager
-def execute_or_bail():
+def execute_or_bail(sub_command: str):
     """
     Either execute (the wrapped code) successfully or bail out with a helpful error message.
 
@@ -103,7 +103,7 @@ def execute_or_bail():
         logger.info("Ran for %.2fs before an exceptional termination!", timer.elapsed)
         croak(exc, 5)
     else:
-        logger.info("Ran for %.2fs and finished successfully!", timer.elapsed)
+        logger.info("Ran '%s' for %.2fs and finished successfully!", sub_command, timer.elapsed)
 
 
 def log_command_line():
@@ -140,7 +140,7 @@ def run_arg_as_command(my_name="arthur.py"):
     except Exception as exc:
         croak(exc, 1)
 
-    with execute_or_bail():
+    with execute_or_bail(args.sub_command):
         log_command_line()
         etl.config.load_config(args.config)
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -103,10 +103,13 @@ def execute_or_bail(sub_command: str):
         logger.info("Ran for %.2fs before an exceptional termination!", timer.elapsed)
         croak(exc, 5)
     else:
-        logger.info("Ran '%s' for %.2fs and finished successfully!", sub_command, timer.elapsed)
+        logger.info(
+            f"Ran '{sub_command}' for {timer.elapsed:.2f}s and finished successfully!",
+            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}},
+        )
 
 
-def log_command_line():
+def log_command_line() -> None:
     logger.info(
         "Starting log for %s with ETL ID %s", etl.config.package_version(), etl.monitor.Monitor.etl_id
     )

--- a/python/etl/logs/formatter.py
+++ b/python/etl/logs/formatter.py
@@ -48,7 +48,7 @@ class JsonFormatter(logging.Formatter):
             "log_level": record.levelname,
             "log_severity": record.levelno,
             "logger": record.name,
-            "message": str(record.getMessage()),
+            "message": record.getMessage(),
             "process.id": record.process,
             "process.name": record.processName,
             "source.filename": record.filename,
@@ -59,9 +59,9 @@ class JsonFormatter(logging.Formatter):
             "thread.name": record.threadName,
             "timestamp": int(record.created * 1000.0),
         }
-        # Always add monitor information if present.
-        if hasattr(record, "monitor"):
-            values["monitor"] = record.monitor  # type: ignore
+        # Always add metrics if present.
+        if hasattr(record, "metrics"):
+            values["metrics"] = record.metrics  # type: ignore
         # Always add exception information if present.
         if record.exc_text is not None:
             if values["message"] != "\n":

--- a/python/etl/logs/formatter.py
+++ b/python/etl/logs/formatter.py
@@ -48,7 +48,7 @@ class JsonFormatter(logging.Formatter):
             "log_level": record.levelname,
             "log_severity": record.levelno,
             "logger": record.name,
-            "message": record.getMessage(),
+            "message": str(record.getMessage()),
             "process.id": record.process,
             "process.name": record.processName,
             "source.filename": record.filename,
@@ -59,4 +59,12 @@ class JsonFormatter(logging.Formatter):
             "thread.name": record.threadName,
             "timestamp": int(record.created * 1000.0),
         }
+        # Always add monitor information if present.
+        if hasattr(record, "monitor"):
+            values["monitor"] = record.monitor  # type: ignore
+        # Always add exception information if present.
+        if record.exc_text is not None:
+            if values["message"] != "\n":
+                values["message"] += "\n"  # type: ignore
+            values["message"] += record.exc_text  # type: ignore
         return json.dumps(values, default=str, separators=(",", ":"), sort_keys=True)

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -215,7 +215,17 @@ class Monitor(metaclass=MetaMonitor):
         if exc_type is None:
             event = STEP_FINISH
             errors = None
-            logger.info("Finished %s step for '%s' (%0.2fs)", self._step, self._target, seconds)
+            logger.info(
+                f"Finished {self._step} step for '{self._target}' ({seconds:0.2f}s)",
+                extra={
+                    "metrics": {
+                        "elapsed": seconds,
+                        "rowcount": self._extra.get("rowcount"),
+                        "step": self._step,
+                        "target": self._target,
+                    }
+                },
+            )
         else:
             event = STEP_FAIL
             errors = [
@@ -224,7 +234,16 @@ class Monitor(metaclass=MetaMonitor):
                     "message": traceback.format_exception_only(exc_type, exc_value)[0].strip(),
                 }
             ]
-            logger.warning("Failed %s step for '%s' (%0.2fs)", self._step, self._target, seconds)
+            logger.warning(
+                f"Failed {self._step} step for '{self._target}' ({seconds:0.2f}s)",
+                extra={
+                    "metrics": {
+                        "elapsed": seconds,
+                        "step": self._step,
+                        "target": self._target,
+                    }
+                },
+            )
 
         payload = MonitorPayload(
             self, event, self._end_time, elapsed=seconds, errors=errors, extra=self._extra


### PR DESCRIPTION
A couple updates to our logging configuration:
* Store elapsed time for the overall run in a `metrics` object.
* Store per-table finish (or fail) information in a `metrics` object.

This will look something like this:

* Message: `Ran 'upgrade' for 20.31s and finished successfully!` with:
```
"metrics":  {
    "elapsed": 20.313043,
    "sub_command": "upgrade"
}
```

* Message: `Finished upgrade step for 'dw.fact_order' (3.71s)` with:
```
"metrics": {
    "elapsed": 3.708742,
    "step": "upgrade",
    "target": "dw.fact_order",
}
```
