### PR TITLE
Add etl_id to CloudWatch logs

### DIFF
--- a/python/etl/logs/cloudwatch.py
+++ b/python/etl/logs/cloudwatch.py
@@ -31,7 +31,8 @@ def add_cloudwatch_logging(prefix) -> None:
 
     log_level = get_config_value("arthur_settings.logging.cloudwatch.log_level")
     handler.setLevel(log_level)
-    handler.setFormatter(JsonFormatter(prefix))
+    # The extra "str()" gets around the meta class approach to store the etl_id.
+    handler.setFormatter(JsonFormatter(prefix, str(etl.monitor.Monitor.etl_id)))
 
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -178,8 +178,8 @@ class Monitor(metaclass=MetaMonitor):
         return Monitor.cluster_info
 
     @property
-    def etl_id(self):
-        return Monitor.etl_id
+    def etl_id(self) -> str:
+        return str(Monitor.etl_id)
 
     @property
     def target(self):


### PR DESCRIPTION
This updates the JSON formatter for log records, which is used to send logs to CloudWatch, so that the `etl_id`
value is part of the record. (Also, adding an `application_name` to match previous record shapes sent to Elasticsearch.)

Additionally, an `exception` field is added to the record which holds the value of the exception instance.

Example fields now coming through:
```
{
    "application_name": "arthur-etl",
    "environment": "tom",
    "etl_id": "9FF88E8BA78F4CDB",
    "exception": "UpdateTableError(InternalError_('Cannot insert a NULL value into column ... )",
    "gmtime": "2021-08-04T15:50:47.167Z",
    "log_level": "WARNING",
    "log_severity": 30,
    "logger": "etl.load",
    "message": "Failed to build relation '...",
    "process.id": 33,
    "process.name": "MainProcess",
    "source.filename": "load.py",
    "source.function": "mark_failure",
    "source.line_number": 205,
    "source.module": "load",
    "source.pathname": "/opt/src/arthur-redshift-etl/python/etl/load.py",
    "thread.name": "MainThread",
    "timestamp": 1628092247167
}
```