### PR TITLE
Support multiple groups for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ you can simply use `../arthur-redshift-etl/` to find your way back to this ETL c
 
 Although the Redshift cluster can be administered using the AWS console and `psql`, some
 helper scripts will make setting up the cluster consistently much easier.
-(See below for `initialize` and `create_user`.)
+(See below for `initialize`, `create_groups`, and `create_users`.)
 
 Also, add the AWS IAM role that the database owner may assume within Redshift
 to your settings file so that Redshift has the needed permissions to access the
@@ -166,7 +166,7 @@ Don't forget to run `terminate_emr_cluster.sh` when you're done.
 | ---- | ---- |
 | `initialize`  | Create schemas, groups and users |
 | `create_groups` | Create groups that are mentioned in the configuration file |
-| `create_user` | Create (or configure) users that are not mentioned in the configuration file |
+| `create_users` | Create users that are mentioned in the configuration file |
 
 ```shell
 # The commands to setup the data warehouse users and groups or any database is by ADMIN (connected to `dev`)

--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -22,7 +22,7 @@ _arthur_completion()
                 create_groups
                 create_index
                 create_schemas
-                create_user
+                create_users
                 delete_finished_pipelines
                 design
                 explain

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -44,12 +44,7 @@
                 "comment": { "type": "string" },
                 "description": { "type": "string" },
                 "group": { "$ref": "#/$defs/identifier" },
-                "groups": {
-                    "items": { "$ref": "#/$defs/identifier" },
-                    "maxItems": 1,
-                    "minItems": 1,
-                    "type": "array"
-                },
+                "groups": { "$ref": "#/$defs/identifier_list" },
                 "name": { "$ref": "#/$defs/identifier" },
                 "schema": { "$ref": "#/$defs/identifier" }
             },

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -420,7 +420,7 @@ def _get_encrypted_password(cx, user) -> Optional[str]:
     return "md5" + md5.hexdigest()
 
 
-def create_user(cx: Connection, user: str, group: str) -> None:
+def create_user(cx: Connection, user: str) -> None:
     password = _get_encrypted_password(cx, user)
     if password is None:
         logger.warning("Missing entry in PGPASSFILE file for '%s'", user)
@@ -428,7 +428,7 @@ def create_user(cx: Connection, user: str, group: str) -> None:
         raise ETLRuntimeError(
             f"password missing from PGPASSFILE for user '{user}'"
         )  # lgtm[py/clear-text-logging-sensitive-data]
-    execute(cx, f"""CREATE USER "{user}" IN GROUP "{group}" PASSWORD %s""", (password,))
+    execute(cx, f"""CREATE USER "{user}" PASSWORD %s""", (password,))
 
 
 def alter_password(cx: Connection, user: str, ignore_missing_password=False) -> None:

--- a/tests/config/test_dw.py
+++ b/tests/config/test_dw.py
@@ -36,6 +36,6 @@ class TestConfigDW(unittest.TestCase):
         found = etl.config.dw.DataWarehouseConfig.parse_users(self.settings)
         self.assertEqual(len(found), 2)
         self.assertEqual(found[0].name, "etl")
-        self.assertEqual(found[0].group, "etl")
+        self.assertEqual(found[0].groups, ["etl"])
         self.assertEqual(found[1].name, "a_user")
-        self.assertEqual(found[1].group, "a_group")
+        self.assertEqual(found[1].groups, ["a_group"])


### PR DESCRIPTION
## Description

This PR brings us the option to configure multiple groups for each user.
This allows us to bring in the configuration of users, which we have done before on the command line.

There seem to be a lot of changes here but it's really just pushing the change of "group -> groups" through.

That said, having **this PR first** would help: Add "groups" and "comment" to user info #591

### User-visible changes

The following commands have been updated:
* `initialize` -- all users and groups from the configuration are created if requested. This now supports users being in multiple groups.
* `create_users` (or its alias `create_user`) -- this no longer supports specifying a group or creating a schema for the user. You should specify a user's groups in the configuration file. If you need to create a schema, use `update_user`.
* `update_user` -- this no longer supports specifying a group or creating a schema for the user. You should specify a user's groups in the configuration file. You can use this command to add a user's schema. If you have added the user's password to your `.pgpass` file, then the user's password will be updated.

Note that users are now created without passwords and cannot login until you run:
```
arthur.py update_user
```

In order to be backwards compatible with current configuration files, both `group` with a single identifier and `groups` with a list oof identifiers is supported to configure a user's groups.

Note that `users` is a list in the configuration and you cannot spread the definition of users over multiple files. The last list of users in configuration files wins.

Here's an example for user configuration.
```yaml
{
    "data_warehouse": {
        "users": [
            {
                "name": "default",
                "group": "analyst"
            },
            {
                "name": "tom",
                "groups": ["analyst", "etl_ro"]
            }
        ]
    }
}
```

## Links

Supports: Manage users access and group membership using configuration #581

## Testing

You can run all commands using `--dry-run` to make sure that they would do what you want them to do.