### PR TITLE
Add "list_users" command

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -29,6 +29,7 @@ _arthur_completion()
                 extract
                 help
                 initialize
+                list_users
                 load
                 ls
                 ping

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -352,6 +352,7 @@ def build_full_parser(prog_name):
         ShowRandomPassword,
         CreateGroupsCommand,
         CreateUserCommand,
+        ListUsersCommand,
         UpdateUserCommand,
         RunSqlCommand,
         # Commands to help with table designs and uploading them
@@ -710,6 +711,22 @@ class CreateUserCommand(SubCommand):
                 add_user_schema=args.add_user_schema,
                 dry_run=args.dry_run,
             )
+
+
+class ListUsersCommand(SubCommand):
+    def __init__(self):
+        super().__init__(
+            "list_users",
+            "list users as they are configured",
+            "List all users and their groups in the way that they are configurd.",
+        )
+
+    def add_arguments(self, parser):
+        parser.add_argument("-t", "--transpose", help="group list by user's groups", action="store_true")
+
+    def callback(self, args):
+        with etl.db.log_error():
+            etl.data_warehouse.list_users(transpose=args.transpose)
 
 
 class UpdateUserCommand(SubCommand):

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -116,9 +116,8 @@ def set_safe_config_value(name: str, value: str) -> None:
 def get_config_map() -> Dict[str, str]:
     if _mapped_config is None:
         return {}
-    else:
-        # Since the mapped config is flattened, we don't worry about a deep copy here.
-        return dict(_mapped_config)
+    # Since the mapped config is flattened, we don't worry about a deep copy here.
+    return dict(_mapped_config)
 
 
 def _flatten_hierarchy(prefix, props):

--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -34,7 +34,7 @@
       {
         # Default group specified as group of pseudo-user "default"
         "name": "default",
-        "group": "analyst_ro"
+        "group": "analyst"
       }
     ]
   },

--- a/python/etl/config/dw.py
+++ b/python/etl/config/dw.py
@@ -1,6 +1,6 @@
 """Data warehouse configuration based on config files for setup, sources, transformations, users."""
 
-from typing import Dict
+from typing import Dict, List
 
 import etl.config.env
 import etl.db
@@ -18,7 +18,7 @@ class DataWarehouseUser:
     data warehouse as read-only.
     """
 
-    def __init__(self, user_info):
+    def __init__(self, user_info) -> None:
         self.name = user_info["name"]
         self.group = user_info["group"]
         self.schema = user_info.get("schema")
@@ -61,7 +61,7 @@ class DataWarehouseSchema:
     those are really all the same here.
     """
 
-    def __init__(self, schema_info, etl_access=None):
+    def __init__(self, schema_info, etl_access=None) -> None:
         self.name = schema_info["name"]
         self.description = schema_info.get("description")
         # Schemas have an 'owner' user (with ALL privileges)
@@ -155,22 +155,22 @@ class DataWarehouseSchema:
             return etl.db.parse_connection_string(etl.config.env.get(self._dsn_env_var))
 
     @property
-    def groups(self):
+    def groups(self) -> List[str]:
         return self.reader_groups + self.writer_groups
 
     @property
-    def backup_name(self):
+    def backup_name(self) -> str:
         return etl.names.as_backup_name(self.name)
 
     @property
-    def staging_name(self):
+    def staging_name(self) -> str:
         return etl.names.as_staging_name(self.name)
 
 
 class DataWarehouseConfig:
     """Pretty interface to create objects from the settings files."""
 
-    def __init__(self, settings):
+    def __init__(self, settings) -> None:
         dw_settings = settings["data_warehouse"]
         schema_settings = settings.get("sources", []) + dw_settings.get("transformations", [])
 

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Settings",
     "description": "Schema for settings of data warehouse, upstream sources, and ETL",
