### PR TITLE
DENG-1120: Use default cluster statement timeout value when none is provided

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1128,10 +1128,10 @@ class LoadDataWarehouseCommand(SubCommand):
             "resources.RedshiftCluster.max_concurrency", 1
         )
         statement_timeout = args.statement_timeout
-        if etl.config.is_set("resources.RedshiftCluster.statement_timeout"):
-            statement_timeout = statement_timeout or etl.config.get_config_int(
-                "resources.RedshiftCluster.statement_timeout"
-            )
+        if statement_timeout is None and etl.config.is_config_set(
+            "resources.RedshiftCluster.statement_timeout"
+        ):
+            statement_timeout = etl.config.get_config_int("resources.RedshiftCluster.statement_timeout")
         wlm_query_slots = args.wlm_query_slots or etl.config.get_config_int(
             "resources.RedshiftCluster.wlm_query_slots", 1
         )
@@ -1224,10 +1224,10 @@ class UpgradeDataWarehouseCommand(SubCommand):
             "resources.RedshiftCluster.max_concurrency", 1
         )
         statement_timeout = args.statement_timeout
-        if etl.config.is_set("resources.RedshiftCluster.statement_timeout"):
-            statement_timeout = statement_timeout or etl.config.get_config_int(
-                "resources.RedshiftCluster.statement_timeout"
-            )
+        if statement_timeout is None and etl.config.is_config_set(
+            "resources.RedshiftCluster.statement_timeout"
+        ):
+            statement_timeout = etl.config.get_config_int("resources.RedshiftCluster.statement_timeout")
         wlm_query_slots = args.wlm_query_slots or etl.config.get_config_int(
             "resources.RedshiftCluster.wlm_query_slots", 1
         )
@@ -1287,10 +1287,10 @@ class UpdateDataWarehouseCommand(SubCommand):
     def callback(self, args):
         relations = self.find_relation_descriptions(args, default_scheme="s3", return_all=True)
         statement_timeout = args.statement_timeout
-        if etl.config.is_set("resources.RedshiftCluster.statement_timeout"):
-            statement_timeout = statement_timeout or etl.config.get_config_int(
-                "resources.RedshiftCluster.statement_timeout"
-            )
+        if statement_timeout is None and etl.config.is_config_set(
+            "resources.RedshiftCluster.statement_timeout"
+        ):
+            statement_timeout = etl.config.get_config_int("resources.RedshiftCluster.statement_timeout")
         wlm_query_slots = args.wlm_query_slots or etl.config.get_config_int(
             "resources.RedshiftCluster.wlm_query_slots", 1
         )

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1127,9 +1127,11 @@ class LoadDataWarehouseCommand(SubCommand):
         max_concurrency = args.max_concurrency or etl.config.get_config_int(
             "resources.RedshiftCluster.max_concurrency", 1
         )
-        statement_timeout = args.statement_timeout or etl.config.get_config_int(
-            "resources.RedshiftCluster.statement_timeout", 0
-        )
+        statement_timeout = args.statement_timeout
+        if etl.config.is_set("resources.RedshiftCluster.statement_timeout"):
+            statement_timeout = statement_timeout or etl.config.get_config_int(
+                "resources.RedshiftCluster.statement_timeout"
+            )
         wlm_query_slots = args.wlm_query_slots or etl.config.get_config_int(
             "resources.RedshiftCluster.wlm_query_slots", 1
         )
@@ -1221,9 +1223,11 @@ class UpgradeDataWarehouseCommand(SubCommand):
         max_concurrency = args.max_concurrency or etl.config.get_config_int(
             "resources.RedshiftCluster.max_concurrency", 1
         )
-        statement_timeout = args.statement_timeout or etl.config.get_config_int(
-            "resources.RedshiftCluster.statement_timeout", 0
-        )
+        statement_timeout = args.statement_timeout
+        if etl.config.is_set("resources.RedshiftCluster.statement_timeout"):
+            statement_timeout = statement_timeout or etl.config.get_config_int(
+                "resources.RedshiftCluster.statement_timeout"
+            )
         wlm_query_slots = args.wlm_query_slots or etl.config.get_config_int(
             "resources.RedshiftCluster.wlm_query_slots", 1
         )
@@ -1282,9 +1286,11 @@ class UpdateDataWarehouseCommand(SubCommand):
 
     def callback(self, args):
         relations = self.find_relation_descriptions(args, default_scheme="s3", return_all=True)
