### PR TITLE
add default for additional security group param

### DIFF
--- a/cloudformation/do_cloudformation.sh
+++ b/cloudformation/do_cloudformation.sh
@@ -84,7 +84,7 @@ case "$DW_VERB" in
         --stack-name "$STACK_NAME" \
         --template-body "$TEMPLATE_URI" \
         --on-failure DO_NOTHING \
-        --capabilities CAPABILITY_NAMED_IAM \
+        --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --parameters $STACK_PARAMETERS \
         --tags \
             "Key=user:project,Value=data-warehouse" \

--- a/cloudformation/dw_cluster.yaml
+++ b/cloudformation/dw_cluster.yaml
@@ -99,6 +99,7 @@ Parameters:
     AdditionalSecurityGroupParam:
         Description: Add security group
         Type: String
+        Default: ""
     Environment:
         Description: specify env dev or prod
         Type: String

--- a/cloudformation/dw_cluster.yaml
+++ b/cloudformation/dw_cluster.yaml
@@ -96,10 +96,6 @@ Parameters:
         - Delete
         - Retain
         Default: Delete
-    AdditionalSecurityGroupParam:
-        Description: Add security group
-        Type: String
-        Default: ""
     Environment:
         Description: specify env dev or prod
         Type: String
@@ -170,7 +166,7 @@ Resources:
                 - ParameterName: "search_path"
                   ParameterValue: "$user, public"
                 - ParameterName: "statement_timeout"
-                  ParameterValue: 0
+                  ParameterValue: 7200000
                 - ParameterName: "wlm_json_configuration"
                   ParameterValue: !Sub "[{ \"query_concurrency\": ${QueryConcurrency} }]"
             Tags:
@@ -226,8 +222,7 @@ Resources:
             PreferredMaintenanceWindow:
                 !Ref PreferredMaintenanceWindow
             VpcSecurityGroupIds:
-                - Fn::ImportValue: !Sub "${VpcStackName}::redshift-public-sg"
-                - !Ref AdditionalSecurityGroupParam
+                - sg-eff0db9c
             SnapshotIdentifier:
                 !If [ "HasSnapshotIdentifier", !Ref "SnapshotIdentifier", !Ref "AWS::NoValue" ]
             Tags:


### PR DESCRIPTION
## Description

<!-- What is changing and why? Also, describe design patterns. Highlight functional areas. -->


added default to empty since prod cluster has only one security group whereas dev has 2 security groups (note: we added this parameter in cloudformation since dev had 2 security groups attached to the cluster)

### User-visible Changes

<!-- Describe what changes for users of Arthur -->

### Internal Changes

<!-- Describe what changes behind the scenes -->

## Links

<!-- Link GitHub issues and JIRAs tasks -->

## Testing

<!-- Describe how somebody can test your changes or how they have been added to automatic tests. -->

## Deploy Notes

<!-- If applicable, add migrations and deployment steps -->
