### PR TITLE
DENG-1120: Add statement_timeout parameter to Arthur Redshift cluster configuration

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -464,7 +464,7 @@ def add_standard_arguments(parser: argparse.ArgumentParser, option_names: Iterab
         parser.add_argument(
             "-t",
             "--statement-timeout",
-            metavar="N",
+            metavar="MILLISECS",
             type=int,
             help="set the timeout before canceling a statement in Redshift. This time includes planning,"
             " queueing in WLM, and execution time. (overrides "

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1071,7 +1071,7 @@ class LoadDataWarehouseCommand(SubCommand):
                 "prefix",
                 "max-concurrency",
                 "wlm-query-slots",
-                "statement_timeout",
+                "statement-timeout",
                 "skip-copy",
                 "dry-run",
             ],

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -426,6 +426,10 @@
                         "wlm_query_slots": {
                             "type": "integer",
                             "minimum": 1
+                        },
+                        "statement_timeout": {
+                            "type": "integer",
+                            "minimum": 0
                         }
                     },
                     "additionalProperties": false

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -274,11 +274,11 @@ def log_load_error(cx):
                          , starttime
                          , colname
                          , type
-                         , trim(filename) AS filename
+                         , TRIM(filename) AS filename
                          , line_number
-                         , trim(err_reason) AS err_reason
+                         , TRIM(err_reason) AS err_reason
                       FROM stl_load_errors
-                     WHERE session = pg_backend_pid()
+                     WHERE session = PG_BACKEND_PID()
                      ORDER BY starttime DESC
                      LIMIT 1
                 """,
@@ -328,7 +328,6 @@ def copy_using_manifest(
     file_compression: Optional[str] = None,
     dry_run=False,
 ) -> None:
-
     credentials = "aws_iam_role={}".format(aws_iam_role)
     data_format_parameters = determine_data_format_parameters(
         data_format, format_option, file_compression
@@ -377,7 +376,7 @@ def query_load_commits(conn: Connection, table_name: TableName, s3_uri: str, dry
         SELECT TRIM(filename) AS filename
              , lines_scanned
           FROM stl_load_commits
-         WHERE query = pg_last_copy_id()
+         WHERE query = PG_LAST_COPY_ID()
          ORDER BY TRIM(filename)
         """
     if dry_run:
