### PR TITLE
Allow to specify start time when searching logs

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1914,8 +1914,19 @@ class TailLogsCommand(SubCommand):
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["prefix"])
 
+        start_time = (
+            (datetime.utcnow() - timedelta(minutes=15)).replace(microsecond=0, tzinfo=None).isoformat()
+        )
+        parser.add_argument(
+            "-t",
+            "--start-time",
+            default=start_time,
+            help="beginning of time window (default: 15 minutes ago, '%s')" % start_time,
+            type=isoformat_datetime_string,
+        )
+
     def callback(self, args):
-        etl.logs.cloudwatch.tail(args.prefix)
+        etl.logs.cloudwatch.tail(args.prefix, args.start_time)
 
 
 class ShowHelpCommand(SubCommand):

--- a/python/etl/logs/cloudwatch.py
+++ b/python/etl/logs/cloudwatch.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import logging.config
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import boto3
 import watchtower
@@ -37,11 +37,9 @@ def add_cloudwatch_logging(prefix) -> None:
     root_logger.addHandler(handler)
 
 
-def tail(prefix) -> None:
+def tail(prefix: str, start_time: datetime) -> None:
     client = boto3.client("logs")
-
     log_group = get_config_value("arthur_settings.logging.cloudwatch.log_group")
-    start_time = (datetime.utcnow() - timedelta(minutes=15)).replace(microsecond=0)
     logger.info(f"Searching log streams '{log_group}/{prefix}/*' (starting at '{start_time})'")
 
     paginator = client.get_paginator("filter_log_events")
@@ -50,7 +48,6 @@ def tail(prefix) -> None:
         logStreamNamePrefix=prefix,
         startTime=int(start_time.timestamp() * 1000.0),
     )
-
     for response in response_iterator:
         for event in response["events"]:
             stream_name = event["logStreamName"]


### PR DESCRIPTION
This will filter logs from CloudWatch (assuming they were enabled) by log stream and timestamp.

Usage:
```
arthur.py tail_logs

arthur.py tail_logs -t 2021-07-14T10:29:33
```

This allows us to quickly review what "just happened" when we get alerted for an incident.