### PR TITLE
Remove unload from on-demand rebuild pipeline

### DIFF
--- a/python/etl/templates/text/ondemand_rebuild_pipeline.json
+++ b/python/etl/templates/text/ondemand_rebuild_pipeline.json
@@ -145,22 +145,13 @@
             "dependsOn": { "ref": "ArthurLoad" }
         },
         {
-            "id": "ArthurUnload",
-            "name": "Arthur Unload (EC2)",
-            "type": "ShellCommandActivity",
-            "parent": {"ref": "ArthurCommandParent"},
-            "command": "/tmp/redshift_etl/venv/bin/arthur.py --config /tmp/redshift_etl/config/ unload --keep-going --prolix --prefix ${object_store.s3.prefix}",
-            "dependsOn": {"ref": "ArthurLoad"}
-        },
-        {
             "id": "SendHealthCheckAfterEtl",
             "name": "Send Health Check After ETL (EC2)",
             "type": "ShellCommandActivity",
             "parent": { "ref": "ShellCommandParent" },
             "command": "bash /tmp/redshift_etl/bin/send_health_check.sh",
             "dependsOn": [
-                { "ref": "PublishAndBackup" },
-                { "ref": "ArthurUnload" }
+                { "ref": "PublishAndBackup" }
             ],
             "onSuccess": { "ref": "SuccessNotification" },
             "onFail": [


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

This PR removes the unload from the ondemand pipeline. We don't want it there since we want to use this pipeline to run the  Arthur load and transform in staging only, so we only want to unload after the promote, which does not happen in this pipeline.

~This is very specific to our use case of the migration so one way to make this backward compatible (since this is open-source) is to actually create another pipeline that would be called "staging_rebuild" or something like that.~ 
See Tom's comment: https://github.com/harrystech/arthur-redshift-etl/pull/674#issuecomment-1063246432

## Test

We have a full rebuild run yesterday in dev: https://us-east-1.console.aws.amazon.com/datapipeline/home?region=us-east-1#ExecutionDetailsPlace:pipelineId=df-06381941BFK4A6JTL0WQ&show=latest