### PR TITLE
Rename "tags" to "list_tags" command

### DIFF
--- a/etc/arthur_completion.sh
+++ b/etc/arthur_completion.sh
@@ -29,6 +29,7 @@ _arthur_completion()
                 extract
                 help
                 initialize
+                list_tags
                 list_users
                 load
                 ls

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -22,6 +22,7 @@ To inspect the final value of settings (and see the order of files loaded), use:
 """
 
 import datetime
+import itertools
 import logging
 import os
 import os.path
@@ -137,6 +138,14 @@ def get_config_map() -> Dict[str, str]:
         return {}
     # Since the mapped config is flattened, we don't worry about a deep copy here.
     return dict(_mapped_config)
+
+
+def get_tags() -> List[str]:
+    dw_config = get_dw_config()
+    tags = set()
+    for schema in itertools.chain(dw_config.schemas, dw_config.external_schemas):
+        tags.update(schema.tags)
+    return sorted(tags)
 
 
 def _flatten_hierarchy(prefix: str, props):


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

### User-visible Changes

Rename `tags` to `list_tags`.  To test, try out `arthur.py list_tags`. This change makes the command align with the other commands as "verb" or "verb object" (instead of just "object").

To see an output other than `No tags found`, add something like `"tags": ["hello"]` to a schema configuration.

### Internal Changes

The list of command classes is alphabetically sorted now.w