@@ -533,6 +532,15 @@ def insert_from_query(
 def set_wlm_slots(conn: Connection, slots: int, dry_run: bool) -> None:
     etl.db.run(
         conn, f"Using {slots} WLM queue slot(s)", f"SET wlm_query_slot_count TO {slots}", dry_run=dry_run
+    )
+
+
+def set_statement_timeout(conn: Connection, statement_timeout: int, dry_run: bool) -> None:
+    etl.db.run(
+        conn,
+        f"Setting timeout for statements running in Redshift to {statement_timeout} ms",
+        f"SET statement_timeout TO {statement_timeout}",
+        dry_run=dry_run,
     )
 
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -588,11 +588,11 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
     statement_template = """
         SELECT DISTINCT
                {columns}
-          FROM {table}
+          FROM {_table}
          WHERE {condition}
          GROUP BY {columns}
         HAVING COUNT(*) > 1
-         LIMIT {limit}
+         LIMIT {_limit}
         """
     limit = 5  # arbitrarily chosen limit of examples to show
 
@@ -605,7 +605,7 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
             condition = "TRUE"
 
         statement = statement_template.format(
-            columns=quoted_columns, table=relation, condition=condition, limit=limit
+            columns=quoted_columns, _table=relation, condition=condition, _limit=limit
         )
         if dry_run:
             logger.info(

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -588,11 +588,11 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
     statement_template = """
         SELECT DISTINCT
                {columns}
-          FROM {_table}
+          FROM {table_}
          WHERE {condition}
          GROUP BY {columns}
         HAVING COUNT(*) > 1
-         LIMIT {_limit}
+         LIMIT {limit_}
         """
     limit = 5  # arbitrarily chosen limit of examples to show
 
@@ -605,7 +605,7 @@ def verify_constraints(conn: connection, relation: LoadableRelation, dry_run=Fal
             condition = "TRUE"
 
         statement = statement_template.format(
-            columns=quoted_columns, _table=relation, condition=condition, _limit=limit
+            columns=quoted_columns, table_=relation, condition=condition, limit_=limit
         )
         if dry_run:
             logger.info(


### PR DESCRIPTION
## Description
<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->
Adding to Arthur the possibility to set [statement_timeout](https://docs.aws.amazon.com/redshift/latest/dg/r_statement_timeout.html)  when running either Arthur load, upgrade or update. The parameter is setup in `resources.RedshiftCluster.statement_timeout` in the Arthur configuration file. The default 0 means to not timeout.

**Note**: This time includes planning, queueing in workload management (WLM), and execution time. There are other ways to monitor queries, see [WLM query monitoring rules](https://docs.aws.amazon.com/redshift/latest/dg/cm-c-wlm-query-monitoring-rules.html).

### User-visible Changes
<!-- Describe what changes for users of Arthur -->
Users can decide how long they want their query to run before cancelling them, either by setting `resources.RedshiftCluster.statement_timeout` or by passing the value as argument to `--statement-timeout` when running upgrade, updates and load with the Arthur CLI.

### Internal Changes

<!-- Describe what changes behind the scenes -->
Arthur reads the configuration file to get the `statement_timeout` value. It will then run `set statement_timeout to {timeout}` everytime an  Arthur load, upgrade or update command is run, which includes all the ETL runs and commands used during development. 

## Links

<!-- Link GitHub issues and JIRAs tasks -->
https://harrys.atlassian.net/browse/DENG-1120

## Testing

<!-- Describe how somebody can test your changes or how they have been added to automatic tests. -->

### Values of statement timeout is set correctly in the functions
```
$ arthur.py upgrade --only-selected if__dtc.purchase__tax_lines --statement-timeout 6000
...
2021-11-10 16:20:09 - INFO - Using 10 WLM queue slot(s)
2021-11-10 16:20:09 - INFO - Setting timeout for statements running in Redshift to 6000 ms
...
```

**Note:** 3600000 is the default value for our dev cluster, see: harrystech/harrys-data-warehouse#1858
```
$ arthur.py upgrade --only-selected if__dtc.purchase__tax_lines
2021-11-10 16:21:42 - INFO - Using 10 WLM queue slot(s)
2021-11-10 16:21:42 - INFO - Setting timeout for statements running in Redshift to 3600000 ms
```

### Effect of Setting the timeout on queries
```
$ arthur.py upgrade --only-selected if__dtc.purchase__tax_lines --statement-timeout 600 -q
2021-11-10 16:13:10 - WARNING - Failed upgrade step for 'if__dtc.purchase__tax_lines' (3.55s)                                                                                                                                                 
2021-11-10 16:13:10 - CRITICAL - Something bad happened in the ETL: RequiredRelationLoadError
```

```
$ arthur.py upgrade --only-selected if__dtc.purchase__tax_lines --statement-timeout 6000 -q                                                                                                                    
$
```

### Update

```
(aws:data-dev, prefix:youssef) $ arthur.py update --only-selected if__dtc.purchase__tax_lines --statement-timeout 600
...
2021-11-10 16:34:42 - INFO - Using 10 WLM queue slot(s)
2021-11-10 16:34:42 - INFO - Setting timeout for statements running in Redshift to 600 ms
...
2021-11-10 16:35:17 - WARNING - Failed update step for 'if__dtc.purchase__tax_lines' (0.95s)                                                                                                                                                  
2021-11-10 16:35:17 - CRITICAL - Something terrible happened:
```

```
(aws:data-dev, prefix:youssef) $ arthur.py update --only-selected if__dtc.purchase__tax_lines
...
2021-11-10 16:33:43 - INFO - Setting timeout for statements running in Redshift to 3600000 ms
...
2021-11-10 16:33:56 - INFO - Finished update step for 'if__dtc.purchase__tax_lines' (12.34s)
2021-11-10 16:33:56 - INFO - Ran 'update' for 33.37s and finished successfully!
```

### Load

```
$ arthur.py load -h 
...
 -t MILLISECS, --statement-timeout MILLISECS
                              set the timeout before canceling a statement in Redshift. This time includes planning, queueing in WLM, and execution time. (overrides 'resources.RedshiftCluster.statement_timeout')
...
```

## Deploy Notes

<!-- If applicable, add migrations and deployment steps -->
Optional: Setting the value in `aws.yaml` for the data warehouse:

```yaml
 "resources": {
      ...
        "RedshiftCluster": {
            "max_concurrency": 6,
            "wlm_query_slots": 10,
            "statement_timeout": 3600000 # 1 hour, overrides original Redshift cluster parameter value
        }
    }
```