### PR TITLE
Check for Docker version >= 20

### DIFF
--- a/bin/arthur.sh
+++ b/bin/arthur.sh
@@ -14,6 +14,12 @@ if ! type docker >/dev/null ; then
   exit 1
 fi
 
+# Make sure Docker version is recent enough ("--pull always" was added in version 20)
+if [[ $(docker version --format '{{.Server.Version}}') =~ ^1[0-9].* ]]; then
+  echo "You need to upgrade your Docker environment to version >= 20." 1>&2
+  exit 1
+fi
+
 set -o errexit
 
 aws_profile="${AWS_PROFILE-${AWS_DEFAULT_PROFILE-default}}"


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

### User-visible Changes

If somebody has an old version of Docker (< 20), then an error will pop up around:
```
docker \
    --pull always
```
We want that feature so that we can check always whether a new version of Arthur has been published on GitHub's packages registry.

Now `bin/arthur.sh` checks the Docker version and advises to upgrade.

## Testing

Testing is a bit tricky unless you really want to downgrade the installed Docker version. But you can easily replace the `docker version` command with an `echo` statement.
