### PR TITLE
Grant access on "staging" schemas and relations to reader groups.

### DIFF
--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -85,8 +85,8 @@ def create_schema_and_grant_access(conn, schema, owner=None, use_staging=False, 
         logger.info("Creating schema '%s'", name)
         etl.db.create_schema(conn, name, owner)
         etl.db.grant_all_on_schema_to_user(conn, name, schema.owner)
-    if not schema.groups or use_staging:
-        # Don't grant usage on staging schemas to readers/writers (if any)
+    if not schema.groups:
+        # Note that we'll grant usage on staging schemas to readers/writers (if any)
         return None
     if dry_run:
         logger.info("Dry-run: Skipping granting access in '%s' to '%s'", name, group_names)

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -361,8 +361,7 @@ def create_or_replace_relation(conn: connection, relation: LoadableRelation, dry
             create_view(conn, relation, dry_run=dry_run)
         else:
             create_table(conn, relation, dry_run=dry_run)
-        if not relation.use_staging:
-            grant_access(conn, relation, dry_run=dry_run)
+        grant_access(conn, relation, dry_run=dry_run)
     except Exception as exc:
         raise RelationConstructionError(exc) from exc
 


### PR DESCRIPTION
- Grant usage and select access on `etl_staging$` schemas and `etl_staging$` relations to reader groups.
- See [initial QA](https://harrys.atlassian.net/browse/DENG-1097?focusedCommentId=59464).