### PR TITLE
Run unittests as part of selftest

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -2062,7 +2062,7 @@ class SelfTestCommand(SubCommand):
         parser.set_defaults(log_level="CRITICAL")
 
     def callback(self, args):
-        etl.selftest.run_doctest("etl", args.log_level)
+        etl.selftest.run_selftest("etl", args.log_level)
 
 
 if __name__ == "__main__":

--- a/python/etl/selftest.py
+++ b/python/etl/selftest.py
@@ -7,8 +7,7 @@ import unittest
 
 import pkg_resources
 
-# Skip etl.commands to avoid circular dependency.
-# TODO(tom): There is a bug: doctests from etl.commands are not run with "python3 -m etl.selftest".
+# Skip etl.commands to avoid circular dependency!
 import etl.config
 import etl.config.env
 import etl.config.settings
@@ -70,8 +69,9 @@ def run_selftest(module_: str, log_level: str = "INFO") -> None:
     verbosity_levels = {"DEBUG": 2, "INFO": 1, "WARNING": 0, "CRITICAL": 0}
     verbosity = verbosity_levels.get(log_level, 1)
 
-    print("Running doctests...", flush=True)
+    print("Running selftest...", flush=True)
     test_runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=verbosity)
+    # Pass commandline args after first two (usually: "arthur.py" and "selftest").
     test_program = unittest.main(
         module=module_, exit=False, testRunner=test_runner, verbosity=verbosity, argv=sys.argv[:2]
     )
@@ -84,6 +84,7 @@ def run_selftest(module_: str, log_level: str = "INFO") -> None:
 
 
 if __name__ == "__main__":
+    print("WARNING doctests from etl.commands are not run (use 'arthur.py selftest' instead)")
     try:
         run_selftest(__name__)
     except Exception as exc:


### PR DESCRIPTION
## Description

### User-visible Changes

The `selftest` command runs the unit tests in addition to doctests. This change also lists how many tests are added. This means we can now easily run unit tests that we've started to add.

```
arthur.py selftest 
Running doctests...
Adding 1 doctest(s) from 'etl.commands'
Adding 2 doctest(s) from 'etl.config'
Adding 1 doctest(s) from 'etl.config.env'
Adding 2 doctest(s) from 'etl.db'
Adding 2 doctest(s) from 'etl.design.bootstrap'
Adding 4 doctest(s) from 'etl.dialect.redshift'
Adding 1 doctest(s) from 'etl.errors'
Adding 1 doctest(s) from 'etl.extract.database_extractor'
Adding 1 doctest(s) from 'etl.file_sets'
Adding 1 doctest(s) from 'etl.load'
Adding 1 doctest(s) from 'etl.monitor'
Adding 16 doctest(s) from 'etl.names'
Adding 1 doctest(s) from 'etl.relation'
Adding 1 doctest(s) from 'etl.s3'
Adding 5 doctest(s) from 'etl.text'
Adding 1 doctest(s) from 'etl.util.timer'
Adding 2 doctest(s) from 'etl.validate'
Adding 3 unittests from '/opt/src/arthur-redshift-etl/tests' directory
----------------------------------------------------------------------
Ran 46 tests in 0.115s

OK
```


## Testing

Run the self test :-)
