### PR TITLE
Use "repository" from "github" context to pick output image

### DIFF
--- a/.github/workflows/publish-latest-remote.yaml
+++ b/.github/workflows/publish-latest-remote.yaml
@@ -35,7 +35,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: ghcr.io/harrystech/arthur-redshift-etl/arthur-etl-remote
+        images: ghcr.io/${{ github.repository }}/arthur-etl-remote
         # Use the original tag ref, the SHA1, and versions derived from the tag.
         tags: |
           type=ref,event=tag

--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
     - next
+    - tom/update-publish-with-repo
   release:
     types:
     - published
@@ -35,7 +36,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: ghcr.io/harrystech/arthur-redshift-etl/arthur-etl
+        images: ghcr.io/${{ github.repository }}/arthur-etl
         # Use the original tag ref, the SHA1, and versions derived from the tag.
         tags: |
           type=ref,event=tag

--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -5,7 +5,6 @@ on:
     branches:
     - master
     - next
-    - tom/update-publish-with-repo
   release:
     types:
     - published


### PR DESCRIPTION
## Description

### Internal Changes

Hard-coded reference to repository is replaced with a value from the `github` context.

### User-visible Changes

None

## Links

See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

## Testing

From https://github.com/harrystech/arthur-redshift-etl/runs/8142652797?check_suite_focus=true
```
  with:
    images: ghcr.io/harrystech/arthur-redshift-etl/arthur-etl
    tags: type=ref,event=tag
  type=semver,pattern=v{{major}}.{{minor}}
  type=semver,pattern=v{{version}}
  type=sha
```

## Deploy Notes

Nothing to do here. This enables forked repos to work and publish an image.