### PR TITLE
Add summary log of event types and their count

### DIFF
--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -898,10 +898,8 @@ def summarize_events(relations, step: Optional[str] = None) -> None:
         f"Event count in summary: "
         f"start={stats[STEP_START]}, finish={stats[STEP_FINISH]}, fail={stats[STEP_FAIL]}"
     )
-    if stats[STEP_FAIL] > 0:
-        logger.warning(msg)
-    else:
-        logger.info(msg)
+    level = logging.WARNING if stats[STEP_FAIL] > 0 else logging.INFO
+    logger.log(level, msg)
 
 
 def tail_events(


### PR DESCRIPTION
This PR adds a quick summary line at then of `summarize_events` output so that we don't accidentally miss a `fail` event of a relation.

```
2021-10-04 13:59:06 - INFO - Event count in summary: start=0, finish=999, fail=0
```
