### PR TITLE
Add ref resolution error

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -184,7 +184,8 @@ def load_settings_file(filename: str, settings: dict) -> None:
     logger.info(f"Loading settings from '{filename}'")
     with open(filename) as content:
         new_settings = yaml.safe_load(content)
-    _deep_update(settings, new_settings)
+    if new_settings:
+        _deep_update(settings, new_settings)
 
 
 def get_python_info() -> str:


### PR DESCRIPTION
Add the ref resolution error to the known schema validation errors.

So if there's a problem with a `ref` like this:
```
    "name": { "$ref": "#/definitions/def_does_not_exist" },
```
then the error is:
```
jsonschema.exceptions.RefResolutionError: Unresolvable JSON pointer: 'definitions/def_does_not_exist'
etl.errors.SchemaValidationError: failed to validate against 'table_design.schema'
etl.errors.TableDesignSyntaxError: failed to validate table design for ...
```