### PR TITLE
Docs add autodoc hints

### DIFF
--- a/bin/build_docs
+++ b/bin/build_docs
@@ -6,27 +6,32 @@ case "${1-}" in
   -h|--help|help)
     cat <<USAGE
 
-Usage: $0 [sphinx opts]
+Build or update documentation using Sphinx.
+The API documentation is automatically updated during this step.
 
-Build or update documentation using Sphinx. Any commmand line args are passed to Sphinx.
-The API documentation is automatically created during this step.
+Any remaining command line args are passed to Sphinx ("sphinx-build").
+For example, use "-E" to read all files by not using a saved environment.
 
 USAGE
-  exit
+    exit
+    ;;
 esac
 
-echo "Updating documentation into docs/html"
-
 set -o verbose
-sphinx-apidoc --module-first --separate --ext-autodoc --ext-doctest --ext-viewcode --output "docs/source/etl" "python/etl"
+sphinx-apidoc \
+    --force --module-first --separate \
+    --ext-autodoc --ext-doctest --ext-viewcode \
+    --output "docs/source/etl" "python/etl"
 sphinx-build -M html "docs/source" "./build" "$@"
 cp -a "./build/html" "./docs/"
 
 set +o verbose
-
 cat <<OPEN_HTML
+------------------------------------------
+
 The HTML pages were copied into docs/html.
 To view the documentation, run:
 
-open docs/html/index.html
+  open docs/html/index.html
+
 OPEN_HTML

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,8 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    # This must be after sphinx.ext.napoleon:
+    "sphinx_autodoc_typehints",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -43,8 +45,30 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["README.md"]
 
-needs_sphinx = "4.0"
+needs_sphinx = "4.2"
+
+# -- Options for extensions -------------------------------------------------
+
+napoleon_include_init_with_doc = True
+
 nitpicky = True
+
+# Adding standard libraries here to avoid too many warnings during build.
+nitpick_ignore = [
+    ("py:class", "abc.ABC"),
+    ("py:class", "botocore.response.StreamingBody"),
+    ("py:class", "datetime.datetime"),
+    ("py:class", "logging.Filter"),
+    ("py:class", "logging.Formatter"),
+    ("py:class", "simplejson.encoder.JSONEncoder"),
+    ("py:class", "string.Template"),
+    ("py:class", "textwrap.TextWrapper"),
+    ("py:class", "threading.Thread"),
+]
+nitpick_ignore_regex = [
+    ("py:class", r"argparse\..*"),
+    ("py:data", r"typing\..*"),
+]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -241,20 +241,24 @@ class WideHelpFormatter(argparse.RawTextHelpFormatter):
 
 class FancyArgumentParser(argparse.ArgumentParser):
     """
-    Fancier version of the argument parser supporting "@file".
+    Fancier version of the argument parser supporting `@file` to fetch additional arguments.
 
     Add feature to read command line arguments from files and support:
-        * One argument per line (whitespace is trimmed)
-        * Comments or empty lines (either are ignored)
+
+    - One argument per line (whitespace is trimmed)
+    - Comments or empty lines (either are ignored)
+
     This enables direct use of output from show_downstream_dependents and
     show_upstream_dependencies.
 
-    To use this feature, add an argument with "@" and have values ready inside of it, one per line:
-        cat > tables <<EOF
-        www.users
-        www.user_comments
-        EOF
-        arthur.py load @tables
+    Example:
+        To use this feature, add an argument with "@" and have values ready inside of it, one per line::
+
+            cat > tables <<EOF
+            www.users
+            www.user_comments
+            EOF
+            arthur.py load @tables
     """
 
     def __init__(self, **kwargs) -> None:

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -2,19 +2,23 @@
 Configuration files cover settings and DSNs.
 
 We use the term "config" files to refer to all files that may reside in the "config" directory:
-  * "Settings" files (ending in '.yaml') which drive the data warehouse or resource settings
-  * Environment files (with variables used in connections)
-  * Other files (like release notes)
+
+* "Settings" files (ending in '.yaml') which drive the data warehouse or resource settings
+* Environment files (with variables used in connections)
+* Other files (like release notes)
 
 For settings and environment files, files are loaded in alphabetical order and they keep updating
 values so that only the last one is kept. If you want to ensure a particular order, your best option
-is to prefix the files with a number sequence:
-  01_general.yaml
-  02_deploy.yaml
+is to prefix the files with a number sequence::
+
+    01_general.yaml
+    02_deploy.yaml
+
 and so on.
 
