### PR TITLE
Upgrade jsonschema

### DIFF
--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -292,7 +292,10 @@ def validate_with_schema(obj: dict, schema_name: str) -> None:
     try:
         jsonschema.validate(obj, schema, format_checker=jsonschema.draft7_format_checker)
     except VALIDATION_SCHEMA_ERRORS as exc:
-        raise SchemaValidationError(f"failed to validate against '{schema_name}'") from exc
+        # TODO(tom): Is json_path always set?
+        raise SchemaValidationError(
+            f"failed to validate '{exc.json_path}' against '{schema_name}'"
+        ) from exc
 
 
 def gather_setting_files(config_files: Iterable[str]) -> List[str]:

--- a/python/etl/config/table_design.schema
+++ b/python/etl/config/table_design.schema
@@ -140,17 +140,6 @@
         "constraints": {
             "oneOf": [
                 {
-                    "type": "object",
-                    "description": "DEPRECATED format from v0.23.0 and earlier",
-                    "properties": {
-                        "primary_key": { "$ref": "#/definitions/column_list" },
-                        "natural_key": { "$ref": "#/definitions/column_list" },
-                        "surrogate_key": { "$ref": "#/definitions/one_column_as_list" },
-                        "unique": { "$ref": "#/definitions/column_list" }
-                    },
-                    "additionalProperties": false
-                },
-                {
                     "type": "array",
                     "description": "List of constraints where only unique constraints may appear multiple times",
                     "items": {
@@ -184,6 +173,17 @@
                     },
                     "uniqueItems": true,
                     "minItems": 1
+                },
+                {
+                    "type": "object",
+                    "description": "DEPRECATED format from v0.23.0 and earlier",
+                    "properties": {
+                        "primary_key": { "$ref": "#/definitions/column_list" },
+                        "natural_key": { "$ref": "#/definitions/column_list" },
+                        "surrogate_key": { "$ref": "#/definitions/one_column_as_list" },
+                        "unique": { "$ref": "#/definitions/column_list" }
+                    },
+                    "additionalProperties": false
                 }
             ]
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.19.7
 botocore~=1.22
 funcy==1.16
 jmespath==0.10.0
-jsonschema==3.2.0
+jsonschema==4.2.1
 pgpasslib==1.1.0
 psycopg2-binary==2.9.1
 PyYAML==6.0


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

### User-visible changes

<!-- Describe what changes for users of Arthur -->

The output of a validation failure changes to highlight where in the table design the error occurred. The new version of the `jsonschema` library also provides better output.

Current error message:
```
jsonschema.exceptions.ValidationError: [{'primary_key': ['id']}, {'unique': ['public_id']}, {'unique': ['public_id']}] is not of type 'object'

...

etl.errors.SchemaValidationError: failed to validate against 'table_design.schema'
```

Future error message:
```
jsonschema.exceptions.ValidationError: [{'primary_key': ['id']}, {'unique': ['public_id']}, {'unique': ['public_id']}] has non-unique elements

...

etl.errors.SchemaValidationError: failed to validate '$.constraints' against 'table_design.schema'
```

### Internal changes

<!-- Describe what changes behind the scenes -->

This upgrades `jsonschema` to 4.2.1.
**This is not compatible with Python 3.6.**

## Testing

<!-- Describe how somebody can test your changes or how they have been added to automatic tests. -->

For example, pick a table design with a table constraint and double it up:
```
    "constraints": [
        {
            "unique": [
                "public_id"
            ],
        },
        {
            "unique": [
                "public_id"
            ],
        }
    ],
```