### PR TITLE
DENG-1284: Add flag to not publish staging schema

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1090,6 +1090,14 @@ class LoadDataWarehouseCommand(SubCommand):
             dest="use_staging_schemas",
         )
         parser.add_argument(
+            "--without-publish-staging",
+            default=True,
+            action="store_false",
+            help="Skip publishing staging schemas and keep result of the load step in"
+            " staging (default: publish schemas from staging)",
+            dest="publish_staging_schemas",
+        )
+        parser.add_argument(
             "--skip-loading-sources",
             action="store_true",
             default=False,
@@ -1130,6 +1138,7 @@ class LoadDataWarehouseCommand(SubCommand):
             skip_copy=args.skip_copy,
             skip_loading_sources=args.skip_loading_sources,
             use_staging=args.use_staging_schemas,
+            publish_staging=args.publish_staging_schemas,
             dry_run=args.dry_run,
         )
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1108,6 +1108,11 @@ class LoadDataWarehouseCommand(SubCommand):
         dw_config = etl.config.get_dw_config()
         try:
             args.pattern.selected_schemas()
+            if not (args.publish_staging_schemas or args.use_staging_schemas):
+                raise ValueError(
+                    "The command is ambiguous, use either --without-publish-staging "
+                    "or --without-staging-schemas flag"
+                )
         except ValueError as exc:
             raise InvalidArgumentError(exc) from exc
 

--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1110,8 +1110,8 @@ class LoadDataWarehouseCommand(SubCommand):
             args.pattern.selected_schemas()
             if not (args.publish_staging_schemas or args.use_staging_schemas):
                 raise ValueError(
-                    "The command is ambiguous, use either --without-publish-staging "
-                    "or --without-staging-schemas flag"
+                    "The command is ambiguous, use only one of --without-publish-staging or "
+                    "--without-staging-schemas flags"
                 )
         except ValueError as exc:
             raise InvalidArgumentError(exc) from exc

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1133,6 +1133,7 @@ def load_data_warehouse(
     all_relations: Sequence[RelationDescription],
     selector: TableSelector,
     use_staging=True,
+    publish_staging=True,
     max_concurrency=1,
     wlm_query_slots=1,
     statement_timeout=0,
@@ -1205,7 +1206,7 @@ def load_data_warehouse(
             etl.data_warehouse.restore_schemas(traversed_schemas, dry_run=dry_run)
         raise
 
-    if use_staging:
+    if use_staging and publish_staging:
         logger.info("Publishing %d schema(s) after load success", len(traversed_schemas))
         etl.data_warehouse.publish_schemas(traversed_schemas, dry_run=dry_run)
 

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1209,6 +1209,10 @@ def load_data_warehouse(
     if use_staging and publish_staging:
         logger.info("Publishing %d schema(s) after load success", len(traversed_schemas))
         etl.data_warehouse.publish_schemas(traversed_schemas, dry_run=dry_run)
+    elif use_staging:
+        logger.info(
+            f"Updated {len(traversed_schemas)} staging schema(s) without updating loaded schemas"
+        )
 
 
 def upgrade_data_warehouse(


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

Add flag to the load command to not promote staging schemas after the load finishes when using staging schemas.

## QA

Using this table for test: https://github.com/harrystech/harrys-data-warehouse/pull/1949 with a simple query as a source in Arthur:
```
SELECT SYSDATE as dw_loaded_at
```

## Default behavior
```
$ arhtur.py sync
$ arthur.py load test_load_schema
```

```
2022-02-07 18:30:28 - INFO - Renaming schema 'test_load_schema' to backup 'etl_backup$test_load_schema'
2022-02-07 18:30:29 - INFO - Connecting to: host=polaris.dev.harrys.systems port=5439 dbname=development user=etl password=***
2022-02-07 18:30:29 - INFO - Promoting 1 schema(s) from staging position: 'test_load_schema'
2022-02-07 18:30:29 - INFO - Renaming schema 'test_load_schema' from 'etl_staging$test_load_schema'
2022-02-07 18:30:30 - INFO - Granting readers and writers access to schema 'test_load_schema' after promotion
2022-02-07 18:30:31 - INFO - Ran 'load' for 32.89s and finished successfully!
```

* **The table was promoted:**

```
select * from test_load_schema.table;
```

```
+--------------------------+
|dw_loaded_at              |
+--------------------------+
|2022-02-07 18:30:25.544483|
+--------------------------+
```

The staging table should not exist anymore:

```
select * from etl_staging$test_load_schema.table;
```
```
[3F000] ERROR: schema "etl_staging$test_load_schema" does not exist
```

## Using `--without-publish-staging` flag:
```
$ arthur.py load test_load_schema --without-publish-staging
...
2022-02-07 18:23:36 - INFO - No constraints to verify for 'test_load_schema.table'
2022-02-07 18:23:36 - INFO - Found 1 row(s) in 'test_load_schema.table' (in staging)
2022-02-07 18:23:36 - INFO - Finished load step for 'test_load_schema.table' (3.10s)
2022-02-07 18:23:36 - INFO - Finished with 1 relation(s) in transformation schemas (3.35s)
2022-02-07 18:23:36 - INFO - Updated 1 staging schema(s) without updating loaded schemas
2022-02-07 18:23:36 - INFO - Ran 'load' for 24.28s and finished successfully!
```
**The staging table shows latest timestamp:**
* `select * from etl_staging$test_load_schema.table;`
```
+--------------------------+
|dw_loaded_at              |
+--------------------------+
|2022-02-07 18:23:34.503598|
+--------------------------+
```
**The promoted table still shows an old timestamp **
`select * from test_load_schema.table;`
```
+--------------------------+
|dw_loaded_at              |
+--------------------------+
|2022-02-07 18:15:36.735019|
+--------------------------+
```

## Using both  `--without-publish-staging` and `--without-staging-schema` flag 

```
(aws:data-dev, prefix:youssef) $ arthur.py load test_load_schema --without-staging-schemas --without-publish-staging
2022-02-07 18:12:55 - ERROR - ETL never got off the ground: InvalidArgumentError(ValueError('The command is ambiguous, use only one of --without-publish-staging or --without-staging-schemas flags'))
Bailing out: etl.errors.InvalidArgumentError: The command is ambiguous, use only one of --without-publish-staging or --without-staging-schemas flags
```
### User-visible Changes

Users can add an extra flag to not promote staging schemas. Otherwise, the default value (not specifying the flag) uses the old setting, making the change backward compatible, like for any pipeline already deployed for example.