-To inspect the final value of settings (and see the order of files loaded), use:
-  arthur.py settings --verbose
+To inspect the final value of settings (and see the order of files loaded), use::
+
+    arthur.py settings --verbose
 """
 
 import datetime
@@ -58,11 +62,11 @@ _mapped_config: Optional[Dict[str, str]] = None
 ETL_TMP_DIR = "/tmp/redshift_etl"
 
 
-def arthur_version(package_name="redshift_etl") -> str:
+def arthur_version(package_name: str = "redshift_etl") -> str:
     return f"v{pkg_resources.get_distribution(package_name).version}"
 
 
-def package_version(package_name="redshift_etl") -> str:
+def package_version(package_name: str = "redshift_etl") -> str:
     return f"{package_name} {arthur_version()}"
 
 
@@ -87,7 +91,7 @@ def get_config_int(name: str, default: Optional[int] = None) -> int:
     """
     Lookup a configuration value that is an integer.
 
-    It is an error if the value (even when using the default) is None.
+    It is an error if the value (even when using the default) is `None`.
 
     Args:
         name: dot-separated configuration parameter name
@@ -135,7 +139,7 @@ def get_config_map() -> Dict[str, str]:
     return dict(_mapped_config)
 
 
-def _flatten_hierarchy(prefix, props):
+def _flatten_hierarchy(prefix: str, props):
     assert isinstance(props, dict), f"this should only be called with dicts, not {type(props)}"
     for key in sorted(props):
         full_key = f"{prefix}.{key}"
@@ -169,7 +173,7 @@ def load_environ_file(filename: str) -> None:
     """
     Set environment variables based on file contents.
 
-    Only lines that look like 'NAME=VALUE' or 'export NAME=VALUE' are used,
+    Only lines that look like `NAME=VALUE` or `export NAME=VALUE` are used,
     other lines are silently dropped.
     """
     logger.info(f"Loading environment variables from '{filename}'")
@@ -316,11 +320,17 @@ def validate_with_schema(obj: dict, schema_name: str) -> None:
 
 def gather_setting_files(config_files: Iterable[str]) -> List[str]:
     """
-    Gather all settings files (*.yaml and *.sh files) that should be deployed together.
+    Gather all settings files (i.e., `*.yaml` and `*.sh` files) that should be deployed together.
 
-    NOTE This drops any hierarchy in the config files. It is an error if we detect that there are
-    settings files in separate directories that have the same filename.
-    So trying '-c hello/world.yaml -c hola/world.yaml' triggers an exception.
+    Warning:
+        This drops any hierarchy in the config files. It is an error if we detect that there are
+        settings files in separate directories that have the same filename.
+        So trying `-c hello/world.yaml -c hola/world.yaml` triggers an exception.
+
+    Args:
+        config_files: List of files of file paths from where to collect settings files
+    Returns:
+        List of settings files with their full path
     """
     settings_found: Set[str] = set()
     settings_with_path = []

--- a/python/etl/logs/cloudwatch.py
+++ b/python/etl/logs/cloudwatch.py
@@ -1,7 +1,7 @@
+import datetime
 import json
 import logging
 import logging.config
-from datetime import datetime
 
 import boto3
 import watchtower
@@ -14,10 +14,16 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def add_cloudwatch_logging(prefix) -> None:
+def add_cloudwatch_logging(prefix: str) -> None:
+    """
+    Add logging to CloudWatch by adding another handler and formatter to the log stream.
+
+    Args:
+        prefix: Top-level group of CloudWatch stream.
+    """
     session = boto3.session.Session()
     log_group = get_config_value("arthur_settings.logging.cloudwatch.log_group")
-    now = datetime.utcnow()
+    now = datetime.datetime.utcnow()
     stream_name = f"{prefix}/{now.year}/{now.month}/{now.day}/{etl.monitor.Monitor.etl_id}"
 
     logger.info(f"Starting logging to CloudWatch stream '{log_group}/{stream_name}'")
@@ -38,7 +44,14 @@ def add_cloudwatch_logging(prefix) -> None:
     root_logger.addHandler(handler)
 
 
-def tail(prefix: str, start_time: datetime) -> None:
+def tail(prefix: str, start_time: datetime.datetime) -> None:
+    """
+    Fetch log lines from CloudWatch, filtering for `prefix` as the environment.
+
+    Args:
+        prefix: Top-level group of CloudWatch stream.
+        start_time: How far to go back when loading log lines.
+    """
     client = boto3.client("logs")
     log_group = get_config_value("arthur_settings.logging.cloudwatch.log_group")
     logger.info(f"Searching log streams '{log_group}/{prefix}/*' (starting at '{start_time})'")

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
 myst-parser~=0.15
 Sphinx~=4.2
+sphinx-autodoc-typehints~=1.12
 sphinx-book-theme~=0.1


### PR DESCRIPTION
## Description

This PR improves our configuration for docs, which makes it easier to get started with code and to lookup APIs. See PR comments for screenshot of changes.

### Internal Changes

* `bin/build_docs` will now re-build the API docs in `docs/source/etl`
* Move types from the function to the args section
* Add some hints in Sphinx's `conf.py` to reduce the warnings about standard library. (`py:class` and `py:data`)
* Improve docstrings so that they flow with Spinx's reStructured Text

## Testing

```
bin/build_virtual_env &&
bin/build_docs 
```
