### PR TITLE
DENG-2548: Bump PyYAML version to hotfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jmespath==0.10.0
 jsonschema==3.2.0
 pgpasslib==1.1.0
 psycopg2-binary==2.9.5
-PyYAML==6.0
+PyYAML==6.0.1
 simplejson==3.18.3
 tabulate==0.8.10
 termcolor==1.1.0


### PR DESCRIPTION
Bump PyYAML version to 6.0.1 hotfix that fixes pip installs. See https://github.com/yaml/pyyaml/issues/601.

Testing: Got the test from the hdw-validate job in the `harrys` repo.
Before patch:
```
-->docker run -v $(pwd):/arthur-redshift-etl harrystech/pg-python3:latest  bash -c "apk add --no-cache python3-dev; apk add --no-cache python3 postgresql-libs; apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev; cd arthur-redshift-etl; pip3 install -r requirements.txt;"
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
...
https://files.pythonhosted.org/packages/8c/45/77147700f5088efaf9235a3a62b611b594d477a5c5613b5316d0ebd18be0/psycopg2-binary-2.9.5.tar.gz (384kB)
Collecting PyYAML==6.0 (from -r requirements.txt (line 11))
  Downloading https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz (124kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/PyYAML.egg-info
    writing pip-egg-info/PyYAML.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/PyYAML.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/PyYAML.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/PyYAML.egg-info/SOURCES.txt'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-wvykadqb/PyYAML/setup.py", line 312, in <module>
        python_requires='>=3.6',
      File "/tmp/pip-build-env-0_kq_htp/lib/python3.6/site-packages/setuptools/__init__.py", line 153, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/tmp/pip-build-env-0_kq_htp/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 299, in run
        self.find_sources()
      File "/tmp/pip-build-env-0_kq_htp/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 306, in find_sources
        mm.run()
      File "/tmp/pip-build-env-0_kq_htp/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 541, in run
        self.add_defaults()
      File "/tmp/pip-build-env-0_kq_htp/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults
        sdist.add_defaults(self)
      File "/tmp/pip-build-env-0_kq_htp/lib/python3.6/site-packages/setuptools/command/py36compat.py", line 34, in add_defaults
        self._add_defaults_ext()
      File "/tmp/pip-build-env-0_kq_htp/lib/python3.6/site-packages/setuptools/command/py36compat.py", line 118, in _add_defaults_ext
        self.filelist.extend(build_ext.get_source_files())
      File "/tmp/pip-install-wvykadqb/PyYAML/setup.py", line 204, in get_source_files
        self.cython_sources(ext.sources, ext)
      File "/usr/lib/python3.6/distutils/cmd.py", line 103, in __getattr__
        raise AttributeError(attr)
    AttributeError: cython_sources
```

After patch:
```
-->docker run -v $(pwd):/arthur-redshift-etl harrystech/pg-python3:latest  bash -c "apk add --no-cache python3-dev; apk add --no-cache python3 postgresql-libs; apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev; cd arthur-redshift-etl; pip3 install -r requirements.txt;"
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
...
https://files.pythonhosted.org/packages/06/b3/24afc8868eba069a7f03650ac750a778862dc34941a4bebeb58706715726/charset_normalizer-2.0.12-py3-none-any.whl
Collecting idna<4,>=2.5; python_version >= "3" (from requests!=2.18.0,>=2.14.2->docker==5.0.3->-r requirements.txt (line 5))
  Downloading https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl (61kB)
Collecting zipp>=0.5 (from importlib-metadata; python_version < "3.8"->jsonschema==3.2.0->-r requirements.txt (line 8))
  Downloading https://files.pythonhosted.org/packages/bd/df/d4a4974a3e3957fd1c1fa3082366d7fff6e428ddb55f074bf64876f8e8ad/zipp-3.6.0-py3-none-any.whl
Installing collected packages: typing-extensions, six, python-dateutil, arrow, jmespath, urllib3, botocore, s3transfer, boto3, certifi, charset-normalizer, idna, requests, websocket-client, docker, funcy, zipp, importlib-metadata, attrs, pyrsistent, jsonschema, pgpasslib, psycopg2-binary, PyYAML, simplejson, tabulate, termcolor, importlib-resources, tqdm, watchtower
  Running setup.py install for pyrsistent: started
    Running setup.py install for pyrsistent: finished with status 'done'
  Running setup.py install for psycopg2-binary: started
    Running setup.py install for psycopg2-binary: finished with status 'done'
  Running setup.py install for PyYAML: started
    Running setup.py install for PyYAML: finished with status 'done'
  Running setup.py install for termcolor: started
    Running setup.py install for termcolor: finished with status 'done'
Successfully installed PyYAML-6.0.1 arrow-1.2.3 attrs-22.2.0 boto3-1.23.10 botocore-1.26.10 certifi-2023.5.7 charset-normalizer-2.0.12 docker-5.0.3 funcy-1.18 idna-3.4 importlib-metadata-4.8.3 importlib-resources-5.4.0 jmespath-0.10.0 jsonschema-3.2.0 pgpasslib-1.1.0 psycopg2-binary-2.9.5 pyrsistent-0.18.0 python-dateutil-2.8.2 requests-2.27.1 s3transfer-0.5.2 simplejson-3.18.3 six-1.16.0 tabulate-0.8.10 termcolor-1.1.0 tqdm-4.64.1 typing-extensions-4.1.1 urllib3-1.26.16 watchtower-3.0.0 websocket-client-1.3.1 zipp-3.6.0
You are using pip version 18.1, however version 21.3.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```