### PR TITLE
Add metric block for when ETL hits exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,12 @@ You can also run the linters directly:
 pre-commit run
 ```
 
-#### Running linters and formatters locally
+Or you can re-run some linters with something like:
+```
+pre-commit run black --all-files
+```
+
+#### Running linters and formatters directly
 
 To use the linters (`isort`, `black`, `flake8`, `mypy`) locally, install them
 into a virtual environment:

--- a/etc/cloudwatch.yaml
+++ b/etc/cloudwatch.yaml
@@ -1,0 +1,10 @@
+# Example settings to enable logging to AWS CloudWatch.
+{
+  "arthur_settings": {
+    "logging": {
+      "cloudwatch": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -12,7 +12,6 @@ import logging
 import os
 import shlex
 import sys
-import traceback
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -20,7 +19,6 @@ from typing import Iterable, List, Optional
 
 import boto3
 import simplejson as json
-from termcolor import colored
 
 import etl.config
 import etl.config.env
@@ -47,26 +45,11 @@ import etl.unload
 import etl.validate
 from etl.errors import ETLError, ETLSystemError, InvalidArgumentError
 from etl.text import join_with_single_quotes
+from etl.util import croak
 from etl.util.timer import Timer
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-
-
-def croak(error, exit_code):
-    """
-    Print first line of exception and then bail out with the exit code.
-
-    When you have a large stack trace, it's easy to miss the trigger and
-    so we call it out here again on stderr.
-    """
-    exception_only = traceback.format_exception_only(type(error), error)[0]
-    header = exception_only.splitlines()[0]
-    # Make sure to not send random ASCII sequences to a log file.
-    if sys.stderr.isatty():
-        header = colored(header, color="red", attrs=["bold"])
-    print(f"Bailing out: {header}", file=sys.stderr)
-    sys.exit(exit_code)
 
 
 @contextmanager
@@ -96,21 +79,21 @@ def execute_or_bail(sub_command: str):
                 exc_cause_type.__qualname__,
             )
         logger.info(
-            f"Ran for {timer.elapsed:.2f}s before this untimely end!",
+            f"Ran '{sub_command}' for {timer.elapsed:.2f}s before this untimely end!",
             extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}},
         )
         croak(exc, 2)
     except Exception as exc:
         logger.critical("Something terrible happened:", exc_info=True)
         logger.info(
-            f"Ran for {timer.elapsed:.2f}s before encountering disaster!",
+            f"Ran '{sub_command}' for {timer.elapsed:.2f}s before encountering disaster!",
             extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}},
         )
         croak(exc, 3)
     except BaseException as exc:
         logger.critical("Something really terrible happened:", exc_info=True)
         logger.info(
-            f"Ran for {timer.elapsed:.2f}s before an exceptional termination!",
+            f"Ran '{sub_command}' for {timer.elapsed:.2f}s before an exceptional termination!",
             extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}},
         )
         croak(exc, 5)

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -97,21 +97,21 @@ def execute_or_bail(sub_command: str):
             )
         logger.info(
             f"Ran for {timer.elapsed:.2f}s before this untimely end!",
-            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}}
+            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}},
         )
         croak(exc, 2)
     except Exception as exc:
         logger.critical("Something terrible happened:", exc_info=True)
         logger.info(
             f"Ran for {timer.elapsed:.2f}s before encountering disaster!",
-            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}}
+            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}},
         )
         croak(exc, 3)
     except BaseException as exc:
         logger.critical("Something really terrible happened:", exc_info=True)
         logger.info(
             f"Ran for {timer.elapsed:.2f}s before an exceptional termination!",
-            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}}
+            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}},
         )
         croak(exc, 5)
     else:

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -95,15 +95,24 @@ def execute_or_bail(sub_command: str):
                 exc_cause_type.__module__,
                 exc_cause_type.__qualname__,
             )
-        logger.info("Ran for %.2fs before this untimely end!", timer.elapsed)
+        logger.info(
+            f"Ran for {timer.elapsed:.2f}s before this untimely end!",
+            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}}
+        )
         croak(exc, 2)
     except Exception as exc:
         logger.critical("Something terrible happened:", exc_info=True)
-        logger.info("Ran for %.2fs before encountering disaster!", timer.elapsed)
+        logger.info(
+            f"Ran for {timer.elapsed:.2f}s before encountering disaster!",
+            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}}
+        )
         croak(exc, 3)
     except BaseException as exc:
         logger.critical("Something really terrible happened:", exc_info=True)
-        logger.info("Ran for %.2fs before an exceptional termination!", timer.elapsed)
+        logger.info(
+            f"Ran for {timer.elapsed:.2f}s before an exceptional termination!",
+            extra={"metrics": {"elapsed": timer.elapsed, "sub_command": sub_command}}
+        )
         croak(exc, 5)
     else:
         logger.info(

--- a/python/etl/logs/cloudwatch.py
+++ b/python/etl/logs/cloudwatch.py
@@ -54,3 +54,5 @@ def tail(prefix: str, start_time: datetime) -> None:
             stream_name = event["logStreamName"]
             message = json.loads(event["message"])
             print(f"{stream_name} {message['gmtime']} {message['log_level']} {message['message']}")
+            if "metrics" in message:
+                print(f"{stream_name} {message['gmtime']} (metrics) {message['metrics']}")

--- a/python/etl/util/__init__.py
+++ b/python/etl/util/__init__.py
@@ -1,0 +1,20 @@
+import sys
+import traceback
+
+from termcolor import colored
+
+
+def croak(error, exit_code: int) -> None:
+    """
+    Print first line of exception and then bail out with the exit code.
+
+    When you have a large stack trace, it's easy to miss the trigger and
+    so we call it out here again on stderr.
+    """
+    exception_only = traceback.format_exception_only(type(error), error)[0]
+    header = exception_only.splitlines()[0]
+    # Make sure to not send random ASCII sequences to a log file.
+    if sys.stderr.isatty():
+        header = colored(header, color="red", attrs=["bold"])
+    print(f"Bailing out: {header}", file=sys.stderr)
+    sys.exit(exit_code)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,29 @@
+import unittest
+import unittest.mock
+
+import etl.commands
+
+
+class TestCommands(unittest.TestCase):
+    def test_execute_or_bail_ok(self):
+        """Make sure context runner exits cleanly."""
+        with self.assertLogs(level="INFO") as cm:
+            with etl.commands.execute_or_bail("unittest"):
+                pass
+        self.assertEqual(len(cm.output), 1)
+        self.assertTrue("finished successfully" in cm.output[0])
+
+    def test_execute_or_bail_internal_error(self):
+        """Make sure context runner exits with error message for internal error."""
+        with self.assertLogs(level="INFO") as cm:
+            # This patches the "croak" function that is IMPORTED inside "etl.commands".
+            with unittest.mock.patch("etl.commands.croak") as mocked_croak:
+                with etl.commands.execute_or_bail("unittest"):
+                    # Simulate an internal error where we don't catch an exception.
+                    raise ValueError("oops")
+        mocked_croak.assert_called()
+        # The exit code (2nd arg) is expected to be 3 for uncaught exceptions.
+        self.assertEqual(mocked_croak.call_args[0][1], 3)
+
+        self.assertEqual(len(cm.output), 2)
+        self.assertIn("terrible happened", cm.output[0])


### PR DESCRIPTION
## Description

Add metric block for when ETL hits exception.

### User-visible Changes

The changes appear in log aggregation where additional "metrics" are now available.

Also upon failure, the sub-command is now in the output:
```
2021-11-10 17:25:31 - INFO - Ran 'load' for 75.57s before encountering disaster!
```
instead of:
```
2021-11-10 17:28:21 - INFO - Ran for 75.45s before encountering disaster!
```

### Internal Changes

* Moved `croak` from `etl.commands` to `etl.util` to make it easier to mock.
* Added unit tests for `etl.commands`, though just for the execution context.

## Testing

Run a command that will fail and also send logs to CloudWatch:
```
arthur.py -c /opt/src/arthur-redshift-etl/etc/cloudwatch.yaml upgrade no_such_schema
arthur.py tail_logs 
```

The output will look something like this:
```
(aws:data-dev, prefix:tom) $ arthur.py -c /opt/src/arthur-redshift-etl/etc/cloudwatch.yaml upgrade no_such_schema
...
2021-11-10 22:44:06 - INFO - Loading settings from '/opt/src/arthur-redshift-etl/etc/cloudwatch.yaml'
2021-11-10 22:44:06 - INFO - Starting logging to CloudWatch stream '/dw/dev/arthur-etl/tom/2021/11/10/FA0AF9FB303A4E6D'
...
ValueError: bad pattern (no match against base schemas): no_such_schema.*
2021-11-10 22:44:07 - INFO - Ran 'upgrade' for 0.77s before encountering disaster!
Bailing out: ValueError: bad pattern (no match against base schemas): no_such_schema.*

(aws:data-dev, prefix:tom) $ arthur.py tail_logs 
...
2021-11-10 22:45:40 - INFO - Searching log streams '/dw/dev/arthur-etl/tom/*' (starting at '2021-11-10 22:30:40)'
...
ValueError: bad pattern (no match against base schemas): no_such_schema.*
tom/2021/11/10/FA0AF9FB303A4E6D 2021-11-10T22:44:07.333Z INFO Ran 'upgrade' for 0.77s before encountering disaster!
tom/2021/11/10/FA0AF9FB303A4E6D 2021-11-10T22:44:07.333Z (metrics) {'elapsed': 0.766749, 'sub_command': 'upgrade'}
```

Note the extra line with `(metrics)`.
