### PR TITLE
Release candidate for v1.47.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.9.1
+    rev: 5.9.2
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: python-check-blanket-noqa
       - id: python-use-type-annotations
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.20.0
+    rev: v2.21.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
           - "flake8-docstrings==1.6.0"
           - "flake8-fixme==1.1.1"
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.910
     hooks:
       - id: mypy
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,11 @@ repos:
       - id: mypy
         additional_dependencies:
           - "mypy-boto3~=1.17"
+          - "types-PyYAML==5.4.3"
+          - "types-setuptools==57.0.0"
+          - "types-simplejson==0.1.4"
+          - "types-tabulate==0.1.1"
+          - "types-termcolor==0.1.1"
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.7.1.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: python-check-blanket-noqa
       - id: python-use-type-annotations
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.4
+    rev: v2.20.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,11 @@ COPY --chown=arthur:arthur docker/* /home/arthur/
 
 # Install code under /opt/local/ (although it is under /tmp/ on an EC2 host).
 COPY --chown=arthur:arthur \
-    bin/release_version.sh bin/send_health_check.sh bin/sync_env.sh bin/upload_env.sh \
+    bin/create_validation_credentials \
+    bin/release_version.sh \
+    bin/send_health_check.sh \
+    bin/sync_env.sh \
+    bin/upload_env.sh \
     "/opt/local/$PROJ_NAME/bin/"
 
 COPY requirements*.txt /tmp/

--- a/bin/create_validation_credentials
+++ b/bin/create_validation_credentials
@@ -2,16 +2,21 @@
 
 # Create a credentials file for the validation pipeline.
 
+DEFAULT_VALIDATION_FOLDER="validation"
+
 set -o errexit -o nounset
 
 show_usage_and_exit() {
   cat <<USAGE
 
-Usage: $(basename "$0") <bucket_name> <prefix>
+Usage: $(basename "$0") <bucket_name> <prefix> [<validation-folder>]
 
 This will create an additional credentials file needed for the validation pipeline.
 By changing the target database from "database" to "validation_database", we can make sure that
 the validation pipeline runs on an empty and separate database.
+
+The validation folder name defaults to "$DEFAULT_VALIDATION_FOLDER".
+That is the folder under the environment in "prefix" to be used for the validation setup.
 
 USAGE
   exit "${1-0}"
@@ -23,17 +28,29 @@ case "${1-help}" in
     ;;
 esac
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -lt 2 || $# -gt 3 ]]; then
   echo 1>&2 "Wrong number of arguments."
   show_usage_and_exit 1
 fi
 
 PROJ_BUCKET="$1"
 PROJ_ENVIRONMENT="$2"
+VALIDATION_FOLDER="${3:-$DEFAULT_VALIDATION_FOLDER}"
+
+case $VALIDATION_FOLDER in
+  validation*)
+      true;;
+  *)
+      echo 1>&2 "Bad folder name, should start with 'validation'"
+      exit 1
+      ;;
+esac
 
 # Figure out the "safe" name that drops suspicious characters (replacing them with '_').
 SAFE_ENVIRONMENT="$(echo -n "$PROJ_ENVIRONMENT" | tr -cs '_a-zA-Z0-9' '_')"
-VALIDATION_DATABASE="validation_$SAFE_ENVIRONMENT"
+SAFE_ENVIRONMENT="$(echo -n "$PROJ_ENVIRONMENT" | tr -cs '_a-zA-Z0-9' '_')"
+SAFE_VALIDATION_FOLDER="$(echo -n "$VALIDATION_FOLDER" | tr -cs '_a-zA-Z0-9' '_')"
+VALIDATION_DATABASE="${SAFE_VALIDATION_FOLDER}_${SAFE_ENVIRONMENT}"
 
 # Try first environment specific file, then general one.
 S3_SOURCE_CREDENTIALS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/config/credentials_$SAFE_ENVIRONMENT.sh"
@@ -44,7 +61,7 @@ if ! aws s3 ls "$S3_SOURCE_CREDENTIALS" >/dev/null; then
     exit 2
   fi
 fi
-S3_TARGET_CREDENTIALS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/validation/config/credentials_validation.sh"
+S3_TARGET_CREDENTIALS="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/$VALIDATION_FOLDER/config/credentials_validation.sh"
 
 echo "Using as source: $S3_SOURCE_CREDENTIALS"
 echo "Using as target: $S3_TARGET_CREDENTIALS"

--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -18,6 +18,7 @@ _arthur_completion()
                 bootstrap_sources
                 bootstrap_transformations
                 check_constraints
+                create_external_schemas
                 create_groups
                 create_index
                 create_schemas

--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -55,6 +55,7 @@ _arthur_completion()
                 update
                 update_user
                 upgrade
+                vacuum
                 validate
                 "
             # shellcheck disable=SC2207

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -69,7 +69,7 @@ def croak(error, exit_code):
 
 
 @contextmanager
-def execute_or_bail():
+def execute_or_bail(sub_command: str):
     """
     Either execute (the wrapped code) successfully or bail out with a helpful error message.
 
@@ -103,10 +103,13 @@ def execute_or_bail():
         logger.info("Ran for %.2fs before an exceptional termination!", timer.elapsed)
         croak(exc, 5)
     else:
-        logger.info("Ran for %.2fs and finished successfully!", timer.elapsed)
+        logger.info(
+            f"Ran '{sub_command}' for {timer.elapsed:.2f}s and finished successfully!",
+            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}},
+        )
 
 
-def log_command_line():
+def log_command_line() -> None:
     logger.info(
         "Starting log for %s with ETL ID %s", etl.config.package_version(), etl.monitor.Monitor.etl_id
     )
@@ -140,7 +143,7 @@ def run_arg_as_command(my_name="arthur.py"):
     except Exception as exc:
         croak(exc, 1)
 
-    with execute_or_bail():
+    with execute_or_bail(args.sub_command):
         log_command_line()
         etl.config.load_config(args.config)
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1914,8 +1914,19 @@ class TailLogsCommand(SubCommand):
     def add_arguments(self, parser):
         add_standard_arguments(parser, ["prefix"])
 
+        start_time = (
+            (datetime.utcnow() - timedelta(minutes=15)).replace(microsecond=0, tzinfo=None).isoformat()
+        )
+        parser.add_argument(
+            "-t",
+            "--start-time",
+            default=start_time,
+            help="beginning of time window (default: 15 minutes ago, '%s')" % start_time,
+            type=isoformat_datetime_string,
+        )
+
     def callback(self, args):
-        etl.logs.cloudwatch.tail(args.prefix)
+        etl.logs.cloudwatch.tail(args.prefix, args.start_time)
 
 
 class ShowHelpCommand(SubCommand):

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -5,6 +5,7 @@ This can be the entry point for a console script.  Some functions are broken out
 so that they can be leveraged by utilities in addition to the top-level script.
 """
 
+import abc
 import argparse
 import logging
 import os
@@ -14,7 +15,7 @@ import traceback
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import Iterable, List, Optional
 
 import boto3
 import simplejson as json
@@ -164,8 +165,10 @@ def run_arg_as_command(my_name="arthur.py"):
             prefix = etl.config.get_config_value("object_store.s3.prefix")
             etl.logs.cloudwatch.add_cloudwatch_logging(prefix)
 
-        if getattr(args, "use_monitor", False):
+        if args.uses_monitor:
             etl.monitor.start_monitors(args.prefix)
+            logger.debug("Setting marker in events table for start of '%s' step", args.sub_command)
+            etl.monitor.Monitor.marker_payload(args.sub_command).emit(dry_run=args.dry_run)
 
         dw_config = etl.config.get_dw_config()
         if isinstance(getattr(args, "pattern", None), etl.names.TableSelector):
@@ -305,7 +308,6 @@ def build_basic_parser(prog_name, description=None):
     parser.set_defaults(prolix=None)
     parser.set_defaults(log_level=None)
     parser.set_defaults(func=None)
-    parser.set_defaults(use_monitor=False)
     return parser
 
 
@@ -319,7 +321,7 @@ def build_full_parser(prog_name):
     :param prog_name: Name that should show up as command name in help
     :return: instance of ArgumentParser that is ready to parse and run sub-commands
     """
-    parser = build_basic_parser(prog_name, description="This command allows to drive the ETL steps.")
+    parser = build_basic_parser(prog_name, description="This script allows to drive the ETL steps.")
 
     package = etl.config.package_version()
     parser.add_argument("-V", "--version", action="version", version=f"%(prog)s ({package})")
@@ -332,6 +334,7 @@ def build_full_parser(prog_name):
         dest="sub_command",
     )
     for klass in [
+        # TODO(tom): Split into common and infrequent commands, sort alphabetically.
         # Commands to deal with data warehouse as admin
         InitializeSetupCommand,
         ShowRandomPassword,
@@ -384,16 +387,14 @@ def build_full_parser(prog_name):
     return parser
 
 
-def add_standard_arguments(parser, options):
+def add_standard_arguments(parser: argparse.ArgumentParser, option_names: Iterable[str]) -> None:
     """
     Add from set of "standard" arguments.
 
     They are "standard" in that the name and description should be the same when used
     by multiple sub-commands.
-
-    :param parser: should be a sub-parser
-    :param options: see option strings below, like "prefix", "pattern"
     """
+    options = frozenset(option_names)
     if "dry-run" in options:
         parser.add_argument("-n", "--dry-run", help="do not modify stuff", default=False, action="store_true")
     if "prefix" in options:
@@ -474,8 +475,11 @@ class StorePatternAsSelector(argparse.Action):
         setattr(namespace, self.dest, selector)
 
 
-class SubCommand:
-    """Instances (of child classes) will setup sub-parsers and have callbacks for those."""
+class SubCommand(abc.ABC):
+    """Abstract parent class for all commands which add sub-parsers and callbacks."""
+
+    # By default, commands do not have monitor events.
+    uses_monitor = False
 
     def __init__(self, name: str, help_: str, description: str, aliases: Optional[List[str]] = None) -> None:
         self.name = name
@@ -491,6 +495,7 @@ class SubCommand:
         else:
             parser = parent_parser.add_parser(self.name, help=self.help, description=self.description)
         parser.set_defaults(func=self.callback)
+        parser.set_defaults(uses_monitor=self.uses_monitor)
 
         # Log level and prolix setting need to be always known since `run_arg_as_command` depends
         # on them.
@@ -521,10 +526,6 @@ class SubCommand:
         self.add_arguments(parser)
         return parser
 
-    def add_arguments(self, parser):
-        """Override this method for sub-classes."""
-        pass
-
     @staticmethod
     def location(args, default_scheme=None):
         """
@@ -537,10 +538,9 @@ class SubCommand:
         scheme = getattr(args, "scheme", default_scheme)
         if scheme == "file":
             return scheme, "localhost", args.table_design_dir
-        elif scheme == "s3":
+        if scheme == "s3":
             return scheme, args.bucket_name, args.prefix
-        else:
-            raise ETLSystemError("scheme invalid")
+        raise ETLSystemError("scheme invalid")
 
     def find_relation_descriptions(
         self, args, default_scheme=None, required_relation_selector=None, return_all=False
@@ -577,18 +577,13 @@ class SubCommand:
 
         return descriptions
 
+    @abc.abstractmethod
+    def add_arguments(self, parser):
+        ...
+
+    @abc.abstractmethod
     def callback(self, args):
-        """Override this method for sub-classes."""
-        raise NotImplementedError("Instance of {} has no proper callback".format(self.__class__.__name__))
-
-
-class MonitoredSubCommand(SubCommand):
-    """A sub-command that will also use monitors to update some event table."""
-
-    def add_to_parser(self, parent_parser) -> argparse.ArgumentParser:
-        parser = super().add_to_parser(parent_parser)
-        parser.set_defaults(use_monitor=True)
-        return parser
+        ...
 
 
 class InitializeSetupCommand(SubCommand):
@@ -596,9 +591,10 @@ class InitializeSetupCommand(SubCommand):
         super().__init__(
             "initialize",
             "create ETL database",
-            "(Re)create database referenced in ETL credential, optionally creating users and groups."
-            " Normally, we expect this to be a validation database (name starts with 'validation')."
-            " When bringing up your primary production or development database, use the --force option.",
+            "(Re)create database referenced in ETL credential, optionally creating users and"
+            " groups. Normally, we expect this to be a validation database (name starts with"
+            " 'validation'). When bringing up your primary production or development database,"
+            " use the --force option.",
         )
 
     def add_arguments(self, parser):
@@ -694,7 +690,7 @@ class UpdateUserCommand(SubCommand):
         super().__init__(
             "update_user",
             "update user's group, password, and path",
-            "Update an existing user with group membership, password, and search path."
+            "For an existing user, update group membership, password, and search path."
             " Note that you have to set a password for the user in your '~/.pgpass' file"
             " before invoking this command if you want to update the password. The password must"
             " be valid in Redshift, so must contain upper-case and lower-case characters as well"
@@ -771,8 +767,8 @@ class BootstrapSourcesCommand(SubCommand):
         super().__init__(
             "bootstrap_sources",
             "bootstrap schema information from sources",
-            "Download schema information from upstream sources for table designs."
-            " If there is no current design file, then create one as a starting point.",
+            "Download schema information from upstream sources and compare against current table"
+            " designs. If there is no current design file, then create one as a starting point.",
             aliases=["design"],
         )
 
@@ -913,7 +909,9 @@ class SyncWithS3Command(SubCommand):
         )
 
 
-class ExtractToS3Command(MonitoredSubCommand):
+class ExtractToS3Command(SubCommand):
+    uses_monitor = True
+
     def __init__(self):
         super().__init__(
             "extract",
@@ -947,8 +945,8 @@ class ExtractToS3Command(MonitoredSubCommand):
             action="store_const",
             const="manifest-only",
             dest="extractor",
-            help="skip extraction and go straight to creating manifest files "
-            "(implied default for static sources)",
+            help="skip extraction and go straight to creating manifest files, "
+            "implied default for static sources",
         )
         parser.add_argument(
             "-k",
@@ -995,7 +993,6 @@ class ExtractToS3Command(MonitoredSubCommand):
         descriptions = self.find_relation_descriptions(
             args, default_scheme="s3", required_relation_selector=dw_config.required_in_full_load_selector
         )
-        etl.monitor.Monitor.marker_payload("extract").emit(dry_run=args.dry_run)
         etl.extract.extract_upstream_sources(
             args.extractor,
             dw_config.schemas,
@@ -1007,14 +1004,17 @@ class ExtractToS3Command(MonitoredSubCommand):
         )
 
 
-class LoadDataWarehouseCommand(MonitoredSubCommand):
+class LoadDataWarehouseCommand(SubCommand):
+    uses_monitor = True
+
     def __init__(self):
         super().__init__(
             "load",
             "load data into source tables and forcefully update all dependencies",
-            "Load data into the data warehouse from files in S3, which will *rebuild* the data warehouse."
-            " This will operate on entire schemas at once, which will be backed up as necessary."
-            " It is an error to try to select tables unless they are all the tables in the schema.",
+            "Load data into the data warehouse from files in S3, which will *rebuild* the data"
+            " warehouse. This will operate on entire schemas at once, which will be backed up as"
+            " necessary. It is an error to try to select tables unless they are all the tables in"
+            " the schema.",
         )
 
     def add_arguments(self, parser):
@@ -1023,15 +1023,16 @@ class LoadDataWarehouseCommand(MonitoredSubCommand):
         )
         parser.add_argument(
             "--concurrent-extract",
-            help="watch DynamoDB for extract step completion and load source tables as extracts finish"
-            " assuming another Arthur in this prefix is running extract (default: %(default)s)",
+            help="watch DynamoDB for extract step completion and load source tables as extracts"
+            " finish assuming another Arthur in this prefix is running extract"
+            " (default: %(default)s)",
             default=False,
             action="store_true",
         )
         parser.add_argument(
             "--without-staging-schemas",
-            help="do NOT do all the work in hidden schemas and publish to standard names on completion"
-            " (default: use staging schemas)",
+            help="do NOT do all the work in hidden schemas and publish to standard names on"
+            " completion (default: use staging schemas)",
             default=True,
             action="store_false",
             dest="use_staging_schemas",
@@ -1056,7 +1057,6 @@ class LoadDataWarehouseCommand(MonitoredSubCommand):
             required_relation_selector=dw_config.required_in_full_load_selector,
             return_all=True,
         )
-        etl.monitor.Monitor.marker_payload("load").emit(dry_run=args.dry_run)
         max_concurrency = args.max_concurrency or etl.config.get_config_int(
             "resources.RedshiftCluster.max_concurrency", 1
         )
@@ -1076,7 +1076,9 @@ class LoadDataWarehouseCommand(MonitoredSubCommand):
         )
 
 
-class UpgradeDataWarehouseCommand(MonitoredSubCommand):
+class UpgradeDataWarehouseCommand(SubCommand):
+    uses_monitor = True
+
     def __init__(self):
         super().__init__(
             "upgrade",
@@ -1142,7 +1144,6 @@ class UpgradeDataWarehouseCommand(MonitoredSubCommand):
             required_relation_selector=dw_config.required_in_full_load_selector,
             return_all=True,
         )
-        etl.monitor.Monitor.marker_payload("upgrade").emit(dry_run=args.dry_run)
         max_concurrency = args.max_concurrency or etl.config.get_config_int(
             "resources.RedshiftCluster.max_concurrency", 1
         )
@@ -1164,13 +1165,15 @@ class UpgradeDataWarehouseCommand(MonitoredSubCommand):
         )
 
 
-class UpdateDataWarehouseCommand(MonitoredSubCommand):
+class UpdateDataWarehouseCommand(SubCommand):
+    uses_monitor = True
+
     def __init__(self):
         super().__init__(
             "update",
             "update data in the data warehouse from files in S3",
-            "Load data into data warehouse from files in S3 and then update all dependent CTAS relations"
-            " (within a transaction).",
+            "Load data into data warehouse from files in S3 and then update all dependent"
+            " CTAS relations (within a transaction).",
         )
 
     def add_arguments(self, parser):
@@ -1199,7 +1202,6 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
 
     def callback(self, args):
         relations = self.find_relation_descriptions(args, default_scheme="s3", return_all=True)
-        etl.monitor.Monitor.marker_payload("update").emit(dry_run=args.dry_run)
         wlm_query_slots = args.wlm_query_slots or etl.config.get_config_int(
             "resources.RedshiftCluster.wlm_query_slots", 1
         )
@@ -1214,7 +1216,9 @@ class UpdateDataWarehouseCommand(MonitoredSubCommand):
         )
 
 
-class UnloadDataToS3Command(MonitoredSubCommand):
+class UnloadDataToS3Command(SubCommand):
+    uses_monitor = True
+
     def __init__(self):
         super().__init__(
             "unload",
@@ -1240,7 +1244,6 @@ class UnloadDataToS3Command(MonitoredSubCommand):
 
     def callback(self, args):
         descriptions = self.find_relation_descriptions(args, default_scheme="s3")
-        etl.monitor.Monitor.marker_payload("unload").emit(dry_run=args.dry_run)
         etl.unload.unload_to_s3(
             descriptions, allow_overwrite=args.force, keep_going=args.keep_going, dry_run=args.dry_run
         )
@@ -1311,10 +1314,10 @@ class PromoteSchemasCommand(SubCommand):
         super().__init__(
             "promote_schemas",
             "move staging or backup schemas into standard position",
-            "Move hidden schemas (staging or backup) to standard position (schema names and permissions)."
-            " When promoting from staging, current standard position schemas are backed up first."
-            " Promoting (ie, restoring) a backup should only happen after a load finished successfully"
-            " but left bad data behind.",
+            "Move hidden schemas (staging or backup) to standard position (schema names and"
+            " permissions). When promoting from staging, current standard position schemas are"
+            " backed up first. Promoting (ie, restoring) a backup should only happen after a load"
+            " finished successfully but left bad data behind.",
         )
 
     def add_arguments(self, parser):
@@ -1686,8 +1689,8 @@ class RenderTemplateCommand(SubCommand):
         super().__init__(
             "render_template",
             "render selected template by filling in configuration settings",
-            "Print template after replacing placeholders (like '${resources.VPC.region}') with values"
-            " from the settings files",
+            "Print template after replacing placeholders (like '${resources.VPC.region}') with"
+            " values from the settings files",
         )
 
     def add_arguments(self, parser):
@@ -1781,9 +1784,8 @@ class QueryEventsCommand(SubCommand):
         super().__init__(
             "query_events",
             "query the tables of ETL events",
-            "Query the table of events written during an ETL."
-            " When an ETL is specified, then it is used as a filter."
-            " Otherwise ETLs from the last 48 hours are listed.",
+            "Query the table of events written during an ETL. When an ETL is specified, then it is"
+            " used as a filter. Otherwise ETLs from the last 48 hours are listed.",
         )
 
     def add_arguments(self, parser):
@@ -1811,7 +1813,7 @@ class SummarizeEventsCommand(SubCommand):
         super().__init__(
             "summarize_events",
             "summarize events from the latest ETL (for given step)",
-            "For selected (or all) relations, show events from ETL, " "grouped by schema.",
+            "For selected (or all) relations, show events from ETL, grouped by schema.",
         )
 
     def add_arguments(self, parser):
@@ -1834,8 +1836,8 @@ class TailEventsCommand(SubCommand):
             "tail_events",
             "show tail of the ETL events and optionally follow for changes",
             "Show latest ETL events for the selected tables in a 15-minute window or"
-            " since the given start time. (Use '-t #{@latestRunTime}' in a Data Pipeline definition.)"
-            " Optionally keep looking for events in 30s intervals,"
+            " since the given start time. (Use '-t #{@latestRunTime}' in a Data Pipeline"
+            " definition.) Optionally keep looking for events in 30s intervals,"
             " which automatically quits when no new event arrives within an hour.",
         )
 

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -48,6 +48,7 @@
             "pattern": "^(([a-zA-Z0-9._$-]+/?)|(\\${[.\\w]+})/?)+$"
         },
         "upstream_database": {
+            "description": "Description of an upstream database with access, tables and permissions for the copy",
             "type": "object",
             "properties": {
                 "name": { "$ref": "#/definitions/identifier" },
@@ -62,6 +63,7 @@
             "additionalProperties": false
         },
         "upstream_static": {
+            "description": "Description of an upstream source consisting of files in S3, may also be an unload target",
             "type": "object",
             "properties": {
                 "name": { "$ref": "#/definitions/identifier" },
@@ -84,12 +86,17 @@
             "additionalProperties": false
         },
         "upstream_external": {
+            "description": "Description of an external schema in AWS Redshift (listed in an AWS Glue Data Catalog)",
             "type": "object",
             "properties": {
                 "name": { "$ref": "#/definitions/identifier" },
                 "description": { "type": "string" },
-                "external": { "enum": [ true ] }
+                "external": { "enum": [ true ] },
+                "groups": { "$ref": "#/definitions/identifier_list" },
+                "database": { "$ref": "#/definitions/identifier" },
+                "iam_role": { "$ref": "#/definitions/aws_arn" }
             },
+            "required": [ "name", "external" ],
             "additionalProperties": false
         },
         "s3_data_format": {
@@ -275,34 +282,39 @@
             "description": "Location and attributes for shared storage, e.g. for unloads",
             "type": "object",
             "properties": {
+                "iam_role": {
+                    "description": "DEPRECATED Use the more specific IAM role for S3",
+                    "$ref": "#/definitions/aws_arn"
+                },
                 "s3": {
                     "type": "object",
                     "properties": {
-                        "bucket_name": { "$ref": "#/definitions/identifier" }
+                        "bucket_name": { "$ref": "#/definitions/identifier" },
+                        "iam_role": { "$ref": "#/definitions/aws_arn" }
                     },
                     "required": [ "bucket_name" ],
                     "additionalProperties": false
-                },
-                "iam_role": { "$ref": "#/definitions/aws_arn" }
+                }
             },
-            "required": [ "s3", "iam_role" ],
+            "required": [ "s3" ],
             "additionalProperties": false
         },
         "object_store": {
-            "description": "Location and attributes for (temporary) storage",
+            "description": "Location and attributes for (temporary) storage for code and extracted data",
             "type": "object",
             "properties": {
+                "iam_role": { "$ref": "#/definitions/aws_arn" },
                 "s3": {
                     "type": "object",
                     "properties": {
-                        "bucket_name": { "$ref": "#/definitions/identifier" }
+                        "bucket_name": { "$ref": "#/definitions/identifier" },
+                        "iam_role": { "$ref": "#/definitions/aws_arn" }
                     },
                     "required": [ "bucket_name" ],
                     "additionalProperties": false
-                },
-                "iam_role": { "$ref": "#/definitions/aws_arn" }
+                }
             },
-            "required": [ "s3", "iam_role" ],
+            "required": [ "s3" ],
             "additionalProperties": false
         },
         "resources": {

--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -192,11 +192,16 @@
             "properties": {
                 "distribution": {
                     "oneOf": [
-                        { "enum": [ "all", "even", "auto" ] },
+                        { "enum": [ "all", "auto", "even", "ALL", "AUTO", "EVEN" ] },
                         { "$ref": "#/definitions/one_column_as_list" }
                     ]
                 },
-                "compound_sort": { "$ref": "#/definitions/column_list" },
+                "compound_sort": {
+                    "oneOf": [
+                        { "enum": [ "auto", "AUTO" ] },
+                        { "$ref": "#/definitions/column_list" }
+                    ]
+                },
                 "interleaved_sort": { "$ref": "#/definitions/column_list" }
             },
             "not": {

--- a/python/etl/design/bootstrap.py
+++ b/python/etl/design/bootstrap.py
@@ -810,8 +810,8 @@ def bootstrap_transformations(
             logger.info(
                 "Working on transformation '%s' (%d/%d)", relation.identifier, index + 1, len(relations)
             )
-            # Be careful to not trigger a load of an unknown design file by accessing "kind".
-            actual_kind = source_name or (relation.kind if relation.design_file_name else None)
+            # Be careful to not trigger a load of an unknown design file by accessing "source_name".
+            actual_kind = source_name or (relation.source_type if relation.design_file_name else None)
             try:
                 table_design = create_table_design_for_transformation(
                     conn, actual_kind, relation, update or check_only

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -69,7 +69,7 @@ def load_table_design_from_localfile(local_filename, table_name):
         with open(local_filename) as f:
             table_design = load_table_design(f, table_name)
     except Exception:
-        logger.error("Failed to load table design from '%s'", local_filename)
+        logger.warning("Failed to load table design from '%s'", local_filename)
         raise
     return table_design
 

--- a/python/etl/dialect/__init__.py
+++ b/python/etl/dialect/__init__.py
@@ -16,5 +16,4 @@ def show_ddl(relations: List[RelationDescription]) -> None:
             )
         else:
             ddl_stmt = build_table_ddl(relation.target_table_name, relation.table_design)
-        print("-- arthur.target: {table}".format(table=relation.target_table_name.identifier))
         print(ddl_stmt + "\n;")

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -184,9 +184,6 @@ def build_table_ddl(table_name: TableName, table_design: dict, is_temp=False) ->
     columns = build_columns(table_design["columns"], is_temp=is_temp)
     constraints = build_table_constraints(table_design)
     attributes = build_table_attributes(table_design)
-    # Exclude temp tables from snapshots.
-    if is_temp:
-        attributes.append("BACKUP NO")
 
     ddl = """
         -- arthur.ddl: {table_name.identifier}

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -95,10 +95,10 @@ def build_table_constraints(table_design: dict) -> List[str]:
         "natural_key": "UNIQUE",
     }
     ddl_for_constraints = []
-    for constraint in table_constraints:
+    for constraint in sorted(table_constraints, key=lambda d: d.items()):
         [[constraint_type, column_list]] = constraint.items()
         ddl_for_constraints.append(
-            "{} ( {} )".format(type_lookup[constraint_type], join_with_double_quotes(column_list))
+            f"{type_lookup[constraint_type]} ( {join_with_double_quotes(column_list)} )"
         )
     return ddl_for_constraints
 
@@ -107,30 +107,37 @@ def build_table_attributes(table_design: dict) -> List[str]:
     """
     Return the attributes from the table design, ready to be inserted into a SQL DDL statement.
 
-    >>> build_table_attributes({})  # no-op
-    []
+    >>> build_table_attributes({})  # defaults are now explicit
+    ['DISTSTYLE AUTO', 'SORTKEY AUTO']
     >>> build_table_attributes({"attributes": {"distribution": "even"}})
-    ['DISTSTYLE EVEN']
+    ['DISTSTYLE EVEN', 'SORTKEY AUTO']
     >>> build_table_attributes({"attributes": {"distribution": ["key"], "compound_sort": ["name"]}})
     ['DISTSTYLE KEY', 'DISTKEY ( "key" )', 'COMPOUND SORTKEY ( "name" )']
     """
     table_attributes = table_design.get("attributes", {})
-    distribution = table_attributes.get("distribution", [])
-    compound_sort = table_attributes.get("compound_sort", [])
-    interleaved_sort = table_attributes.get("interleaved_sort", [])
+    # The default in AWS Redshift is now to have AUTO sort and distribution, see also:
+    # https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html
+    # https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-best-dist-key.html
+    distribution = table_attributes.get("distribution", "auto")
+    compound_sort = table_attributes.get("compound_sort")
+    interleaved_sort = table_attributes.get("interleaved_sort")
+    if compound_sort is None and interleaved_sort is None:
+        compound_sort = "auto"
 
     ddl_attributes = []
-    # TODO Use for staging tables: ddl_attributes.append("BACKUP NO")
-    if distribution:
-        if isinstance(distribution, list):
-            ddl_attributes.append("DISTSTYLE KEY")
-            ddl_attributes.append("DISTKEY ( {} )".format(join_with_double_quotes(distribution)))
+    if isinstance(distribution, list):
+        ddl_attributes.append("DISTSTYLE KEY")
+        ddl_attributes.append(f"DISTKEY ( {join_with_double_quotes(distribution)} )")
+    else:
+        ddl_attributes.append(f"DISTSTYLE {distribution.upper()}")
+
+    if compound_sort is not None:
+        if isinstance(compound_sort, list):
+            ddl_attributes.append(f"COMPOUND SORTKEY ( {join_with_double_quotes(compound_sort)} )")
         else:
-            ddl_attributes.append("DISTSTYLE {}".format(distribution.upper()))
-    if compound_sort:
-        ddl_attributes.append("COMPOUND SORTKEY ( {} )".format(join_with_double_quotes(compound_sort)))
-    elif interleaved_sort:
-        ddl_attributes.append("INTERLEAVED SORTKEY ( {} )".format(join_with_double_quotes(interleaved_sort)))
+            ddl_attributes.append(f"SORTKEY {compound_sort.upper()}")
+    if interleaved_sort is not None:
+        ddl_attributes.append(f"INTERLEAVED SORTKEY ( {join_with_double_quotes(interleaved_sort)} )")
     return ddl_attributes
 
 
@@ -180,8 +187,12 @@ def build_table_ddl(table_name: TableName, table_design: dict, is_temp=False) ->
     columns = build_columns(table_design["columns"], is_temp=is_temp)
     constraints = build_table_constraints(table_design)
     attributes = build_table_attributes(table_design)
+    # Exclude temp tables from snapshots.
+    if is_temp:
+        attributes.append("BACKUP NO")
 
     ddl = """
+        -- arthur.ddl: {table_name.identifier}
         CREATE TABLE {table_name} (
             {columns_and_constraints}
         )
@@ -198,6 +209,7 @@ def build_view_ddl(view_name: TableName, columns: List[str], query_stmt: str) ->
     """Assemble the DDL of a view in a Redshift data warehouse."""
     comma_separated_columns = join_with_double_quotes(columns, sep=",\n            ")
     ddl_initial = """
+        -- arthur.ddl: {view_name.identifier}
         CREATE VIEW {view_name} (
             {columns}
         ) AS
@@ -211,6 +223,7 @@ def build_insert_ddl(table_name: TableName, column_list, query_stmt) -> str:
     """Assemble the statement to insert data based on a query."""
     columns = join_with_double_quotes(column_list, sep=",\n            ")
     insert_stmt = """
+        -- arthur.insert: {table.identifier}
         INSERT INTO {table} (
             {columns}
         )
@@ -326,6 +339,7 @@ def copy_using_manifest(
         compupdate = "OFF"
 
     copy_stmt = """
+        -- arthur.copy: {table.identifier}
         COPY {table} (
             {columns}
         )
@@ -481,6 +495,7 @@ def unload(
     credentials = f"aws_iam_role={aws_iam_role}"
     # TODO(tom): Need to review why we can't use r"\N"
     null_string = "\\\\N"
+    # TODO(tom): Add '-- arthur.unload: {table_name.identifier}' at top of query
     unload_statement = """
         UNLOAD ('
             SELECT {}

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -118,11 +118,16 @@ def build_table_attributes(table_design: dict) -> List[str]:
     # The default in AWS Redshift is now to have AUTO sort and distribution, see also:
     # https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html
     # https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-best-dist-key.html
-    distribution = table_attributes.get("distribution", "auto")
     compound_sort = table_attributes.get("compound_sort")
     interleaved_sort = table_attributes.get("interleaved_sort")
     if compound_sort is None and interleaved_sort is None:
         compound_sort = "auto"
+    if interleaved_sort is None:
+        distribution = table_attributes.get("distribution", "auto")
+    else:
+        # Tables that have an interleaved sort cannot have an AUTO distribution.
+        # ERROR:  Dist/Sort/Encode auto table should not have interleaved sortkey.
+        distribution = table_attributes.get("distribution", "even")
 
     ddl_attributes = []
     if isinstance(distribution, list):

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -107,10 +107,10 @@ def build_table_attributes(table_design: dict) -> List[str]:
     """
     Return the attributes from the table design, ready to be inserted into a SQL DDL statement.
 
-    >>> build_table_attributes({})  # defaults are now explicit
-    ['DISTSTYLE AUTO', 'SORTKEY AUTO']
+    >>> build_table_attributes({})
+    []
     >>> build_table_attributes({"attributes": {"distribution": "even"}})
-    ['DISTSTYLE EVEN', 'SORTKEY AUTO']
+    ['DISTSTYLE EVEN']
     >>> build_table_attributes({"attributes": {"distribution": ["key"], "compound_sort": ["name"]}})
     ['DISTSTYLE KEY', 'DISTKEY ( "key" )', 'COMPOUND SORTKEY ( "name" )']
     """

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -272,7 +272,7 @@ class LoadableRelation:
 
             target = relation.target_table_name
             source = {"bucket_name": relation.bucket_name}
-            if relation.is_view_relation or relation.is_ctas_relation:
+            if relation.is_transformation:
                 source["object_key"] = relation.sql_file_name
             else:
                 source["object_key"] = relation.manifest_file_name
@@ -1445,7 +1445,7 @@ def show_downstream_dependents(
     width_dep = max(len(identifier) for identifier in current_level)
     line_template = (
         "{relation.identifier:{width}s}"
-        " # kind={relation.kind} index={index:4d} level={level:3d}"
+        " # {relation.source_type} index={index:4d} level={level:3d}"
         " flag={flag:9s}"
         " is_required={relation.is_required}"
     )
@@ -1502,7 +1502,7 @@ def show_upstream_dependencies(relations: Sequence[RelationDescription], selecto
 
     max_len = max(len(identifier) for identifier in dependencies)
     line_template = (
-        "{relation.identifier:{width}s} # kind={relation.kind} index={index:4d}"
+        "{relation.identifier:{width}s} # {relation.source_type} index={index:4d}"
         " is_required={relation.is_required}"
     )
     for i, relation in enumerate(execution_order):

--- a/python/etl/logs/cloudwatch.py
+++ b/python/etl/logs/cloudwatch.py
@@ -31,7 +31,8 @@ def add_cloudwatch_logging(prefix) -> None:
 
     log_level = get_config_value("arthur_settings.logging.cloudwatch.log_level")
     handler.setLevel(log_level)
-    handler.setFormatter(JsonFormatter(prefix))
+    # The extra "str()" gets around the meta class approach to store the etl_id.
+    handler.setFormatter(JsonFormatter(prefix, str(etl.monitor.Monitor.etl_id)))
 
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)

--- a/python/etl/logs/cloudwatch.py
+++ b/python/etl/logs/cloudwatch.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import logging.config
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import boto3
 import watchtower
@@ -37,11 +37,9 @@ def add_cloudwatch_logging(prefix) -> None:
     root_logger.addHandler(handler)
 
 
-def tail(prefix) -> None:
+def tail(prefix: str, start_time: datetime) -> None:
     client = boto3.client("logs")
-
     log_group = get_config_value("arthur_settings.logging.cloudwatch.log_group")
-    start_time = (datetime.utcnow() - timedelta(minutes=15)).replace(microsecond=0)
     logger.info(f"Searching log streams '{log_group}/{prefix}/*' (starting at '{start_time})'")
 
     paginator = client.get_paginator("filter_log_events")
@@ -50,7 +48,6 @@ def tail(prefix) -> None:
         logStreamNamePrefix=prefix,
         startTime=int(start_time.timestamp() * 1000.0),
     )
-
     for response in response_iterator:
         for event in response["events"]:
             stream_name = event["logStreamName"]

--- a/python/etl/logs/formatter.py
+++ b/python/etl/logs/formatter.py
@@ -67,7 +67,8 @@ class JsonFormatter(logging.Formatter):
             values["metrics"] = record.metrics  # type: ignore
         # Always add exception (value) as a field if exception info is present.
         if record.exc_info is not None:
-            values["exception"] = repr(record.exc_info[1])
+            values["exception.class"] = record.exc_info[1].__class__.__name__
+            values["exception.message"] = str(record.exc_info[1])
         # Always add formatted exception to message if exception info is present.
         if record.exc_text is not None:
             if values["message"] != "\n":

--- a/python/etl/logs/formatter.py
+++ b/python/etl/logs/formatter.py
@@ -59,4 +59,12 @@ class JsonFormatter(logging.Formatter):
             "thread.name": record.threadName,
             "timestamp": int(record.created * 1000.0),
         }
+        # Always add metrics if present.
+        if hasattr(record, "metrics"):
+            values["metrics"] = record.metrics  # type: ignore
+        # Always add exception information if present.
+        if record.exc_text is not None:
+            if values["message"] != "\n":
+                values["message"] += "\n"  # type: ignore
+            values["message"] += record.exc_text  # type: ignore
         return json.dumps(values, default=str, separators=(",", ":"), sort_keys=True)

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -215,7 +215,17 @@ class Monitor(metaclass=MetaMonitor):
         if exc_type is None:
             event = STEP_FINISH
             errors = None
-            logger.info("Finished %s step for '%s' (%0.2fs)", self._step, self._target, seconds)
+            logger.info(
+                f"Finished {self._step} step for '{self._target}' ({seconds:0.2f}s)",
+                extra={
+                    "metrics": {
+                        "elapsed": seconds,
+                        "rowcount": self._extra.get("rowcount"),
+                        "step": self._step,
+                        "target": self._target,
+                    }
+                },
+            )
         else:
             event = STEP_FAIL
             errors = [
@@ -224,7 +234,16 @@ class Monitor(metaclass=MetaMonitor):
                     "message": traceback.format_exception_only(exc_type, exc_value)[0].strip(),
                 }
             ]
-            logger.warning("Failed %s step for '%s' (%0.2fs)", self._step, self._target, seconds)
+            logger.warning(
+                f"Failed {self._step} step for '{self._target}' ({seconds:0.2f}s)",
+                extra={
+                    "metrics": {
+                        "elapsed": seconds,
+                        "step": self._step,
+                        "target": self._target,
+                    }
+                },
+            )
 
         payload = MonitorPayload(
             self, event, self._end_time, elapsed=seconds, errors=errors, extra=self._extra

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -290,7 +290,7 @@ class MonitorPayload:
             if not payload[key]:
                 del payload[key]
 
-        compact_text = json.dumps(payload, sort_keys=True, separators=(",", ":"), cls=FancyJsonEncoder)
+        compact_text = json.dumps(payload, cls=FancyJsonEncoder, separators=(",", ":"), sort_keys=True)
         if dry_run:
             logger.debug("Dry-run: payload = %s", compact_text)
             return
@@ -564,16 +564,15 @@ def start_monitors(environment):
 def _format_output_column(key: str, value: str) -> str:
     if value is None:
         return "---"
-    elif key == "timestamp":
+    if key == "timestamp":
         # Make timestamp readable by turning epoch seconds into a date.
         return datetime.utcfromtimestamp(float(value)).replace(microsecond=0).isoformat()
-    elif key == "elapsed":
+    if key == "elapsed":
         # Reduce number of decimals to 2.
         return "{:6.2f}".format(float(value))
-    elif key == "rowcount":
+    if key == "rowcount":
         return "{:9d}".format(int(value))
-    else:
-        return value
+    return value
 
 
 def _query_for_etls(step=None, hours_ago=0, days_ago=0) -> List[dict]:

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -178,8 +178,8 @@ class Monitor(metaclass=MetaMonitor):
         return Monitor.cluster_info
 
     @property
-    def etl_id(self):
-        return Monitor.etl_id
+    def etl_id(self) -> str:
+        return str(Monitor.etl_id)
 
     @property
     def target(self):

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -126,9 +126,10 @@ class TableName:
         """List external schemas that are not managed by us and may not exist during validation."""
         if self._external_schemas is None:
             try:
-                self._external_schemas = frozenset(etl.config.get_dw_config().external_schema_names)
+                schemas = etl.config.get_dw_config().external_schemas
             except AttributeError:
                 raise ETLSystemError("dw_config has not been set!")
+            self._external_schemas = frozenset(schema.name for schema in schemas)
         return self._external_schemas
 
     def to_tuple(self):

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -152,7 +152,7 @@ class TableName:
         >>> tn.identifier
         'hello.world'
         """
-        return "{}.{}".format(*self.to_tuple())
+        return f"{self.schema}.{self.table}"
 
     @property
     def identifier_as_re(self) -> str:
@@ -208,7 +208,7 @@ class TableName:
         >>> str(tn.as_staging_table_name())
         '"etl_staging$hello"."world"'
         """
-        return '"{}"."{}"'.format(*self.to_tuple())
+        return f'"{self.schema}"."{self.table}"'
 
     def __format__(self, code):
         """
@@ -240,10 +240,9 @@ class TableName:
             raise ValueError("unknown format code '{}' for {}".format(code, self.__class__.__name__))
 
     def __eq__(self, other: object):
-        if isinstance(other, TableName):
-            return self.to_tuple() == other.to_tuple()
-        else:
+        if not isinstance(other, TableName):
             return False
+        return self.to_tuple() == other.to_tuple()
 
     def __hash__(self):
         return hash(self.to_tuple())

--- a/python/etl/templates/sql/table_attributes.sql
+++ b/python/etl/templates/sql/table_attributes.sql
@@ -1,0 +1,23 @@
+-- Lookup actual table attributes for sorting columns and distribution styles.
+-- This query needs admin privileges.
+-- Args: selected_schemas
+WITH table_info AS (
+    SELECT "schema" AS schema_name
+         , "table" AS table_name
+         , encoded
+         , diststyle AS distribution_style
+         , sortkey1 AS first_sort_column
+         , sortkey_num AS total_sort_columns
+         , unsorted AS percentage_unsorted
+    FROM pg_catalog.svv_table_info
+)
+SELECT schema_name
+     , table_name
+     , encoded
+     , distribution_style
+     , first_sort_column
+     , total_sort_columns
+     , percentage_unsorted
+FROM table_info
+WHERE schema_name IN %(selected_schemas)s
+ORDER BY schema_name, table_name

--- a/python/etl/templates/text/warmup_pipeline.json
+++ b/python/etl/templates/text/warmup_pipeline.json
@@ -1,0 +1,161 @@
+{
+    "objects": [
+        {
+            "id": "Default",
+            "name": "Default",
+            "schedule": { "ref": "WarmupSchedule" },
+            "scheduleType": "cron",
+            "failureAndRerunMode": "CASCADE",
+            "resourceRole": "${resources.EC2.iam_instance_profile}",
+            "role": "${resources.DataPipeline.role}",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/validation_warmup/",
+            "region": "${resources.VPC.region}",
+            "maximumRetries": "2"
+        },
+        {
+            "id": "WarmupSchedule",
+            "name": "Run every saturday after the Redshift Cluster Maintenance",
+            "type": "Schedule",
+            "period": "7 days",
+            "startDateTime": "#{myStartDateTime}",
+            "occurrences": "#{myOccurrences}"
+        },
+        {
+            "id": "SNSParent",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-validation"
+        },
+        {
+            "id": "SuccessNotification",
+            "type": "SnsAlarm",
+            "parent": { "ref": "SNSParent" },
+            "subject": "ETL Warmup Success: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
+        },
+        {
+            "id": "FailureNotification",
+            "type": "SnsAlarm",
+            "parent": { "ref": "SNSParent" },
+            "subject": "ETL Warmup Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
+        },
+        {
+            "id": "PagerNotification",
+            "type": "SnsAlarm",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
+            "subject": "ETL Warmup Failure: ${object_store.s3.prefix} at #{node.@scheduledStartTime}",
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
+        },
+        {
+            "id": "ResourceParent",
+            "keyPair": "${resources.key_name}",
+            "subnetId": "${resources.VPC.public_subnet}",
+            "terminateAfter": "#{myTimeout} Hours"
+        },
+        {
+            "id": "ArthurDriverEC2Resource",
+            "type": "Ec2Resource",
+            "parent": { "ref": "ResourceParent" },
+            "actionOnTaskFailure": "terminate",
+            "actionOnResourceFailure": "retryAll",
+            "instanceType": "${resources.EC2.instance_type}",
+            "imageId": "${resources.EC2.image_id}",
+            "securityGroupIds": [
+                "${resources.EC2.public_security_group}",
+                "${resources.VPC.whitelist_security_group}"
+            ],
+            "associatePublicIpAddress": "true"
+        },
+        {
+            "id": "Ec2CommandGrandParent",
+            "runsOn": { "ref": "ArthurDriverEC2Resource" }
+        },
+        {
+            "id": "ShellCommandParent",
+            "parent": { "ref": "Ec2CommandGrandParent" }
+        },
+        {
+            "id": "ArthurCommandParent",
+            "parent": { "ref": "Ec2CommandGrandParent" },
+            "maximumRetries": "0"
+        },
+        {
+            "id": "CopyStartupScripts",
+            "name": "Copy Startup Scripts (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "/usr/bin/aws s3 cp --recursive --exclude '*' --include 'bootstrap.sh' --include 'create_validation_credentials' --include 'sync_env.sh' s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin /tmp"
+        },
+        {
+            "id": "SyncEnvironment",
+            "name": "Sync environments (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "/bin/bash /tmp/sync_env.sh -y ${object_store.s3.bucket_name} ${object_store.s3.prefix} ${object_store.s3.prefix}/validation_warmup",
+            "dependsOn": { "ref": "CopyStartupScripts" }
+        },
+        {
+            "id": "CreateValidationCredentials",
+            "name": "Create validation credentials (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "/bin/bash /tmp/create_validation_credentials ${object_store.s3.bucket_name} ${object_store.s3.prefix} validation_warmup",
+            "dependsOn": { "ref": "SyncEnvironment" }
+        },
+        {
+            "id": "Bootstrap",
+            "name": "Bootstrap (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "/bin/bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}/validation_warmup",
+            "dependsOn": { "ref": "CreateValidationCredentials" }
+        },
+        {
+            "id": "ArthurInitialize",
+            "name": "Initialize (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ initialize --prolix",
+            "dependsOn": { "ref": "Bootstrap" }
+        },
+        {
+            "id": "ArthurLoad",
+            "name": "Arthur Load with skip loading source (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix ${object_store.s3.prefix} --skip-loading-sources",
+            "dependsOn": { "ref": "ArthurInitialize" }
+        }
+    ],
+    "parameters": [
+        {
+            "id": "myStartDateTime",
+            "type": "String",
+            "optional": "false",
+            "description": "UTC ISO formatted string giving the datetime to start the pipeline",
+            "watermark": "2525-01-01T00:00:00",
+            "helpText": "When should the pipeline's daily cadence start?"
+        },
+        {
+            "id": "myOccurrences",
+            "type": "String",
+            "optional": "false",
+            "description": "Number of occurrences for this pipeline",
+            "watermark": "1000",
+            "helpText": "How often should the pipeline schedule be repeated?"
+        },
+        {
+            "id": "myTimeout",
+            "type": "Integer",
+            "optional": "true",
+            "description": "How many hours to allow the pipeline to run before terminating it",
+            "watermark": "2",
+            "default": "2",
+            "helpText": "How long can the pipeline run?"
+        }
+    ],
+    "values": {
+        "myStartDateTime": "2525-01-01T00:00:00",
+        "myOccurrences": "1000",
+        "myTimeout": "4"
+    }
+}

--- a/python/etl/templates/text/warmup_pipeline.json
+++ b/python/etl/templates/text/warmup_pipeline.json
@@ -14,7 +14,7 @@
         },
         {
             "id": "WarmupSchedule",
-            "name": "Run every saturday after the Redshift Cluster Maintenance",
+            "name": "Run once a week (every Saturday after the Redshift Cluster Maintenance)",
             "type": "Schedule",
             "period": "7 days",
             "startDateTime": "#{myStartDateTime}",
@@ -119,10 +119,10 @@
         },
         {
             "id": "ArthurLoad",
-            "name": "Arthur Load with skip loading source (EC2)",
+            "name": "Arthur Load with skip loading sources (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix ${object_store.s3.prefix} --skip-loading-sources",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix ${object_store.s3.prefix}/validation_warmup --skip-loading-sources",
             "dependsOn": { "ref": "ArthurInitialize" }
         }
     ],

--- a/python/scripts/install_extraction_pipeline.sh
+++ b/python/scripts/install_extraction_pipeline.sh
@@ -5,20 +5,21 @@ USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
 if [[ $# -lt 1 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Single-shot extraction pipeline. You get to pick the arguments to 'extract' command.
 
 Usage: $(basename "$0") extract_arg [extract_arg ...]
 
 The commandline arguments will be passed to 'extract'.
-(So pass in schema names, table patterns, or options like '--keep-going'.)
+So pass in arguments like schema names, table glob patterns, or options like '--keep-going'.
+
 The environment defaults to "$DEFAULT_PREFIX".
 
 Example: $(basename "$0") dw
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -26,11 +27,10 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
-
 
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
 PROJ_ENVIRONMENT="$DEFAULT_PREFIX"
@@ -40,11 +40,14 @@ START_DATE_TIME="$START_NOW"
 function join_by { local IFS="$1"; shift; echo "$*"; }
 EXTRACT_ARGUMENTS=$(join_by ',' "$@")
 
-# Verify that this bucket/environment pair is set up on s3
+# Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 
 set -o xtrace
@@ -55,6 +58,7 @@ AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-et
 PIPELINE_NAME="Extraction Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
 # shellcheck disable=SC2064
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
@@ -70,9 +74,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +x
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \
@@ -84,7 +88,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this extraction pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_pizza_load_pipeline.sh
+++ b/python/scripts/install_pizza_load_pipeline.sh
@@ -40,10 +40,13 @@ CONTINUE_FROM_RELATION="${2:-*}"
 START_DATE_TIME="$START_NOW"
 TIMEOUT="${3:-$DEFAULT_TIMEOUT}"
 
-# Verify that this bucket/environment pair is set up on s3
+# Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-  echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
   exit 1
 fi
 
@@ -52,7 +55,7 @@ set -o xtrace
 # Note: "key" and "value" are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=pizza"
 
-PIPELINE_NAME="ETL Pizza Loader Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
+PIPELINE_NAME="ETL Pizza Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
 
@@ -72,7 +75,7 @@ PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
   set +x
-  echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
   exit 1
 fi
 
@@ -86,7 +89,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this pizza pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_pizza_pipeline.sh
+++ b/python/scripts/install_pizza_pipeline.sh
@@ -29,8 +29,8 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-  echo >&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
-  echo >&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
   exit 1
 fi
 
@@ -40,10 +40,13 @@ CONTINUE_FROM_RELATION="${2:-*}"
 START_DATE_TIME="$START_NOW"
 TIMEOUT="${3:-$DEFAULT_TIMEOUT}"
 
-# Verify that this bucket/environment pair is set up on s3
+# Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-  echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
   exit 1
 fi
 
@@ -52,7 +55,7 @@ set -o xtrace
 # Note: "key" and "value" are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=pizza"
 
-PIPELINE_NAME="ETL Pizza Loader Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
+PIPELINE_NAME="ETL Pizza Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
 
@@ -71,8 +74,8 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-  set +x
-  echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
   exit 1
 fi
 
@@ -86,7 +89,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this pizza pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_rebuild_pipeline.sh
+++ b/python/scripts/install_rebuild_pipeline.sh
@@ -4,7 +4,7 @@ START_NOW=$(date -u +"%Y-%m-%dT%H:%M:%S")
 DEFAULT_TIMEOUT=6
 
 if [[ $# -lt 3 || $# -gt 4 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Rebuild ETL to extract, load (including transforms), and unload data.
 
@@ -14,7 +14,7 @@ Start time should be 'now' or take the ISO8601 format like: $START_NOW
 Optional timeout should be the number of hours pipeline is allowed to run. Defaults to $DEFAULT_TIMEOUT.
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -22,27 +22,30 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
 
 PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
 PROJ_ENVIRONMENT="$1"
 
 if [[ "$2" == "now" ]]; then
-    START_DATE_TIME="$START_NOW"
+  START_DATE_TIME="$START_NOW"
 else
-    START_DATE_TIME="$2"
+  START_DATE_TIME="$2"
 fi
 OCCURRENCES="$3"
 TIMEOUT="${4:-$DEFAULT_TIMEOUT}"
 
-# Verify that this bucket/environment pair is set up on s3
+# Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 
 set -o xtrace
@@ -53,6 +56,7 @@ AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-et
 PIPELINE_NAME="ETL Rebuild Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
 # shellcheck disable=SC2064
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
@@ -68,9 +72,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +x
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \
@@ -83,7 +87,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this rebuild pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_refresh_pipeline.sh
+++ b/python/scripts/install_refresh_pipeline.sh
@@ -41,7 +41,7 @@ OCCURRENCES="$3"
 shift 3
 # shellcheck disable=SC2124
 SELECTION="$@"
-C_S_SELECTION=$(join_by ',' "$SELECTION")
+C_S_SELECTION=$(join_by ',' "$@")
 
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/current/bin/bootstrap.sh"

--- a/python/scripts/install_upgrade_pipeline.sh
+++ b/python/scripts/install_upgrade_pipeline.sh
@@ -5,19 +5,21 @@ USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
 if [[ $# -lt 1 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Single-shot upgrade pipeline. You get to pick the arguments to 'upgrade' command.
 
 Usage: $(basename "$0") upgrade_arg [upgrade_arg ...]
 
-The remaining arguments will be passed to 'upgrade'.
+The commandline arguments will be passed to 'upgrade'.
+So pass in arguments like schema names, table glob patterns or options like '--only-selected'.
+
 The environment defaults to "$DEFAULT_PREFIX".
 
 Example: $(basename "$0") --continue-from :transformations
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -25,22 +27,25 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
 
-PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
 PROJ_ENVIRONMENT="$DEFAULT_PREFIX"
-UPGRADE_ARGUMENTS="$*"
-
 START_DATE_TIME="$START_NOW"
+
+UPGRADE_ARGUMENTS="$*"
 
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 
 set -o xtrace
@@ -51,6 +56,7 @@ AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-et
 PIPELINE_NAME="Upgrade Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
 # shellcheck disable=SC2064
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
@@ -66,9 +72,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +x
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \
@@ -80,7 +86,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this upgrade pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_validation_pipeline.sh
+++ b/python/scripts/install_validation_pipeline.sh
@@ -5,7 +5,7 @@ USER="${USER-nobody}"
 DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
 
 if [[ $# -gt 3 || "$1" = "-h" ]]; then
-    cat <<USAGE
+  cat <<USAGE
 
 Usage: $(basename "$0") [<environment> [<startdatetime> [<occurrences>]]]
 
@@ -14,7 +14,7 @@ Start time should take the ISO8601 format, defaults to "$START_NOW" (now).
 The number of occurrences defaults to 1.
 
 USAGE
-    exit 0
+  exit 0
 fi
 
 set -o errexit -o nounset
@@ -22,9 +22,9 @@ set -o errexit -o nounset
 # Verify that there is a local configuration directory
 DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
 if [[ ! -d "$DEFAULT_CONFIG" ]]; then
-    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
-    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
-    exit 1
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
 fi
 
 PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
@@ -35,8 +35,11 @@ OCCURRENCES="${3:-1}"
 # Verify that this bucket/environment pair is set up on S3
 BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
 if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
-    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
-    exit 1
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
 fi
 # NOTE we don't test for the validation folder since that gets created automatically.
 
@@ -46,11 +49,11 @@ set -o xtrace
 GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD 2>/dev/null || true)
 
 if [[ "$PROJ_ENVIRONMENT" =~ "production" ]]; then
-    PIPELINE_NAME="ETL Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+  PIPELINE_NAME="ETL Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 elif [[ -n "$GIT_BRANCH" ]]; then
-    PIPELINE_NAME="Validation Pipeline ($DEFAULT_PREFIX:$GIT_BRANCH $PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+  PIPELINE_NAME="Validation Pipeline ($DEFAULT_PREFIX:$GIT_BRANCH $PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 else
-    PIPELINE_NAME="Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+  PIPELINE_NAME="Validation Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
 fi
 
 # Note: "key" and "value" are lower-case keywords here.
@@ -58,6 +61,7 @@ AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-et
 
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
 # shellcheck disable=SC2064
 trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
 
@@ -73,9 +77,9 @@ aws datapipeline create-pipeline \
 PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
 
 if [[ -z "$PIPELINE_ID" ]]; then
-    set +x
-    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
-    exit 1
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
 fi
 
 aws datapipeline put-pipeline-definition \
@@ -87,7 +91,7 @@ aws datapipeline put-pipeline-definition \
 
 aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
 
-set +x
+set +o xtrace
 echo
 echo "You can monitor the status of this validation pipeline using:"
 echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/python/scripts/install_warmup_pipeline.sh
+++ b/python/scripts/install_warmup_pipeline.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+START_NOW=$(date -u +"%Y-%m-%dT%H:%M:%S")
+USER="${USER-nobody}"
+DEFAULT_PREFIX="${ARTHUR_DEFAULT_PREFIX-$USER}"
+
+if [[ $# -gt 3 || "$1" = "-h" ]]; then
+    cat <<USAGE
+
+Warmup ETL to run all the queries on empty data. This allow us to pre-compile queries
+before a rebuild when the cluster is fresh out of maintenance, thus reducing duration.
+
+Usage: $(basename "$0") [<environment> [<startdatetime> [<occurrences>]]]
+
+Start time should be 'now' or take the ISO8601 format like: $START_NOW
+The number of occurrences defaults to 1.
+
+USAGE
+    exit 0
+fi
+
+set -o errexit -o nounset
+
+# Verify that there is a local configuration directory
+DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
+if [[ ! -d "$DEFAULT_CONFIG" ]]; then
+    echo "Failed to find \'$DEFAULT_CONFIG\' directory."
+    echo "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+    exit 1
+fi
+
+PROJ_BUCKET=$( arthur.py show_value object_store.s3.bucket_name )
+PROJ_ENVIRONMENT="${1:-$DEFAULT_PREFIX}"
+START_DATE_TIME="${2:-$START_NOW}"
+OCCURRENCES="${3:-1}"
+
+# Verify that this bucket/environment pair is set up on S3
+BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
+if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
+    echo "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist!"
+    exit 1
+fi
+# NOTE we don't test for the validation folder since that gets created automatically.
+
+set -o xtrace
+
+# N.B. This assumes you are in the directory with your warehouse definition (schemas, config, ...)
+GIT_BRANCH=$(git symbolic-ref --short --quiet HEAD 2>/dev/null || true)
+
+if [[ "$PROJ_ENVIRONMENT" =~ "production" ]]; then
+    PIPELINE_NAME="ETL Warmup Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+elif [[ -n "$GIT_BRANCH" ]]; then
+    PIPELINE_NAME="Warmup Pipeline ($DEFAULT_PREFIX:$GIT_BRANCH $PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+else
+    PIPELINE_NAME="Warmup Pipeline ($PROJ_ENVIRONMENT @ $START_DATE_TIME, N=$OCCURRENCES)"
+fi
+
+# Note: "key" and "value" are lower-case keywords here.
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=warmup"
+
+PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
+PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+# shellcheck disable=SC2064
+trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
+
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" warmup_pipeline > "$PIPELINE_DEFINITION_FILE"
+
+# shellcheck disable=SC2086
+aws datapipeline create-pipeline \
+    --unique-id warmup-pipeline \
+    --name "$PIPELINE_NAME" \
+    --tags $AWS_TAGS \
+    | tee "$PIPELINE_ID_FILE"
+
+PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
+
+if [[ -z "$PIPELINE_ID" ]]; then
+    set +x
+    echo "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+    exit 1
+fi
+
+aws datapipeline put-pipeline-definition \
+    --pipeline-definition "file://$PIPELINE_DEFINITION_FILE" \
+    --parameter-values \
+        myStartDateTime="$START_DATE_TIME" \
+        myOccurrences="$OCCURRENCES" \
+    --pipeline-id "$PIPELINE_ID"
+
+aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID"
+
+set +x
+echo
+echo "You can monitor the status of this Warmup pipeline using:"
+echo "  watch --interval=5 arthur.py show_pipelines -q '$PIPELINE_ID'"

--- a/requirements-linters.txt
+++ b/requirements-linters.txt
@@ -6,8 +6,13 @@ flake8-comprehensions==3.5.0
 flake8-docstrings==1.6.0
 flake8-fixme==1.1.1
 isort==5.9.1
-mypy==0.812
+mypy==0.910
 mypy-boto3~=1.17
 mypy-extensions==0.4.3
 pre-commit==2.13.0
 pyupgrade==2.20.0
+types-PyYAML
+types-setuptools
+types-simplejson
+types-tabulate
+types-termcolor

--- a/requirements-linters.txt
+++ b/requirements-linters.txt
@@ -10,4 +10,4 @@ mypy==0.812
 mypy-boto3~=1.17
 mypy-extensions==0.4.3
 pre-commit==2.13.0
-pyupgrade==2.19.4
+pyupgrade==2.20.0

--- a/requirements-linters.txt
+++ b/requirements-linters.txt
@@ -11,8 +11,8 @@ mypy-boto3~=1.17
 mypy-extensions==0.4.3
 pre-commit==2.13.0
 pyupgrade==2.20.0
-types-PyYAML
-types-setuptools
-types-simplejson
-types-tabulate
-types-termcolor
+types-PyYAML==5.4.3
+types-setuptools==57.0.0
+types-simplejson==0.1.4
+types-tabulate==0.1.1
+types-termcolor==0.1.1

--- a/requirements-linters.txt
+++ b/requirements-linters.txt
@@ -5,7 +5,7 @@ flake8-bugbear==21.4.3
 flake8-comprehensions==3.5.0
 flake8-docstrings==1.6.0
 flake8-fixme==1.1.1
-isort==5.9.1
+isort==5.9.2
 mypy==0.910
 mypy-boto3~=1.17
 mypy-extensions==0.4.3

--- a/requirements-linters.txt
+++ b/requirements-linters.txt
@@ -10,7 +10,7 @@ mypy==0.910
 mypy-boto3~=1.17
 mypy-extensions==0.4.3
 pre-commit==2.13.0
-pyupgrade==2.20.0
+pyupgrade==2.21.0
 types-PyYAML==5.4.3
 types-setuptools==57.0.0
 types-simplejson==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ PyYAML==5.4.1
 simplejson==3.17.2
 tabulate==0.8.9
 termcolor==1.1.0
-tqdm==4.61.1
+tqdm==4.61.2
 watchtower==1.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jsonschema==3.2.0
 pgpasslib==1.1.0
 psycopg2-binary==2.9.1
 PyYAML==5.4.1
-simplejson==3.17.2
+simplejson==3.17.3
 tabulate==0.8.9
 termcolor==1.1.0
 tqdm==4.61.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow==1.1.1
-boto3==1.17.104
+boto3==1.17.111
 botocore~=1.20
 funcy==1.16
 jmespath==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "python/scripts/install_refresh_pipeline.sh",
         "python/scripts/install_upgrade_pipeline.sh",
         "python/scripts/install_validation_pipeline.sh",
+        "python/scripts/install_warmup_pipeline.sh",
         "python/scripts/launch_ec2_instance.sh",
         "python/scripts/launch_emr_cluster.sh",
         "python/scripts/re_run_partial_pipeline.py",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-ARTHUR_VERSION = "1.46.0"
+ARTHUR_VERSION = "1.47.0"
 
 
 setup(


### PR DESCRIPTION
## User-facing changes
* There is a new "warmup" pipeline that can be used to run through SQL but without data.
    * The expected use is after a maintenance event on a Redshift cluster when the cache was flushed. Running through all the SQL code pre-compiles it so that that time needn't be spent during the normal ETL.
    * This pipeline also comes in handy to actually run through SQL in general which the normal validation pipeline doesn't do.
    * In order to run without data, loading upstream data or data from external tables is skipped.
* There is a new `create_external_schemas` command to create the external schemas defined. The settings file allows to define the IAM role, (Glue Data Catalog) database, and permissions.
* The `create_validation_credentials` script has an additional argument that allows to pass in a name for the folder to be used other than the default `validation`.
* `create_validation_credentials` is easily available inside the Docker image.
* Logging is improved and metrics are added at the end of a sub-command and at the fail or finish events.
    * This includes "elapsed" times and "rowcount" (for tables).
* There is a new `vacuum` command to run `VACUUM` on a table.
* The `tail_logs` command has a new argument to set the earliest time from which logs are searched.
* (The sort and distribution keys can be set to the literal `AUTO`.) (Use at your own risk.)
* We're starting to add tokens in front of queries to make them easier to identify, e.g. `-- arthur.ddl`.
* There's a new SQL template: `table_attributes` to review sort and distribution settings of tables.

## Bug fixes
* The logging to CloudWatch now sends the traceback and exception info in log messages.
* The pipeline installation scripts are updated to provide better feedback when pipelines cannot be created.

## Internal changes
* We'll leverage ABC for sub-command classes and class-attributes to define which sub-commands use a monitor.
* Slowly moving through the code base to update `().format` to `f""`.
* Generally, we'll try to send error output from scripts to stderr.

## Version updates
* `boto3` 1.17.111
* `isort` 5.9.2
* `mypy` 0.920 -- this required adding some `types-` libraries
* `pyupgrade` 2.21.0
* `simplejson` 3.17.3
* `tqdm` 4.61.2