-    "definitions": {
+    "$defs": {
         "identifier": {
             "description": "Standard identifier (either SQL or AWS)",
             "type": "string",
@@ -12,17 +12,17 @@
         },
         "identifier_list": {
             "type": "array",
-            "items": { "$ref": "#/definitions/identifier" },
+            "items": { "$ref": "#/$defs/identifier" },
             "uniqueItems": true,
             "minItems": 1
         },
         "user_info": {
             "type": "object",
             "properties": {
-                "name": { "$ref": "#/definitions/identifier" },
+                "name": { "$ref": "#/$defs/identifier" },
                 "description": { "type": "string" },
-                "group": { "$ref": "#/definitions/identifier" },
-                "schema": { "$ref": "#/definitions/identifier" }
+                "group": { "$ref": "#/$defs/identifier" },
+                "schema": { "$ref": "#/$defs/identifier" }
             },
             "required": [ "name", "group" ],
             "additionalProperties": false
@@ -51,13 +51,13 @@
             "description": "Description of an upstream database with access, tables and permissions for the copy",
             "type": "object",
             "properties": {
-                "name": { "$ref": "#/definitions/identifier" },
+                "name": { "$ref": "#/$defs/identifier" },
                 "description": { "type": "string" },
-                "read_access": { "$ref": "#/definitions/identifier" },
-                "include_tables": { "$ref": "#/definitions/glob_pattern_list" },
-                "exclude_tables": { "$ref": "#/definitions/glob_pattern_list" },
-                "readers": { "$ref": "#/definitions/identifier_list" },
-                "writers": { "$ref": "#/definitions/identifier_list" }
+                "read_access": { "$ref": "#/$defs/identifier" },
+                "include_tables": { "$ref": "#/$defs/glob_pattern_list" },
+                "exclude_tables": { "$ref": "#/$defs/glob_pattern_list" },
+                "readers": { "$ref": "#/$defs/identifier_list" },
+                "writers": { "$ref": "#/$defs/identifier_list" }
             },
             "required": [ "name", "read_access", "include_tables" ],
             "additionalProperties": false
@@ -66,15 +66,15 @@
             "description": "Description of an upstream source consisting of files in S3, may also be an unload target",
             "type": "object",
             "properties": {
-                "name": { "$ref": "#/definitions/identifier" },
+                "name": { "$ref": "#/$defs/identifier" },
                 "description": { "type": "string" },
-                "s3_bucket": { "$ref": "#/definitions/bucket_template" },
-                "s3_path_template": { "$ref": "#/definitions/path_template" },
-                "s3_data_format": { "$ref": "#/definitions/s3_data_format" },
-                "s3_unload_path_template": { "$ref": "#/definitions/path_template" },
-                "include_tables": { "$ref": "#/definitions/glob_pattern_list" },
-                "readers": { "$ref": "#/definitions/identifier_list" },
-                "writers": { "$ref": "#/definitions/identifier_list" }
+                "s3_bucket": { "$ref": "#/$defs/bucket_template" },
+                "s3_path_template": { "$ref": "#/$defs/path_template" },
+                "s3_data_format": { "$ref": "#/$defs/s3_data_format" },
+                "s3_unload_path_template": { "$ref": "#/$defs/path_template" },
+                "include_tables": { "$ref": "#/$defs/glob_pattern_list" },
+                "readers": { "$ref": "#/$defs/identifier_list" },
+                "writers": { "$ref": "#/$defs/identifier_list" }
             },
             "anyOf": [
                 { "required": [ "name", "s3_bucket", "s3_path_template"  ] },
@@ -89,12 +89,12 @@
             "description": "Description of an external schema in AWS Redshift (listed in an AWS Glue Data Catalog)",
             "type": "object",
             "properties": {
-                "name": { "$ref": "#/definitions/identifier" },
+                "name": { "$ref": "#/$defs/identifier" },
                 "description": { "type": "string" },
                 "external": { "enum": [ true ] },
-                "groups": { "$ref": "#/definitions/identifier_list" },
-                "database": { "$ref": "#/definitions/identifier" },
-                "iam_role": { "$ref": "#/definitions/aws_arn" }
+                "groups": { "$ref": "#/$defs/identifier_list" },
+                "database": { "$ref": "#/$defs/identifier" },
+                "iam_role": { "$ref": "#/$defs/aws_arn" }
             },
             "required": [ "name", "external" ],
             "additionalProperties": false
@@ -231,12 +231,12 @@
         "data_warehouse": {
             "type": "object",
             "properties": {
-                "admin_access": { "$ref": "#/definitions/identifier" },
-                "etl_access": { "$ref": "#/definitions/identifier" },
-                "owner": { "$ref": "#/definitions/user_info" },
+                "admin_access": { "$ref": "#/$defs/identifier" },
+                "etl_access": { "$ref": "#/$defs/identifier" },
+                "owner": { "$ref": "#/$defs/user_info" },
                 "users": {
                     "type": "array",
-                    "items": { "$ref": "#/definitions/user_info" },
+                    "items": { "$ref": "#/$defs/user_info" },
                     "uniqueItems": true,
                     "minItems": 1
                 },
@@ -246,9 +246,9 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "name": { "$ref": "#/definitions/identifier" },
+                            "name": { "$ref": "#/$defs/identifier" },
                             "description": { "type": "string" },
-                            "groups": { "$ref": "#/definitions/identifier_list" }
+                            "groups": { "$ref": "#/$defs/identifier_list" }
                         },
                         "required": [ "name" ],
                         "additionalProperties": false
@@ -258,7 +258,7 @@
                 "required_for_success": {
                     "description": "List of patterns to identify 'required' relations whose fault will stop the ETL",
                     "oneOf": [
-                        { "$ref": "#/definitions/glob_pattern_list" },
+                        { "$ref": "#/$defs/glob_pattern_list" },
                         { "type": "boolean" }
                     ]
                 }
@@ -271,9 +271,9 @@
             "description": "List of upstream sources (databases or files in S3)",
             "items": {
                 "oneOf": [
-                    { "$ref": "#/definitions/upstream_database" },
-                    { "$ref": "#/definitions/upstream_static" },
-                    { "$ref": "#/definitions/upstream_external" }
+                    { "$ref": "#/$defs/upstream_database" },
+                    { "$ref": "#/$defs/upstream_static" },
+                    { "$ref": "#/$defs/upstream_external" }
                 ]
             },
             "minItems": 1,
@@ -311,13 +311,13 @@
             "properties": {
                 "iam_role": {
                     "description": "DEPRECATED Use the more specific IAM role for S3",
-                    "$ref": "#/definitions/aws_arn"
+                    "$ref": "#/$defs/aws_arn"
                 },
                 "s3": {
                     "type": "object",
                     "properties": {
-                        "bucket_name": { "$ref": "#/definitions/identifier" },
-                        "iam_role": { "$ref": "#/definitions/aws_arn" }
+                        "bucket_name": { "$ref": "#/$defs/identifier" },
+                        "iam_role": { "$ref": "#/$defs/aws_arn" }
                     },
                     "required": [ "bucket_name" ],
                     "additionalProperties": false
@@ -330,13 +330,13 @@
             "description": "Location and attributes for (temporary) storage for code and extracted data",
             "type": "object",
             "properties": {
-                "iam_role": { "$ref": "#/definitions/aws_arn" },
+                "iam_role": { "$ref": "#/$defs/aws_arn" },
                 "s3": {
                     "type": "object",
                     "properties": {
-                        "bucket_name": { "$ref": "#/definitions/identifier" },
-                        "iam_role": { "$ref": "#/definitions/aws_arn" },
-                        "upload_acl": { "$ref": "#/definitions/s3_acl" }
+                        "bucket_name": { "$ref": "#/$defs/identifier" },
+                        "iam_role": { "$ref": "#/$defs/aws_arn" },
+                        "upload_acl": { "$ref": "#/$defs/s3_acl" }
                     },
                     "required": [ "bucket_name" ],
                     "additionalProperties": false
@@ -348,19 +348,19 @@
         "resources": {
             "type": "object",
             "properties": {
-                "key_name": { "$ref": "#/definitions/identifier" },
+                "key_name": { "$ref": "#/$defs/identifier" },
                 "VPC": {
                     "type": "object",
                     "properties": {
-                        "region": { "$ref": "#/definitions/identifier" },
+                        "region": { "$ref": "#/$defs/identifier" },
                         "account": {
                             "type": "string",
                             "pattern": "^[0-9]+$"
                         },
-                        "name": { "$ref": "#/definitions/identifier" },
-                        "public_subnet": { "$ref": "#/definitions/identifier" },
-                        "private_subnet": { "$ref": "#/definitions/identifier" },
-                        "whitelist_security_group": { "$ref": "#/definitions/identifier" }
+                        "name": { "$ref": "#/$defs/identifier" },
+                        "public_subnet": { "$ref": "#/$defs/identifier" },
+                        "private_subnet": { "$ref": "#/$defs/identifier" },
+                        "whitelist_security_group": { "$ref": "#/$defs/identifier" }
                     },
                     "required": [ "region", "account", "name", "public_subnet", "whitelist_security_group" ],
                     "additionalProperties": false
@@ -370,8 +370,8 @@
                     "properties": {
                         "instance_type": { "type": "string" },
                         "image_id": { "type": "string" },
-                        "public_security_group": { "$ref": "#/definitions/identifier" },
-                        "iam_instance_profile": { "$ref": "#/definitions/identifier" }
+                        "public_security_group": { "$ref": "#/$defs/identifier" },
+                        "iam_instance_profile": { "$ref": "#/$defs/identifier" }
                     },
                     "required": [ "instance_type", "image_id", "public_security_group", "iam_instance_profile" ],
                     "additionalProperties": false
@@ -380,8 +380,8 @@
                     "type": "object",
                     "properties": {
                         "release_label": { "type": "string" },
-                        "master": { "$ref": "#/definitions/cluster_group" },
-                        "core": { "$ref": "#/definitions/cluster_group" },
+                        "master": { "$ref": "#/$defs/cluster_group" },
+                        "core": { "$ref": "#/$defs/cluster_group" },
                         "max_partitions": {
                             "description": "Maximum number of partitions during extract, limits num_partitions for each table",
                             "type": "integer",
@@ -394,7 +394,7 @@
                 "DataPipeline": {
                     "type": "object",
                     "properties": {
-                        "role": { "$ref": "#/definitions/identifier" }
+                        "role": { "$ref": "#/$defs/identifier" }
                     },
                     "required": [ "role" ],
                     "additionalProperties": false
@@ -402,7 +402,7 @@
                 "RedshiftCluster": {
                     "type": "object",
                     "properties": {
-                        "name": { "$ref": "#/definitions/identifier" },
+                        "name": { "$ref": "#/$defs/identifier" },
                         "max_concurrency": {
                             "type": "integer",
                             "minimum": 1
@@ -423,11 +423,11 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "unique-id": { "$ref": "#/definitions/identifier" },
+                    "unique-id": { "$ref": "#/$defs/identifier" },
                     "description": { "type": "string" },
                     "start-time": { "type": "string" },
                     "occurrences": { "type": "integer" },
-                    "patterns": { "$ref": "#/definitions/glob_pattern_list" }
+                    "patterns": { "$ref": "#/$defs/glob_pattern_list" }
                 },
                 "required": [ "unique-id", "description" ],
                 "additionalProperties": false

--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Table Design",
     "description": "Description of a table design as a JSON schema",
-    "definitions": {
+    "$defs": {
         "table_name": {
             "description": "Fully qualified name of the table or view, <schema name>.<table name>",
             "type" : "string",
@@ -17,13 +17,13 @@
         },
         "column_list": {
             "type": "array",
-            "items": { "$ref": "#/definitions/identifier" },
+            "items": { "$ref": "#/$defs/identifier" },
             "minItems": 1,
             "uniqueItems": true
         },
         "one_column_as_list": {
             "type": "array",
-            "items": { "$ref": "#/definitions/identifier" },
+            "items": { "$ref": "#/$defs/identifier" },
             "minItems": 1,
             "maxItems": 1
         },
@@ -71,7 +71,7 @@
     },
     "type" : "object",
     "properties" : {
-        "name" : { "$ref": "#/definitions/table_name" },
+        "name" : { "$ref": "#/$defs/table_name" },
         "description": {
             "type": "string",
             "description": "Description of the table (may start with qualifier such as 'DEPRECATED')"
@@ -93,18 +93,18 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "name": { "$ref": "#/definitions/identifier" },
+                            "name": { "$ref": "#/$defs/identifier" },
                             "description": { "type": "string" },
-                            "sql_type": { "$ref": "#/definitions/data_type" },
-                            "source_sql_type": { "$ref": "#/definitions/data_type" },
-                            "expression": { "$ref": "#/definitions/expression" },
-                            "type": { "$ref": "#/definitions/generic_type" },
-                            "encoding": { "$ref": "#/definitions/compression_encoding" },
+                            "sql_type": { "$ref": "#/$defs/data_type" },
+                            "source_sql_type": { "$ref": "#/$defs/data_type" },
+                            "expression": { "$ref": "#/$defs/expression" },
+                            "type": { "$ref": "#/$defs/generic_type" },
+                            "encoding": { "$ref": "#/$defs/compression_encoding" },
                             "references": {
                                 "type": "array",
                                 "items": [
-                                    { "$ref": "#/definitions/table_name" },
-                                    { "$ref": "#/definitions/one_column_as_list" }
+                                    { "$ref": "#/$defs/table_name" },
+                                    { "$ref": "#/$defs/one_column_as_list" }
                                 ]
                             },
                             "not_null": { "type": "boolean" },
@@ -126,7 +126,7 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "name": { "$ref": "#/definitions/identifier" },
+                            "name": { "$ref": "#/$defs/identifier" },
                             "description": { "type": "string" }
                         },
                         "required": [ "name" ],
@@ -143,10 +143,10 @@
                     "type": "object",
                     "description": "DEPRECATED format from v0.23.0 and earlier",
                     "properties": {
-                        "primary_key": { "$ref": "#/definitions/column_list" },
-                        "natural_key": { "$ref": "#/definitions/column_list" },
-                        "surrogate_key": { "$ref": "#/definitions/one_column_as_list" },
-                        "unique": { "$ref": "#/definitions/column_list" }
+                        "primary_key": { "$ref": "#/$defs/column_list" },
+                        "natural_key": { "$ref": "#/$defs/column_list" },
+                        "surrogate_key": { "$ref": "#/$defs/one_column_as_list" },
+                        "unique": { "$ref": "#/$defs/column_list" }
                     },
                     "additionalProperties": false
                 },
@@ -158,25 +158,25 @@
                         "oneOf": [
                             {
                                 "properties": {
-                                    "primary_key": { "$ref": "#/definitions/column_list" }
+                                    "primary_key": { "$ref": "#/$defs/column_list" }
                                 },
                                 "additionalProperties": false
                             },
                             {
                                 "properties": {
-                                    "natural_key": { "$ref": "#/definitions/column_list" }
+                                    "natural_key": { "$ref": "#/$defs/column_list" }
                                 },
                                 "additionalProperties": false
                             },
                             {
                                 "properties": {
-                                    "surrogate_key": { "$ref": "#/definitions/one_column_as_list" }
+                                    "surrogate_key": { "$ref": "#/$defs/one_column_as_list" }
                                 },
                                 "additionalProperties": false
                             },
                             {
                                 "properties": {
-                                    "unique": { "$ref": "#/definitions/column_list" }
+                                    "unique": { "$ref": "#/$defs/column_list" }
                                 },
                                 "additionalProperties": false
                             }
@@ -193,16 +193,16 @@
                 "distribution": {
                     "oneOf": [
                         { "enum": [ "all", "auto", "even", "ALL", "AUTO", "EVEN" ] },
-                        { "$ref": "#/definitions/one_column_as_list" }
+                        { "$ref": "#/$defs/one_column_as_list" }
                     ]
                 },
                 "compound_sort": {
                     "oneOf": [
                         { "enum": [ "auto", "AUTO" ] },
-                        { "$ref": "#/definitions/column_list" }
+                        { "$ref": "#/$defs/column_list" }
                     ]
                 },
-                "interleaved_sort": { "$ref": "#/definitions/column_list" }
+                "interleaved_sort": { "$ref": "#/$defs/column_list" }
             },
             "not": {
                 "required": [ "compound_sort", "interleaved_sort" ]
@@ -213,14 +213,14 @@
             "type": "object",
             "properties": {
                 "condition": {
-                    "$ref": "#/definitions/expression",
+                    "$ref": "#/$defs/expression",
                     "description": "Condition in SQL that will be part of the WHERE clause during extraction"
                 },
                 "split_by": { "oneOf": [
-                    { "$ref": "#/definitions/expression" },
-                    { "$ref": "#/definitions/one_column_as_list" }
+                    { "$ref": "#/$defs/expression" },
+                    { "$ref": "#/$defs/one_column_as_list" }
                 ] },
-                "boundary_query": { "$ref": "#/definitions/expression" },
+                "boundary_query": { "$ref": "#/$defs/expression" },
                 "num_partitions": {
                     "type": "integer",
                     "minimum": 1
@@ -231,7 +231,7 @@
         "depends_on": {
             "description": "List of all dependency tables of this transformation",
             "type": "array",
-            "items": { "$ref": "#/definitions/table_name" },
+            "items": { "$ref": "#/$defs/table_name" },
             "minItems": 1,
             "uniqueItems": true            
         }        

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -227,12 +227,16 @@ def _create_groups(conn: Connection, groups: Iterable[str], dry_run=False) -> No
     with conn:
         for group in groups:
             if etl.db.group_exists(conn, group):
-                logger.info("Skipping group '%s' which already exists", group)
+                logger.info(
+                    "Skipping group '%s' which already exists", group
+                )  # lgtm[py/clear-text-logging-sensitive-data]
                 continue
             if dry_run:
-                logger.info("Dry-run: Skipping creating group '%s'", group)
+                logger.info(
+                    "Dry-run: Skipping creating group '%s'", group
+                )  # lgtm[py/clear-text-logging-sensitive-data]
                 continue
-            logger.info("Creating group '%s'", group)
+            logger.info("Creating group '%s'", group)  # lgtm[py/clear-text-logging-sensitive-data]
             etl.db.create_group(conn, group)
 
 

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -218,7 +218,7 @@ def execute(cx, stmt, args=(), return_result=False):
     with cx.cursor() as cursor:
         executable_statement = mogrify(cursor, stmt, args)
         printable_stmt = remove_password(executable_statement.decode())
-        logger.debug("QUERY:\n%s\n;", printable_stmt)
+        logger.debug("QUERY:\n%s\n;", printable_stmt)  # lgtm[py/clear-text-logging-sensitive-data]
         with Timer() as timer:
             cursor.execute(executable_statement)
         if cursor.rowcount is not None and cursor.rowcount > 0:


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->
This PR adds `list_users` which shows all users the way that they are **configured**.

See also: Support multiple groups for users #579

### User-visible changes

The following command has been added:
* `list_users` -- list all users (and their groups). This command has the option to "transpose" the output and list all groups (and the users in them).

### Internal changes

The schema definitions are now in `$defs`. See https://json-schema.org/understanding-json-schema/structuring.html#defs

A bunch of functions have more type annotations of arguments and return values.

## Links

<!-- Link GitHub issues and JIRAs tasks -->

Supports: Manage users access and group membership using configuration #581

## Testing

<!-- Describe how somebody can test your changes or how they have been added to automatic tests. -->

```shell
arthur.py list_users

arthur.py list_users -t
```