### PR TITLE
Provide summary of failed relations after validate

### DIFF
--- a/python/etl/commands.py
+++ b/python/etl/commands.py
@@ -533,7 +533,7 @@ class SubCommand(abc.ABC):
 
         # Log level and prolix setting need to be always known since `run_arg_as_command` depends
         # on them.
-        # TODO move this into a parent parser and merge with --submit, --config
+        # TODO(tom): move this into a parent parser and merge with --submit, --config
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
             "-o", "--prolix", action="store_true", default=False, help="send full log to console"

--- a/python/etl/design/load.py
+++ b/python/etl/design/load.py
@@ -129,7 +129,7 @@ def validate_identity_as_surrogate_key(table_design):
     surrogate_keys = [col for constraint in constraints for col in constraint.get("surrogate_key", [])]
     if len(surrogate_keys) and not surrogate_keys == identity_columns:
         raise TableDesignSemanticError("surrogate key must be identity column")
-    # TODO Complain if surrogate_key is missing but identity is present
+    # TODO(tom): Complain if surrogate_key is missing but identity is present
 
 
 def validate_column_references(table_design):

--- a/python/etl/extract/static.py
+++ b/python/etl/extract/static.py
@@ -9,7 +9,7 @@ from etl.relation import RelationDescription
 class StaticExtractor(Extractor):
     """Enable using files in S3 as an upstream data source."""
 
-    # TODO Describe expected file paths, existence of "_SUCCESS" file
+    # TODO(tom): Describe expected file paths, existence of "_SUCCESS" file
 
     def __init__(
         self,

--- a/python/etl/load.py
+++ b/python/etl/load.py
@@ -1013,7 +1013,9 @@ def create_source_tables_in_parallel(
     pool = etl.db.connection_pool(max_concurrency, dsn_etl)
     futures: Dict[str, concurrent.futures.Future] = {}
     try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_concurrency) as executor:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_concurrency, thread_name_prefix="create-source"
+        ) as executor:
             for relation in source_relations:
                 future = executor.submit(build_one_relation_using_pool, pool, relation, dry_run=dry_run)
                 futures[relation.identifier] = future

--- a/python/etl/monitor.py
+++ b/python/etl/monitor.py
@@ -670,7 +670,7 @@ def scan_etl_events(etl_id, selected_columns: Optional[Iterable[str]] = None) ->
     keys = ["extra.rowcount" if column == "rowcount" else column for column in columns]
 
     # We need to scan here since the events are stored by "target" and not by "etl_id".
-    # TODO Try to find all the "known" relations and query on them with a filter on the etl_id.
+    # TODO(tom): Try to find all the "known" relations and query on them with a filter on the etl_id.
     client = boto3.client("dynamodb")
     paginator = client.get_paginator("scan")
     response_iterator = paginator.paginate(

--- a/python/etl/names.py
+++ b/python/etl/names.py
@@ -210,7 +210,7 @@ class TableName:
         """
         return f'"{self.schema}"."{self.table}"'
 
-    def __format__(self, code):
+    def __format__(self, code) -> str:
         """
         Format name as delimited identifier (with quotes) or just as an identifier.
 
@@ -234,10 +234,9 @@ class TableName:
         """
         if (not code) or (code == "s"):
             return str(self)
-        elif code == "x":
+        if code == "x":
             return "'{:s}'".format(self.identifier)
-        else:
-            raise ValueError("unknown format code '{}' for {}".format(code, self.__class__.__name__))
+        raise ValueError(f"unknown format code '{code}' for {self.__class__.__name__}")
 
     def __eq__(self, other: object):
         if not isinstance(other, TableName):

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -114,7 +114,7 @@ class RelationDescription:
     def __repr__(self):
         return "{}({}:{})".format(self.__class__.__name__, self.identifier, self.source_path_name)
 
-    def __format__(self, code):
+    def __format__(self, code) -> str:
         r"""
         Format target table as delimited identifier (with quotes) or just as an identifier.
 
@@ -128,12 +128,11 @@ class RelationDescription:
         """
         if (not code) or (code == "s"):
             return str(self.target_table_name)
-        elif code == "x":
+        if code == "x":
             return "{:x}".format(self.target_table_name)
-        else:
-            raise ValueError("unsupported format code '{}' passed to RelationDescription".format(code))
+        raise ValueError(f"unsupported format code '{code}' passed to RelationDescription")
 
-    def load(self, callback=None) -> None:
+    def load(self, callback=None) -> "RelationDescription":
         """
         Force a loading of the table design (which is normally loaded "on demand").
 
@@ -152,6 +151,7 @@ class RelationDescription:
             )
         if callback is not None:
             callback()
+        return self
 
     @staticmethod
     def load_in_parallel(relations: Sequence["RelationDescription"]) -> None:

--- a/python/etl/relation.py
+++ b/python/etl/relation.py
@@ -638,7 +638,7 @@ def order_by_dependencies(
         _sanitize_dependencies(sortable_descriptions)
         _sort_by_dependencies(sortable_descriptions)
         # A functional approach would be to create new instances here. Instead we reach back. Shrug.
-        # TODO Sort by level first, then order.
+        # TODO(tom): Sort by level first, then order.
         for sortable in sortable_descriptions:
             sortable.original_description._execution_order = sortable.order
             sortable.original_description._execution_level = sortable.level


### PR DESCRIPTION
## Description

So far we need to go through logs of the validation to figure out which relations had issues. This PR now adds a summary at the end to make it much easier to see which relations failed validations.

This code also fixes some coding in the `__format__` calls which are leveraged now more by the logs during validation.

### User-visible Changes

If the validation fails, there's now a summary at the end instead of a "something happened while keep_going was active".

Example:
```
```

### Internal Changes

<!-- Describe what changes behind the scenes -->
Instead of capturing a single event that something failed, we now store every relation that fails during validation.

## Testing

<!-- Describe how somebody can test your changes or how they have been added to automatic tests. -->
You should try this out with a validation that fails :-) Just put a couple errors in SQL or YAML files and run the validation pipeline.

## Deploy Notes

<!-- If applicable, add migrations and deployment steps -->