-        statement_timeout = args.statement_timeout or etl.config.get_config_int(
-            "resources.RedshiftCluster.statement_timeout", 0
-        )
+        statement_timeout = args.statement_timeout
+        if etl.config.is_set("resources.RedshiftCluster.statement_timeout"):
+            statement_timeout = statement_timeout or etl.config.get_config_int(
+                "resources.RedshiftCluster.statement_timeout"
+            )
         wlm_query_slots = args.wlm_query_slots or etl.config.get_config_int(
             "resources.RedshiftCluster.wlm_query_slots", 1
         )

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -48,7 +48,6 @@ VALIDATION_SCHEMA_ERRORS = (
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-
 # Global config objects - always use accessors!
 _dw_config: Optional[DataWarehouseConfig] = None
 _mapped_config: Optional[Dict[str, str]] = None
@@ -336,6 +335,11 @@ def gather_setting_files(config_files: Iterable[str]) -> List[str]:
         settings_found.add(filename)
         settings_with_path.append(fullname)
     return sorted(settings_with_path)
+
+
+def is_set(name: str):
+    if _mapped_config is not None:
+        return name in _mapped_config.keys()
 
 
 @lru_cache()

--- a/python/etl/config/__init__.py
+++ b/python/etl/config/__init__.py
@@ -65,6 +65,12 @@ def package_version(package_name="redshift_etl") -> str:
     return f"{package_name} {arthur_version()}"
 
 
+def is_config_set(name: str) -> bool:
+    if _mapped_config is not None:
+        return name in _mapped_config.keys()
+    return False
+
+
 def get_dw_config():
     return _dw_config
 
@@ -335,11 +341,6 @@ def gather_setting_files(config_files: Iterable[str]) -> List[str]:
         settings_found.add(filename)
         settings_with_path.append(fullname)
     return sorted(settings_with_path)
-
-
-def is_set(name: str):
-    if _mapped_config is not None:
-        return name in _mapped_config.keys()
 
 
 @lru_cache()

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -537,14 +537,14 @@ def set_wlm_slots(conn: Connection, slots: int, dry_run: bool) -> None:
 
 def set_statement_timeout(conn: Connection, statement_timeout: Optional[int], dry_run: bool) -> None:
     if statement_timeout is None:
-        logger.info("Using default cluster statement timeout")
-    else:
-        etl.db.run(
-            conn,
-            f"Setting timeout for statements running in Redshift to {statement_timeout} ms",
-            f"SET statement_timeout TO {statement_timeout}",
-            dry_run=dry_run,
-        )
+        logger.debug("Using default cluster statement timeout")
+        return
+    etl.db.run(
+        conn,
+        f"Setting timeout for statements running in Redshift to {statement_timeout} ms",
+        f"SET statement_timeout TO {statement_timeout}",
+        dry_run=dry_run,
+    )
 
 
 def unload(

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -535,13 +535,16 @@ def set_wlm_slots(conn: Connection, slots: int, dry_run: bool) -> None:
     )
 
 
-def set_statement_timeout(conn: Connection, statement_timeout: int, dry_run: bool) -> None:
-    etl.db.run(
-        conn,
-        f"Setting timeout for statements running in Redshift to {statement_timeout} ms",
-        f"SET statement_timeout TO {statement_timeout}",
-        dry_run=dry_run,
-    )
+def set_statement_timeout(conn: Connection, statement_timeout: Optional[int], dry_run: bool) -> None:
+    if statement_timeout is None:
+        logger.info("Using default cluster statement timeout")
+    else:
+        etl.db.run(
+            conn,
+            f"Setting timeout for statements running in Redshift to {statement_timeout} ms",
+            f"SET statement_timeout TO {statement_timeout}",
+            dry_run=dry_run,
+        )
 
 
 def unload(


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->
Use the default cluster value when no statement timeout is given instead of using zero (no timeout).

## QA

With nothing set in `aws.yaml`:
```
(aws:data-dev, prefix:youssef) $ arthur.py update --only augur_inputs.conversion_v2
...
2021-11-19 18:11:28 - DEBUG - Using default cluster statement timeout
2021-11-19 18:11:28 - INFO - Starting upgrade step for 'augur_inputs.conversion_v2' (1/1)
```

With timeout set in `aws.yaml`:
```
(aws:data-dev, prefix:youssef) $ arthur.py update --only augur_inputs.conversion_v2
...
2021-11-19 18:17:36 - INFO - Using 10 WLM queue slot(s)
2021-11-19 18:17:36 - INFO - Setting timeout for statements running in Redshift to 3600000 ms
...
```

With timeout set in command line:
```
(aws:data-dev, prefix:youssef) $ arthur.py upgrade --only augur_inputs.conversion_v2 -t 1
...
2021-11-19 18:07:21 - INFO - Using 10 WLM queue slot(s)
2021-11-19 18:07:21 - INFO - Setting timeout for statements running in Redshift to 1 ms
2021-11-19 18:07:21 - INFO - Starting upgrade step for 'augur_inputs.conversion_v2' (1/1)
2021-11-19 18:07:21 - WARNING - Failed upgrade step for 'augur_inputs.conversion_v2' (0.06s)...
```

with timeout 0:
```
(aws:data-dev, prefix:youssef) $ arthur.py upgrade --only augur_inputs.conversion_v2 -t 0
...
2021-11-19 18:18:49 - INFO - Using 10 WLM queue slot(s)
2021-11-19 18:18:49 - INFO - Setting timeout for statements running in Redshift to 0 ms
...
```