### PR TITLE
Move wlm_query_slot_count into Redshift dialect file

### DIFF
--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -473,6 +473,12 @@ def insert_from_query(
         raise
 
 
+def set_wlm_slots(conn: Connection, slots: int, dry_run: bool) -> None:
+    etl.db.run(
+        conn, f"Using {slots} WLM queue slot(s)", f"SET wlm_query_slot_count TO {slots}", dry_run=dry_run
+    )
+
+
 def unload(
     conn: Connection,
     table_name: TableName,


### PR DESCRIPTION
This moves the Redshift-specific code for WLM slots into the "dialects" file.