### PR TITLE
Refactor python/data_warehouse.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN python3 -m venv "/opt/local/$PROJ_NAME/venv" && \
     python3 -m pip install --upgrade pip==20.3.4 --disable-pip-version-check --no-cache-dir && \
     python3 -m pip install --requirement /tmp/requirements-all.txt --disable-pip-version-check --no-cache-dir
 
-# Create an empty .pgpass file to help with create_user and update_user commands.
-RUN echo '# Format to set password (used by create_user and update_user): *:5439:*:<user>:<password>' > /home/arthur/.pgpass \
+# Create an empty .pgpass file to help with the format of this file.
+RUN echo '# Format to set password when updating users: *:5439:*:<user>:<password>' > /home/arthur/.pgpass \
     && chmod go= /home/arthur/.pgpass
 
 # Note that at runtime we (can or may) mount the local directory here.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Don't forget to run `terminate_emr_cluster.sh` when you're done.
 | Sub-command   | Goal |
 | ---- | ---- |
 | `initialize`  | Create schemas, groups and users |
-| `create_user`    | Create (or configure) users that are not mentioned in the configuration file |
+| `create_groups` | Create groups that are mentioned in the configuration file |
+| `create_user` | Create (or configure) users that are not mentioned in the configuration file |
 
 ```shell
 # The commands to setup the data warehouse users and groups or any database is by ADMIN (connected to `dev`)

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1360,7 +1360,7 @@ class CreateSchemasCommand(SubCommand):
             "create_schemas",
             "create schemas from data warehouse config",
             "Create schemas as configured and set permissions."
-            " Optionally move existing schemas to backup or create in staging position."
+            " Optionally move existing schemas to backup or create new schemas in staging position."
             " (Any patterns must be schema names.)",
         )
 

--- a/python/etl/config/settings.py
+++ b/python/etl/config/settings.py
@@ -12,7 +12,7 @@ def show_value(name: str, default: Optional[str]) -> None:
 
     This fails if the variable is not set and no default is provided.
 
-    This is a callback for a command.
+    This is a callback of a command.
     """
     value = etl.config.get_config_value(name, default)
     if value is None:
@@ -27,7 +27,7 @@ def show_vars(names: List[str]) -> None:
     This shows all known configuration settings as "variables" with their values or just
     the variables that are selected.
 
-    This is a callback for a command.
+    This is a callback of a command.
     """
     config_mapping = etl.config.get_config_map()
     all_keys = sorted(config_mapping)

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -20,7 +20,7 @@ from typing import Iterable, List, Sequence
 from psycopg2.extensions import connection as Connection  # only used for typing
 
 import etl.config
-import etl.config.dw
+import etl.config.dw  # lgtm[py/import-and-import-from]
 import etl.db
 import etl.dialect.redshift
 from etl.config.dw import DataWarehouseSchema, DataWarehouseUser
@@ -241,15 +241,21 @@ def _create_groups(conn: Connection, groups: Iterable[str], dry_run=False) -> No
                 continue
             if dry_run:
                 logger.info(
-                    "Dry-run: Skipping creating group '%s'", group
-                )  # lgtm[py/clear-text-logging-sensitive-data]
+                    "Dry-run: Skipping creating group '%s'",
+                    group,  # lgtm[py/clear-text-logging-sensitive-data]
+                )
                 continue
-            logger.info("Creating group '%s'", group)  # lgtm[py/clear-text-logging-sensitive-data]
+            logger.info(
+                "Creating group '%s'",
+                group,  # lgtm[py/clear-text-logging-sensitive-data]
+            )
             etl.db.create_group(conn, group)
     if found:
         logger.info(
-            "%d group(s) already existed: %s", len(found), join_with_single_quotes(found)
-        )  # lgtm[py/clear-text-logging-sensitive-data]
+            "%d group(s) already existed: %s",
+            len(found),
+            join_with_single_quotes(found),  # lgtm[py/clear-text-logging-sensitive-data]
+        )
 
 
 def _create_or_update_user(conn: Connection, user: DataWarehouseUser, only_update=False, dry_run=False):


### PR DESCRIPTION
## Description

### User-visible Changes

Show list of groups that already existed at the end of `create_groups` instead of showing every group separately. This makes the output more concise and easier to report on.

### Internal Changes

* Consistency: Use the comment `This is a callback of a command.` when a function is tied to a command.
* Typing: Add more static types for function signatures
* Consistency: Use this code pattern when possible:
```
        if dry-run:
            logger.info("Dry-run: Skipping ...")
            return
        # do it
```
instead of (the heavily indented alternative):
```
        if dry-run:
            logger.info("Dry-run: Skipping ...")
        else:
            # do it
```

## Testing

Run:
```
arthur.py create_groups --dry-run
```
You'll see something like this:
```
2021-12-06 20:28:29 - INFO - 3 group(s) already existed: ...
```
