### PR TITLE
Add exception class and message to CloudWatch

### DIFF
--- a/python/etl/logs/formatter.py
+++ b/python/etl/logs/formatter.py
@@ -67,7 +67,8 @@ class JsonFormatter(logging.Formatter):
             values["metrics"] = record.metrics  # type: ignore
         # Always add exception (value) as a field if exception info is present.
         if record.exc_info is not None:
-            values["exception"] = repr(record.exc_info[1])
+            values["exception.class"] = record.exc_info[1].__class__.__name__
+            values["exception.message"] = str(record.exc_info[1])
         # Always add formatted exception to message if exception info is present.
         if record.exc_text is not None:
             if values["message"] != "\n":


### PR DESCRIPTION
This changes the exception information to split into class and message like so:
```
"exception": {
    "class": "UpdateTableError",
    "message": "Cannot insert a NULL value into column site
DETAIL:  
  -----------------------------------------------
  error:  Cannot insert a NULL value into column site
  code:      8007
  context:   query execution
  query:     5497726
  location:  column:1
  process:   query0_102_5497726 [pid=20385]
  -----------------------------------------------

"
}
```
This allows easy search for the exception class and cleans up the message.