### PR TITLE
Fall back to "even" with interleaved sort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,11 @@ COPY --chown=arthur:arthur docker/* /home/arthur/
 
 # Install code under /opt/local/ (although it is under /tmp/ on an EC2 host).
 COPY --chown=arthur:arthur \
-    bin/release_version.sh bin/send_health_check.sh bin/sync_env.sh bin/upload_env.sh \
+    bin/create_validation_credentials \
+    bin/release_version.sh \
+    bin/send_health_check.sh \
+    bin/sync_env.sh \
+    bin/upload_env.sh \
     "/opt/local/$PROJ_NAME/bin/"
 
 COPY requirements*.txt /tmp/

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -118,11 +118,16 @@ def build_table_attributes(table_design: dict) -> List[str]:
     # The default in AWS Redshift is now to have AUTO sort and distribution, see also:
     # https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html
     # https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-best-dist-key.html
-    distribution = table_attributes.get("distribution", "auto")
     compound_sort = table_attributes.get("compound_sort")
     interleaved_sort = table_attributes.get("interleaved_sort")
     if compound_sort is None and interleaved_sort is None:
         compound_sort = "auto"
+    if interleaved_sort is None:
+        distribution = table_attributes.get("distribution", "auto")
+    else:
+        # Tables that have an interleaved sort cannot have an AUTO distribution.
+        # ERROR:  Dist/Sort/Encode auto table should not have interleaved sortkey.
+        distribution = table_attributes.get("distribution", "even")
 
     ddl_attributes = []
     if isinstance(distribution, list):


### PR DESCRIPTION
We've added defaults to "auto" for distribution and sort keys, alas that's not legal when the table is to have an interleaved sort. First step: fall back to "even" instead of "all" for tables with interleaved sort keys. Second step: Add to validation that a table with interleaved sort key should have a defined distribution key.