### PR TITLE
Add "groups" and "comment" to user info

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -727,7 +727,7 @@ class ListUsersCommand(SubCommand):
         super().__init__(
             "list_users",
             "list users as they are configured",
-            "List all users and their groups in the way that they are configurd.",
+            "List all users and their groups in the way that they are configured.",
         )
 
     def add_arguments(self, parser):
@@ -756,7 +756,7 @@ class UpdateUserCommand(SubCommand):
         parser.add_argument(
             "-a", "--add-user-schema", help="add new schema, writable for the user", action="store_true"
         )
-        parser.add_argument("username", help="name of existing user")
+        parser.add_argument("name", help="name of user")
 
     def callback(self, args):
         with etl.db.log_error():

--- a/python/etl/config/settings.schema
+++ b/python/etl/config/settings.schema
@@ -34,15 +34,26 @@
             "uniqueItems": true
         },
         "user_info": {
-            "type": "object",
+            "additionalProperties": false,
+            "not": { "required": [ "group", "groups" ] },
+            "oneOf": [
+                {"required": [ "name", "groups" ]},
+                {"required": [ "name", "group" ]}
+            ],
             "properties": {
-                "name": { "$ref": "#/$defs/identifier" },
+                "comment": { "type": "string" },
                 "description": { "type": "string" },
                 "group": { "$ref": "#/$defs/identifier" },
+                "groups": {
+                    "items": { "$ref": "#/$defs/identifier" },
+                    "maxItems": 1,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": { "$ref": "#/$defs/identifier" },
                 "schema": { "$ref": "#/$defs/identifier" }
             },
-            "required": [ "name", "group" ],
-            "additionalProperties": false
+            "type": "object"
         },
         "glob_pattern_list": {
             "type": "array",

--- a/python/etl/db.py
+++ b/python/etl/db.py
@@ -420,7 +420,7 @@ def _get_encrypted_password(cx, user) -> Optional[str]:
     return "md5" + md5.hexdigest()
 
 
-def create_user(cx, user, group):
+def create_user(cx: Connection, user: str, group: str) -> None:
     password = _get_encrypted_password(cx, user)
     if password is None:
         logger.warning("Missing entry in PGPASSFILE file for '%s'", user)
@@ -428,28 +428,28 @@ def create_user(cx, user, group):
         raise ETLRuntimeError(
             f"password missing from PGPASSFILE for user '{user}'"
         )  # lgtm[py/clear-text-logging-sensitive-data]
-    execute(cx, """CREATE USER "{}" IN GROUP "{}" PASSWORD %s""".format(user, group), (password,))
+    execute(cx, f"""CREATE USER "{user}" IN GROUP "{group}" PASSWORD %s""", (password,))
 
 
-def alter_password(cx, user, ignore_missing_password=False):
+def alter_password(cx: Connection, user: str, ignore_missing_password=False) -> None:
     password = _get_encrypted_password(cx, user)
     if password is None:
         logger.warning("Failed to find password in PGPASSFILE for '%s'", user)
         if not ignore_missing_password:
             raise ETLRuntimeError("password missing from PGPASSFILE for user '{}'".format(user))
         return
-    execute(cx, """ALTER USER "{}" PASSWORD %s""".format(user), (password,))
+    execute(cx, f"""ALTER USER "{user}" PASSWORD %s""", (password,))
 
 
-def alter_group_add_user(cx, group, user):
-    execute(cx, """ALTER GROUP "{}" ADD USER "{}" """.format(group, user))
+def alter_group_add_user(cx: Connection, group: str, user: str) -> None:
+    execute(cx, f"""ALTER GROUP "{group}" ADD USER "{user}" """)
 
 
-def alter_search_path(cx, user, schemas):
-    execute(cx, """ALTER USER "{}" SET SEARCH_PATH TO {}""".format(user, ", ".join(schemas)))
+def alter_search_path(cx: Connection, user: str, schemas: Iterable[str]) -> None:
+    execute(cx, f"""ALTER USER "{user}" SET SEARCH_PATH TO {", ".join(schemas)}""")
 
 
-def user_exists(cx, user) -> bool:
+def user_exists(cx: Connection, user: str) -> bool:
     rows = query(
         cx,
         """
@@ -536,7 +536,7 @@ def revoke_all_on_all_tables_in_schema(cx: Connection, schema: str, groups: Iter
 # ---- TABLES ----
 
 
-def relation_kind(cx, schema, table) -> Optional[str]:
+def relation_kind(cx: Connection, schema: str, table: str) -> Optional[str]:
     """
     Return "kind" of relation, either 'TABLE' or 'VIEW' for relations that actually exist.
 

--- a/tests/config/test_dw.py
+++ b/tests/config/test_dw.py
@@ -1,0 +1,41 @@
+import unittest
+
+import etl.config.dw
+import etl.errors
+
+
+class TestConfigDW(unittest.TestCase):
+    def setUp(self) -> None:
+        self.settings = {
+            "owner": {"name": "etl", "group": "etl"},
+            "users": [
+                {
+                    "name": "default",
+                    "group": "some_group",
+                },
+                {
+                    "name": "a_user",
+                    "groups": ["a_group"],
+                },
+            ],
+        }
+
+    def test_parse_default_group(self):
+        """Make sure we can load default group."""
+        found = etl.config.dw.DataWarehouseConfig.parse_default_group(self.settings)
+        self.assertEqual(found, "some_group")
+
+    def test_parse_default_missing_group(self):
+        """Make sure we error out if default group is missing."""
+        settings = {"users": []}
+        with self.assertRaises(etl.errors.ETLConfigError):
+            etl.config.dw.DataWarehouseConfig.parse_default_group(settings)
+
+    def test_parse_users(self):
+        """Make sure we can load users."""
+        found = etl.config.dw.DataWarehouseConfig.parse_users(self.settings)
+        self.assertEqual(len(found), 2)
+        self.assertEqual(found[0].name, "etl")
+        self.assertEqual(found[0].group, "etl")
+        self.assertEqual(found[1].name, "a_user")
+        self.assertEqual(found[1].group, "a_group")


### PR DESCRIPTION
## Description

This PR sets up assigning users to multiple groups. For now, this continues to support only a single group per user but updates the schema so that we can start changing the settings file.
This PR also adds a [gecos field](https://en.wikipedia.org/wiki/Gecos_field) for users.

These two settings are now compatible with the schema (and lead to the same configuration):
```yaml
                {
                    "name": "a_user",
                    "groups": ["a_group"],
                }
```
```yaml
                {
                    "name": "a_user",
                    "group": "a_group",
                }
```

### User-visible Changes

* The `list_users` command also shows the comment from the settings file.

### Internal Changes

We previously used `config.users[0]` to refer to the "owner" who runs the ETL. This has been replaced with an explicit `config.owner`.

The `__init__` method of `DataWarehouseConfig` has finally been refactored to fit on laptop screen. (Which is to say, keep the lines of code in any method under 40.)

A bunch of functions have more type annotations of arguments and return values.

## Links

Supports: Manage users access and group membership using configuration #581

## Deploy Notes

You can run all commands using `--dry-run` to make sure that they would do what you want them to do.