### PR TITLE
DENG-1270: Add On-Demand Rebuild Pipeline

### DIFF
--- a/python/etl/templates/text/ondemand_rebuild_pipeline.json
+++ b/python/etl/templates/text/ondemand_rebuild_pipeline.json
@@ -9,7 +9,8 @@
             "role": "${resources.DataPipeline.role}",
             "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/",
             "region": "${resources.VPC.region}",
-            "maximumRetries": "2"
+            "maximumRetries": "2",
+            "maxActiveInstances": "1"
         },
         {
             "id": "SNSParent",

--- a/python/etl/templates/text/ondemand_rebuild_pipeline.json
+++ b/python/etl/templates/text/ondemand_rebuild_pipeline.json
@@ -20,21 +20,21 @@
             "id": "SuccessNotification",
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
-            "subject": "ETL Rebuild Success: ${object_store.s3.prefix}",
+            "subject": "ETL On-Demand Rebuild Success: ${object_store.s3.prefix}",
             "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
         },
         {
             "id": "FailureNotification",
             "type": "SnsAlarm",
             "parent": { "ref": "SNSParent" },
-            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix}",
+            "subject": "ETL On-Demand Rebuild Failure: ${object_store.s3.prefix}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
         },
         {
             "id": "PagerNotification",
             "type": "SnsAlarm",
             "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
-            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix}",
+            "subject": "ETL On-Demand Rebuild Failure: ${object_store.s3.prefix}",
             "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
         },
         {

--- a/python/etl/templates/text/ondemand_rebuild_pipeline.json
+++ b/python/etl/templates/text/ondemand_rebuild_pipeline.json
@@ -1,0 +1,184 @@
+{
+    "objects": [
+        {
+            "id": "Default",
+            "name": "Default",
+            "scheduleType": "ondemand",
+            "failureAndRerunMode": "CASCADE",
+            "resourceRole": "${resources.EC2.iam_instance_profile}",
+            "role": "${resources.DataPipeline.role}",
+            "pipelineLogUri": "s3://${object_store.s3.bucket_name}/_logs/${object_store.s3.prefix}/",
+            "region": "${resources.VPC.region}",
+            "maximumRetries": "2"
+        },
+        {
+            "id": "SNSParent",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-status"
+        },
+        {
+            "id": "SuccessNotification",
+            "type": "SnsAlarm",
+            "parent": { "ref": "SNSParent" },
+            "subject": "ETL Rebuild Success: ${object_store.s3.prefix}",
+            "message": "Completed last action successfully at #{node.@actualEndTime}\\nLast node: #{node.name}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}"
+        },
+        {
+            "id": "FailureNotification",
+            "type": "SnsAlarm",
+            "parent": { "ref": "SNSParent" },
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix}",
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
+        },
+        {
+            "id": "PagerNotification",
+            "type": "SnsAlarm",
+            "topicArn": "arn:aws:sns:${resources.VPC.region}:${resources.VPC.account}:${resource_prefix}-page",
+            "subject": "ETL Rebuild Failure: ${object_store.s3.prefix}",
+            "message": "Failed step #{node.name} at #{node.@actualEndTime}\\nPipelineId: #{node.@pipelineId}\\nLog directory: #{node.pipelineLogUri}#{node.@pipelineId}\\n\\nShow error message: arthur.py show_pipelines '#{node.@pipelineId}'"
+        },
+        {
+            "id": "ResourceParent",
+            "keyPair": "${resources.key_name}",
+            "subnetId": "${resources.VPC.public_subnet}",
+            "terminateAfter": "#{myTimeout} Hours"
+        },
+        {
+            "id": "ETLCluster",
+            "name": "ETL EMR Cluster",
+            "type": "EmrCluster",
+            "parent": { "ref": "ResourceParent" },
+            "releaseLabel": "${resources.EMR.release_label}",
+            "masterInstanceType": "${resources.EMR.master.instance_type}",
+            "coreInstanceType": "${resources.EMR.core.instance_type}",
+            "coreInstanceCount": "${resources.EMR.core.instance_count}",
+            "emrManagedMasterSecurityGroupId": "${resources.EMR.master.managed_security_group}",
+            "emrManagedSlaveSecurityGroupId": "${resources.EMR.core.managed_security_group}",
+            "additionalMasterSecurityGroupIds": [
+                "${resources.EC2.public_security_group}",
+                "${resources.VPC.whitelist_security_group}"
+            ],
+            "bootstrapAction": "s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh,${object_store.s3.bucket_name},${object_store.s3.prefix}",
+            "applications": [ "Spark", "Ganglia", "Zeppelin", "Sqoop" ],
+            "configuration": []
+        },
+        {
+            "id": "ArthurDriverEC2Resource",
+            "type": "Ec2Resource",
+            "parent": { "ref": "ResourceParent" },
+            "actionOnTaskFailure": "terminate",
+            "actionOnResourceFailure": "retryAll",
+            "instanceType": "${resources.EC2.instance_type}",
+            "imageId": "${resources.EC2.image_id}",
+            "securityGroupIds": [
+                "${resources.EC2.public_security_group}",
+                "${resources.VPC.whitelist_security_group}"
+            ],
+            "associatePublicIpAddress": "true"
+        },
+        {
+            "id": "Ec2CommandGrandParent",
+            "runsOn": { "ref": "ArthurDriverEC2Resource" }
+        },
+        {
+            "id": "ShellCommandParent",
+            "parent": { "ref": "Ec2CommandGrandParent" }
+        },
+        {
+            "id": "ArthurCommandParent",
+            "parent": { "ref": "Ec2CommandGrandParent" },
+            "maximumRetries": "0"
+        },
+        {
+            "id": "EmrActivityUpstreamExtract",
+            "name": "Arthur Extract (EMR Activity)",
+            "type": "EmrActivity",
+            "step": "/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar,/tmp/redshift_etl/venv/bin/arthur.py,--config,/tmp/redshift_etl/config/,extract,--keep-going,--prolix,--prefix,${object_store.s3.prefix}",
+            "runsOn": { "ref": "ETLCluster" },
+            "maximumRetries": "0"
+        },
+        {
+            "id": "CopyBootstrap",
+            "name": "Copy Bootstrap (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "(sudo yum -y update aws-cli) && /usr/bin/aws s3 cp s3://${object_store.s3.bucket_name}/${object_store.s3.prefix}/bin/bootstrap.sh /tmp/bootstrap.sh"
+        },
+        {
+            "id": "Bootstrap",
+            "name": "Bootstrap (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "bash /tmp/bootstrap.sh ${object_store.s3.bucket_name} ${object_store.s3.prefix}",
+            "dependsOn": { "ref": "CopyBootstrap" }
+        },
+        {
+            "id": "SendHealthCheckAfterBootstrap",
+            "name": "Send Health Check After Bootstrap (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "bash /tmp/redshift_etl/bin/send_health_check.sh start",
+            "dependsOn": { "ref": "Bootstrap" }
+        },
+        {
+            "id": "ArthurTerminateSessions",
+            "name": "Arthur Terminate Sessions (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ terminate_sessions --prolix",
+            "dependsOn": { "ref": "Bootstrap" }
+        },
+        {
+            "id": "ArthurLoad",
+            "name": "Arthur Load (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ArthurCommandParent" },
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix ${object_store.s3.prefix} --concurrent-extract",
+            "dependsOn": { "ref": "ArthurTerminateSessions" }
+        },
+        {
+            "id": "PublishAndBackup",
+            "name": "Publish and Backup (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": {"ref": "ShellCommandParent"},
+            "command": "bash /tmp/redshift_etl/bin/sync_env.sh -y ${object_store.s3.bucket_name} ${object_store.s3.prefix} ${object_store.s3.prefix}/current",
+            "dependsOn": { "ref": "ArthurLoad" }
+        },
+        {
+            "id": "ArthurUnload",
+            "name": "Arthur Unload (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": {"ref": "ArthurCommandParent"},
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ unload --keep-going --prolix --prefix ${object_store.s3.prefix}",
+            "dependsOn": {"ref": "ArthurLoad"}
+        },
+        {
+            "id": "SendHealthCheckAfterEtl",
+            "name": "Send Health Check After ETL (EC2)",
+            "type": "ShellCommandActivity",
+            "parent": { "ref": "ShellCommandParent" },
+            "command": "bash /tmp/redshift_etl/bin/send_health_check.sh",
+            "dependsOn": [
+                { "ref": "PublishAndBackup" },
+                { "ref": "ArthurUnload" }
+            ],
+            "onSuccess": { "ref": "SuccessNotification" },
+            "onFail": [
+                { "ref": "FailureNotification" },
+                { "ref": "PagerNotification" }
+            ]
+        }
+    ],
+    "parameters": [
+        {
+            "id": "myTimeout",
+            "type": "Integer",
+            "optional": "true",
+            "description": "How many hours to allow the pipeline to run before terminating it",
+            "watermark": "6",
+            "helpText": "How long can the pipeline run?"
+        }
+    ],
+    "values": {
+        "myTimeout": "6"
+    }
+}

