### PR TITLE
Push image in next

### DIFF
--- a/.github/workflows/publish-latest-remote.yaml
+++ b/.github/workflows/publish-latest-remote.yaml
@@ -39,17 +39,17 @@ jobs:
         # Use the original tag ref, the SHA1, and versions derived from the tag.
         tags: |
           type=ref,event=tag
+          type=ref,event=branch
           type=semver,pattern=v{{major}}.{{minor}}
           type=semver,pattern=v{{version}}
           type=sha
 
     - name: Build and push with version tags
       id: docker_build
-      if: ${{ github.event_name == 'release' && github.event.release.tag_name != '' }}
       uses: docker/build-push-action@v2
       with:
         context: .
+        push: true
         labels: ${{ steps.meta.outputs.labels }}
-        push: ${{ github.event.action == 'published' }}
         tags: ${{ steps.meta.outputs.tags }}
         target: remote


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

This allow us to get a "next" label, so we can set the dev image in Airflow/ECS to point to next so that we can test it in the dev cluster.