### PR TITLE
Update the Redshift CFn template to include additional IAM roles

### DIFF
--- a/cloudformation/dw_cluster.yaml
+++ b/cloudformation/dw_cluster.yaml
@@ -74,6 +74,11 @@ Parameters:
         Type: String
         Default: ""
 
+    AdditionalClusterIAMRole6:
+        Description: (optional) ARN of an additional IAM role to associate with the Redshift cluster
+        Type: String
+        Default: ""
+
     PreferredMaintenanceWindow:
         Description: (optional) Preferred maintenance window for the Redshift cluster
         Type: String
@@ -102,6 +107,9 @@ Conditions:
     HasAdditionalRole5:
         !Not [ !Equals [ !Ref "AdditionalClusterIAMRole5", "" ] ]
 
+    HasAdditionalRole6:
+        !Not [ !Equals [ !Ref "AdditionalClusterIAMRole6", "" ] ]
+
 
 Resources:
 
@@ -121,12 +129,26 @@ Resources:
             Description: "Parameter group for Redshift cluster"
             ParameterGroupFamily: "redshift-1.0"
             Parameters:
+                - ParemeterName: "auto_analyze"
+                  ParemeterValue: "true"
+                - ParemeterName: "auto_mv"
+                  ParemeterValue: "true"
+                - ParemeterName: "datestyle	"
+                  ParemeterValue: "ISO, MDY"
                 - ParameterName: "require_ssl"
                   ParameterValue: "true"
+                - ParameterName: "enable_case_sensitive_identifier"
+                  ParameterValue: "false"
                 - ParameterName: "enable_user_activity_logging"
                   ParameterValue: "true"
+                - ParameterName: "extra_float_digits"
+                  ParameterValue: 0
+                - ParameterName: "max_concurrency_scaling_clusters"
+                  ParameterValue: 1
+                - ParameterName: "search_path"
+                  ParameterValue: "$user, public"
                 - ParameterName: "statement_timeout"
-                  ParameterValue: 7200000
+                  ParameterValue: 0
                 - ParameterName: "wlm_json_configuration"
                   ParameterValue: !Sub "[{ \"query_concurrency\": ${QueryConcurrency} }]"
             Tags:
@@ -162,6 +184,7 @@ Resources:
                 - !If [ HasAdditionalRole3, !Ref "AdditionalClusterIAMRole3", !Ref "AWS::NoValue" ]
                 - !If [ HasAdditionalRole4, !Ref "AdditionalClusterIAMRole4", !Ref "AWS::NoValue" ]
                 - !If [ HasAdditionalRole5, !Ref "AdditionalClusterIAMRole5", !Ref "AWS::NoValue" ]
+                - !If [ HasAdditionalRole6, !Ref "AdditionalClusterIAMRole6", !Ref "AWS::NoValue" ]
             MasterUsername:
                 !Ref MasterUsername
             MasterUserPassword:


### PR DESCRIPTION
## Description
We currently have evolved to need 6 additional IAM roles for the Redshift cluster, and the current template only supports 5. Add an additional role.

Also, add in more parameters to the Redshift parameter group that weren't explicitly declared before.

### User-visible Changes
None

### Internal Changes
Update to cloudformation template that defines the Redshift clusters.

## Links
https://harrys.atlassian.net/browse/DENG-2129

## Testing
Created a [change set](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/changesets/changes?stackId=arn%3Aaws%3Acloudformation%3Aus-east-1%3A367733367673%3Astack%2Fdw-cluster-dev%2F5b028cc0-a52b-11e7-87d0-50d5cad95262&changeSetId=arn%3Aaws%3Acloudformation%3Aus-east-1%3A367733367673%3AchangeSet%2FDW-2022-12-07-15-18-59%2F93f8dea0-a4f9-4463-9068-5a184e54b9fc) to verify the changes I expect are being propagated:
```
-->./do_cloudformation.sh create-change-set dw_cluster dev \
    MasterUserPassword=UsePreviousValue \
    MasterUsername=UsePreviousValue \
    NodeType=UsePreviousValue \
    PreferredMaintenanceWindow=UsePreviousValue \
    QueryConcurrency=UsePreviousValue \
    SnapshotIdentifier=UsePreviousValue \
    VpcStackName=UsePreviousValue \
AdditionalClusterIAMRole1=UsePreviousValue\
AdditionalClusterIAMRole2=UsePreviousValue\
AdditionalClusterIAMRole3=UsePreviousValue\
AdditionalClusterIAMRole4=arn:aws:iam::367733367673:role/fivetran-reshift \
AdditionalClusterIAMRole5=arn:aws:iam::367733367673:role/HarrysLakeEtlTasks \
AdditionalClusterIAMRole6=arn:aws:iam::367733367673:role/RedshiftSpectrumCrossAccount-dev \
NumberOfNodes=10
```