--- a/python/scripts/install_ondemand_rebuild_pipeline.sh
+++ b/python/scripts/install_ondemand_rebuild_pipeline.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+CURRENT_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S")
 DEFAULT_TIMEOUT=6
 
 if [[ $# -lt 1 || $# -gt 2 || "$1" = "-h" ]]; then
@@ -43,7 +44,7 @@ set -o xtrace
 # Note: "key" and "value" are lower-case keywords here.
 AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=on-demand-rebuild"
 
-PIPELINE_NAME="ETL On-Demand Rebuild Pipeline ($PROJ_ENVIRONMENT)"
+PIPELINE_NAME="ETL On-Demand Rebuild Pipeline ($PROJ_ENVIRONMENT @ $CURRENT_TIMESTAMP)"
 PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
 PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
 

--- a/python/scripts/install_ondemand_rebuild_pipeline.sh
+++ b/python/scripts/install_ondemand_rebuild_pipeline.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+DEFAULT_TIMEOUT=6
+
+if [[ $# -lt 1 || $# -gt 2 || "$1" = "-h" ]]; then
+  cat <<USAGE
+
+Rebuild ETL to extract, load (including transforms), and unload data.
+
+Usage: $(basename "$0") <environment> [timeout]
+Optional timeout should be the number of hours pipeline is allowed to run. Defaults to $DEFAULT_TIMEOUT.
+
+USAGE
+  exit 0
+fi
+
+set -o errexit -o nounset
+
+# Verify that there is a local configuration directory
+DEFAULT_CONFIG="${DATA_WAREHOUSE_CONFIG:-./config}"
+if [[ ! -d "$DEFAULT_CONFIG" ]]; then
+  echo 1>&2 "Failed to find \'$DEFAULT_CONFIG\' directory."
+  echo 1>&2 "Make sure you are in the directory with your data warehouse setup or have DATA_WAREHOUSE_CONFIG set."
+  exit 1
+fi
+
+PROJ_BUCKET=$(arthur.py show_value object_store.s3.bucket_name)
+PROJ_ENVIRONMENT="$1"
+TIMEOUT="${2:-$DEFAULT_TIMEOUT}"
+
+# Verify that this bucket/environment pair is set up on S3
+BOOTSTRAP="s3://$PROJ_BUCKET/$PROJ_ENVIRONMENT/bin/bootstrap.sh"
+if ! aws s3 ls "$BOOTSTRAP" > /dev/null; then
+  echo 1>&2 "Failed to access \"$BOOTSTRAP\"!"
+  echo 1>&2 "Check whether the bucket \"$PROJ_BUCKET\" and folder \"$PROJ_ENVIRONMENT\" exist,"
+  echo 1>&2 "whether you have the correct access permissions, and"
+  echo 1>&2 "whether you have uploaded the Arthur environment."
+  exit 1
+fi
+
+set -o xtrace
+
+# Note: "key" and "value" are lower-case keywords here.
+AWS_TAGS="key=user:project,value=data-warehouse key=user:sub-project,value=dw-etl key=user:data-pipeline-type,value=on-demand-rebuild"
+
+PIPELINE_NAME="ETL On-Demand Rebuild Pipeline ($PROJ_ENVIRONMENT)"
+PIPELINE_DEFINITION_FILE="/tmp/pipeline_definition_${USER-nobody}_$$.json"
+PIPELINE_ID_FILE="/tmp/pipeline_id_${USER-nobody}_$$.json"
+
+# shellcheck disable=SC2064
+trap "rm -f \"$PIPELINE_ID_FILE\"" EXIT
+
+arthur.py render_template --prefix "$PROJ_ENVIRONMENT" ondemand_rebuild_pipeline > "$PIPELINE_DEFINITION_FILE"
+
+# shellcheck disable=SC2086
+aws datapipeline create-pipeline \
+    --unique-id dw-etl-rebuild-pipeline \
+    --name "$PIPELINE_NAME" \
+    --tags $AWS_TAGS \
+    | tee "$PIPELINE_ID_FILE"
+
+PIPELINE_ID=$(jq --raw-output < "$PIPELINE_ID_FILE" '.pipelineId')
+
+if [[ -z "$PIPELINE_ID" ]]; then
+  set +o xtrace
+  echo 1>&2 "Failed to find pipeline id in output -- pipeline probably wasn't created. Check your VPN etc."
+  exit 1
+fi
+
+aws datapipeline put-pipeline-definition \
+    --pipeline-definition "file://$PIPELINE_DEFINITION_FILE" \
+    --parameter-values \
+        myTimeout="$TIMEOUT" \
+    --pipeline-id "$PIPELINE_ID"
+
+set +o xtrace
+echo
+echo "Your On-Demand Rebuild Pipeline ('$PIPELINE_ID') has been created!"
+echo "You can start the pipeline by running the following command:"
+echo "    aws datapipeline activate-pipeline --pipeline-id "$PIPELINE_ID""

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     scripts=[
         "python/scripts/compare_events.py",
         "python/scripts/install_extraction_pipeline.sh",
+        "python/scripts/install_ondemand_rebuild_pipeline.sh",
         "python/scripts/install_pizza_load_pipeline.sh",
         "python/scripts/install_pizza_pipeline.sh",
         "python/scripts/install_rebuild_pipeline.sh",


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

### User-visible Changes

<!-- Describe what changes for users of Arthur -->
Users are able to build a ondemand rebuild pipeline in arthur.

## Links
https://harrys.atlassian.net/browse/DENG-1270

## Testing
Ran below command in arthur
```shell
install_ondemand_rebuild_pipeline.sh jwong
```

Was able to create a on-demand rebuild pipeline:
```
+ aws datapipeline put-pipeline-definition --pipeline-definition file:///tmp/pipeline_definition_arthur_33.json --parameter-values myTimeout=6 --pipeline-id df-03035043C5I4J7VUW9D3
{
    "validationErrors": [], 
    "errored": false, 
    "validationWarnings": []
}
+ set +o xtrace

Your On-Demand Rebuild Pipeline ('df-03035043C5I4J7VUW9D3') has been created!
You can start the pipeline by running the following command:
    aws datapipeline activate-pipeline --pipeline-id df-03035043C5I4J7VUW9D3
```

`df-03035043C5I4J7VUW9D3` is shown in the dev datapipeline:
https://console.aws.amazon.com/datapipeline/home?region=us-east-1#

Was able to kick off on demand rebuild pipeline by running `aws datapipeline activate-pipeline --pipeline-id df-03035043C5I4J7VUW9D3` 

I also got an expected error to make sure we are not concurrently running the pipeline when activating the same pipeline while it is already running:

```
(aws:data-dev, prefix:jwong) $ aws datapipeline activate-pipeline --pipeline-id df-03035043C5I4J7VUW9D3

An error occurred (InvalidRequestException) when calling the ActivatePipeline operation: Web service limit exceeded: Exceeded number of concurrent executions.  Please set the field 'maxActiveInstances' to a higher value in your pipeline or wait for the currenly running executions to complete before trying again
```

## Deploy Notes

<!-- If applicable, add migrations and deployment steps -->
