### PR TITLE
DENG-1314: Add flags to on demand rebuild for load command

### DIFF
--- a/python/etl/templates/text/ondemand_rebuild_pipeline.json
+++ b/python/etl/templates/text/ondemand_rebuild_pipeline.json
@@ -133,7 +133,7 @@
             "name": "Arthur Load (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ArthurCommandParent" },
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix ${object_store.s3.prefix} --concurrent-extract",
+            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ load --prolix --prefix ${object_store.s3.prefix} --concurrent-extract #{myExtraLoadFlags}",
             "dependsOn": { "ref": "ArthurTerminateSessions" }
         },
         {
@@ -177,9 +177,17 @@
             "description": "How many hours to allow the pipeline to run before terminating it",
             "watermark": "6",
             "helpText": "How long can the pipeline run?"
+        },
+        {
+            "id": "myExtraLoadFlags",
+            "type": "String",
+            "optional": "true",
+            "description": "Extra flags to add to the load command",
+            "helpText": "Extra flags to add to the load command other like skipping the use of staging "
         }
     ],
     "values": {
-        "myTimeout": "6"
+        "myTimeout": "6",
+        "myExtraLoadFlags": ""
     }
 }


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

### User-visible Changes

<!-- Describe what changes for users of Arthur -->

Adding possibility to pass `arthur.py load` command flag as `-*` or `--*` to on-demand rebuild pipeline, so that we can pass the flag to `--without-publish-staging`.

## Links

<!-- Link GitHub issues and JIRAs tasks -->
https://harrys.atlassian.net/jira/software/c/projects/DENG/boards/81?modal=detail&selectedIssue=DENG-1328

## Testing

```
(aws:data-dev, prefix:development) $ install_ondemand_rebuild_pipeline.sh -h

Rebuild ETL to extract, load (including transforms), and unload data.

Usage: install_ondemand_rebuild_pipeline.sh <environment> [timeout] [myExtraLoadFlags]
Optional timeout should be the number of hours pipeline is allowed to run. Defaults to 6.
Optional myExtraLoadFlags are passed to the rebuild load command
```

```
(aws:data-dev, prefix:development) $ install_ondemand_rebuild_pipeline.sh test 6 --flag1 --flag2 --flag3
```

![image](https://user-images.githubusercontent.com/29376963/154370067-6fbc96fc-32f5-4677-a7b0-c7ce5876089e.png)

* Separates flags and positional arguments:
```
(aws:data-dev, prefix:development) $ install_ondemand_rebuild_pipeline.sh --flag1 youssef --flag2 6 --flag3
```
![image](https://user-images.githubusercontent.com/29376963/154370264-38073d47-6559-4f39-af48-e20552a94698.png)

## Deploy Notes

<!-- If applicable, add migrations and deployment steps -->
