### PR TITLE
Add flag to not backup on promoting staging

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -1453,13 +1453,22 @@ class PromoteSchemasCommand(SubCommand):
             required=True,
         )
 
+        parser.add_argument(
+            "--no-backup",
+            help="do not backup current data when promoting from staging",
+            action="store_true",
+            default=False,
+        )
+
     def callback(self, args):
         dw_config = etl.config.get_dw_config()
         schema_names = args.pattern.selected_schemas()
         schemas = [schema for schema in dw_config.schemas if schema.name in schema_names]
         with etl.db.log_error():
             if args.from_position == "staging":
-                etl.data_warehouse.publish_schemas(schemas, dry_run=args.dry_run)
+                etl.data_warehouse.publish_schemas(
+                    schemas, dry_run=args.dry_run, backup=not args.no_backup
+                )
             elif args.from_position == "backup":
                 etl.data_warehouse.restore_schemas(schemas, dry_run=args.dry_run)
 

--- a/python/etl/data_warehouse.py
+++ b/python/etl/data_warehouse.py
@@ -193,13 +193,14 @@ def restore_schemas(schemas: Iterable[DataWarehouseSchema], dry_run=False) -> No
     _promote_schemas(schemas, "backup", dry_run=dry_run)
 
 
-def publish_schemas(schemas: Sequence[DataWarehouseSchema], dry_run=False) -> None:
+def publish_schemas(schemas: Sequence[DataWarehouseSchema], dry_run=False, backup=True) -> None:
     """
     Backup current occupants of standard position and put staging schemas there.
 
     This is a callback of a command.
     """
-    backup_schemas(schemas, dry_run=dry_run)
+    if backup:
+        backup_schemas(schemas, dry_run=dry_run)
     _promote_schemas(schemas, "staging", dry_run=dry_run)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-ARTHUR_VERSION = "1.62.0"
+ARTHUR_VERSION = "1.63.0"
 
 
 setup(


### PR DESCRIPTION
# Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->

Adding flag to not backup loaded data when promoting staging data. This allow us to temporarily save disk space.

# QA

##  Creating table in staging
```
arthur.py upgrade --with-staging mock_arthur_schema
```
##  Promoting from staging
```
arthur.py promote_schemas --from-position staging mock_arthur_schema 
...
2022-06-22 16:45:13 - INFO - Creating backup of schema(s) 'mock_arthur_schema'
2022-06-22 16:45:13 - INFO - Revoking access from readers and writers to schema 'mock_arthur_schema' before backup
2022-06-22 16:45:15 - INFO - Renaming schema 'mock_arthur_schema' to backup 'etl_backup$mock_arthur_schema'
2022-06-22 16:45:16 - INFO - Promoting 1 schema(s) from staging position: 'mock_arthur_schema'
2022-06-22 16:45:16 - INFO - Renaming schema 'mock_arthur_schema' from 'etl_staging$mock_arthur_schema'
...
```

```sql
-- Table was promoted
SELECT *
FROM mock_arthur_schema.table;
```

| a\_column |
| :--- |
| constant |

```sql
-- Table was backed up 
SELECT *
FROM etl_backup$mock_arthur_schema.table;
```


| a\_column |
| :--- |
| constant |

##  Recreating table in staging
```
arthur.py upgrade --with-staging mock_arthur_schema
```

```sql
SELECT *
FROM etl_staging$mock_arthur_schema.table;
```

| a\_column |
| :--- |
| constant |

##  Promoting from staging with no backup
```
arthur.py promote_schemas --from-position staging mock_arthur_schema --no-backup
...
2022-06-22 16:45:40 - INFO - Promoting 1 schema(s) from staging position: 'mock_arthur_schema'
2022-06-22 16:45:40 - INFO - Renaming schema 'mock_arthur_schema' from 'etl_staging$mock_arthur_schema'
...
```

```sql
-- Table was promoted
SELECT *
FROM mock_arthur_schema.table;
```

| a\_column |
| :--- |
| constant |

```sql
-- This should return table not found
SELECT *
FROM etl_backup$mock_arthur_schema.table;
```


##  Promoting from backup
```
arthur.py promote_schemas --from-position backup mock_arthur_schema            
...
2022-06-22 16:46:07 - INFO - Promoting 1 schema(s) from backup position: 'mock_arthur_schema'
2022-06-22 16:46:07 - INFO - Renaming schema 'mock_arthur_schema' from 'etl_backup$mock_arthur_schema'
...
```

```sql
-- Table was promoted
SELECT *
FROM mock_arthur_schema.table;
```

| a\_column |
| :--- |
| constant |

##  Recreating table in backup
```
arthur.py promote_schemas --from-position staging mock_arthur_schema            
```

```sql
SELECT *
FROM etl_backup$mock_arthur_schema.table;
```


##  Promoting from backup with no-backup flag (The flag has no effect here)

```
arthur.py promote_schemas --from-position backup mock_arthur_schema --no-backup
...
2022-06-22 16:46:36 - INFO - Promoting 1 schema(s) from backup position: 'mock_arthur_schema'
2022-06-22 16:46:36 - INFO - Renaming schema 'mock_arthur_schema' from 'etl_backup$mock_arthur_schema'
...
```

```sql
SELECT *
FROM mock_arthur_schema.table;
```

```sql
-- This should return table not found
SELECT *
FROM etl_backup$mock_arthur_schema.table;
```
