### PR TITLE
Document settings files

### DIFF
--- a/bin/release_version.sh
+++ b/bin/release_version.sh
@@ -21,6 +21,7 @@ if ! type -a git >/dev/null 2>&1 ; then
     exit 1
 fi
 
+# Create an empty file to add information to (and make sure that it gets cleaned up).
 true > "$TEMP_RELEASE_FILE"
 # shellcheck disable=SC2064
 trap "rm \"$TEMP_RELEASE_FILE\"" EXIT
@@ -36,6 +37,7 @@ else
     echo "commit=$GIT_COMMIT_HASH" >> "$TEMP_RELEASE_FILE"
 fi
 
+# Pick up the date from the latest commit.
 echo "date=$(git log -1 --format='%ai' HEAD)" >> "$TEMP_RELEASE_FILE"
 
 # We add the latest commit hash to the release file which is misleading if we're pulling in modified files.
@@ -46,9 +48,9 @@ if git status --porcelain 2>/dev/null | grep -E '^ M|^M' >/dev/null; then
 fi
 
 if cmp "$TEMP_RELEASE_FILE" "$RELEASE_FILE" >/dev/null 2>&1; then
-    echo "Release information is unchanged."
+    echo "Release information is unchanged." >&2
 else
-    echo "Updating release information in $RELEASE_FILE"
+    echo "Updating release information in $RELEASE_FILE" >&2
     cp "$TEMP_RELEASE_FILE" "$RELEASE_FILE"
 fi
 cat "$TEMP_RELEASE_FILE"

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1973,7 +1973,7 @@ class TailLogsCommand(SubCommand):
 class ShowHelpCommand(SubCommand):
     def __init__(self):
         super().__init__("help", "show help by topic", "Show helpful information around selected topic.")
-        self.topics = ["extract", "load", "pipeline", "sync", "unload", "validate"]
+        self.topics = ["config", "extract", "load", "pipeline", "sync", "unload", "validate"]
 
     def add_arguments(self, parser):
         parser.set_defaults(log_level="CRITICAL")

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1973,7 +1973,7 @@ class TailLogsCommand(SubCommand):
 class ShowHelpCommand(SubCommand):
     def __init__(self):
         super().__init__("help", "show help by topic", "Show helpful information around selected topic.")
-        self.topics = ["config", "extract", "load", "pipeline", "sync", "unload", "validate"]
+        self.topics = ("config", "extract", "load", "pipeline", "sync", "unload", "validate")
 
     def add_arguments(self, parser):
         parser.set_defaults(log_level="CRITICAL")

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -1,10 +1,16 @@
 """
-This module provides global access to settings.  Always treat them nicely and read-only.
+Configuration files cover settings and DSNs.
 
 We use the term "config" files to refer to all files that may reside in the "config" directory:
   * "Settings" files (ending in '.yaml') which drive the data warehouse or resource settings
   * Environment files (with variables used in connections)
   * Other files (like release notes)
+
+For settings and environment files, files are loaded in alphabetical order and they keep updating
+values so that only the last one is kept.
+
+To see the final value of settings based on the order of files, use:
+  arthur.py settings --verbose
 """
 
 import datetime
@@ -47,7 +53,7 @@ _mapped_config: Optional[Dict[str, str]] = None
 ETL_TMP_DIR = "/tmp/redshift_etl"
 
 
-def package_version(package_name="redshift_etl"):
+def package_version(package_name="redshift_etl") -> str:
     return f"{package_name} v{pkg_resources.get_distribution(package_name).version}"
 
 

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -58,8 +58,12 @@ _mapped_config: Optional[Dict[str, str]] = None
 ETL_TMP_DIR = "/tmp/redshift_etl"
 
 
+def arthur_version(package_name="redshift_etl") -> str:
+    return f"v{pkg_resources.get_distribution(package_name).version}"
+
+
 def package_version(package_name="redshift_etl") -> str:
-    return f"{package_name} v{pkg_resources.get_distribution(package_name).version}"
+    return f"{package_name} {arthur_version()}"
 
 
 def get_dw_config():
@@ -294,7 +298,8 @@ def load_config(config_files: Iterable[str], default_file: str = "default_settin
     if _mapped_config is not None:
         _mapped_config["data_warehouse.owner.name"] = _dw_config.owner.name
 
-    set_config_value("version", package_version())
+    set_config_value("package_version", package_version())
+    set_config_value("version", arthur_version())
 
 
 def validate_with_schema(obj: dict, schema_name: str) -> None:

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -7,9 +7,13 @@ We use the term "config" files to refer to all files that may reside in the "con
   * Other files (like release notes)
 
 For settings and environment files, files are loaded in alphabetical order and they keep updating
-values so that only the last one is kept.
+values so that only the last one is kept. If you want to ensure a particular order, your best option
+is to prefix the files with a number sequence:
+  01_general.yaml
+  02_deploy.yaml
+and so on.
 
-To see the final value of settings based on the order of files, use:
+To inspect the final value of settings (and see the order of files loaded), use:
   arthur.py settings --verbose
 """
 
@@ -32,6 +36,7 @@ from simplejson.errors import JSONDecodeError
 import etl.config.dw
 from etl.config.dw import DataWarehouseConfig
 from etl.errors import ETLRuntimeError, InvalidArgumentError, SchemaInvalidError, SchemaValidationError
+from etl.text import join_with_single_quotes
 
 # The json_schema package doesn't have a nice parent class for its exceptions.
 VALIDATION_SCHEMA_ERRORS = (
@@ -144,6 +149,10 @@ def _build_config_map(settings):
     for section in frozenset(settings).difference({"data_warehouse", "sources", "type_maps"}):
         for name, value in _flatten_hierarchy(section, settings[section]):
             mapping[name] = value
+    # The setting for required relations is rather handy to surface here.
+    mapping["data_warehouse.required_for_success"] = join_with_single_quotes(
+        settings["data_warehouse"].get("required_for_success", [])
+    )
     return mapping
 
 


### PR DESCRIPTION
## Description

* Describe how configuration files cover settings and DSNs.
* Add list of "required" relations to output of the settings command
* Split `version` from `package_version` to be more consistent. The version should now point back to a version that can be used as a tag for `bin/arthur.sh`.

### User-visible changes

<!-- Describe what changes for users of Arthur -->

See the documentation:
```
arthur.py help config
```

Check the settings:
```
arthur.py settings data_warehouse.required_for_success package_version version
```

### Internal changes

Added some more info to `bin/release_version.sh`.
