### PR TITLE
Set relation_column_encoding to AUTO by default

### DIFF
--- a/python/etl/config/default_settings.yaml
+++ b/python/etl/config/default_settings.yaml
@@ -16,7 +16,7 @@
     "retriable_error_codes": "8001,15001,15005",
     "concurrent_load_idle_termination_seconds": 3600,
     "redshift": {
-      "relation_column_encoding": "ON"
+      "relation_column_encoding": "AUTO"
     }
   },
   # Target (Redshift) cluster

--- a/python/etl/dialect/redshift.py
+++ b/python/etl/dialect/redshift.py
@@ -181,9 +181,7 @@ def add_auto_encoding(table_design: dict) -> None:
 
 def build_table_ddl(table_name: TableName, table_design: dict, is_temp=False) -> str:
     """Assemble the DDL of a table in a Redshift data warehouse."""
-    if (
-        etl.config.get_config_value("arthur_settings.redshift.relation_column_encoding") or "ON"
-    ) == "AUTO":
+    if etl.config.get_config_value("arthur_settings.redshift.relation_column_encoding", "ON") == "AUTO":
         add_auto_encoding(table_design)
     columns = build_columns(table_design["columns"], is_temp=is_temp)
     constraints = build_table_constraints(table_design)
@@ -333,7 +331,7 @@ def copy_using_manifest(
         data_format, format_option, file_compression
     )
 
-    compupdate = etl.config.get_config_value("arthur_settings.redshift.relation_column_encoding") or "ON"
+    compupdate = etl.config.get_config_value("arthur_settings.redshift.relation_column_encoding", "ON")
     if compupdate == "AUTO":
         compupdate = "OFF"
 


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

### User-visible Changes

<!-- Describe what changes for users of Arthur -->

This changes the default of the `relation_column_encoding` setting from `ON` to `AUTO`. This means that Arthur will pick appropriate encodings for columns. (The encoding value is picked based on the type and whether it's used in distribution or sort keys.) Selecting the encoding speeds up loading data (`COMPUPDATE` can be left off).

## Links

<!-- Link GitHub issues and JIRAs tasks -->

Closes #229

## Testing

<!-- Describe how somebody can test your changes or how they have been added to automatic tests. -->

You can check the active setting using:
```
arthur.py settings arthur_settings.redshift.relation_column_encoding
```

You can check which encoding is used with `show_ddl` on a table.  Unless you already had the auto setting active, you would see for example columns like this:
```
    "created_at" TIMESTAMP WITHOUT TIME ZONE NOT NULL,
```
but then would see an encoding with the new default:
```
    "created_at" TIMESTAMP WITHOUT TIME ZONE ENCODE zstd NOT NULL,
```

## Deploy Notes

<!-- If applicable, add migrations and deployment steps -->
If the `relation_column_encoding` is set to `AUTO` in local configurations, then this can be removed now. If this mode is not desired, then `relation_column_encoding` must be set to `OFF` now.

Harry's internal note: This has been effectively in place in production given that we have a file in the object store with this content:
```yaml
{
  "arthur_settings": {
    "redshift": {
       "relation_column_encoding": "AUTO"
    }
  }
}
```
(This file should now be removed.)
