### PR TITLE
Drop assignee (personal account), fix reviewers

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,23 +1,19 @@
 version: 2
 
 updates:
-  - assignees:
-      - "thomas-vogels"
-    directory: "/"
+  - directory: "/"
     ignore:
       - dependency-name: "Sphinx"
     open-pull-requests-limit: 10
     package-ecosystem: "pip"
     reviewers:
-      - "harrystech/data-eng"
+      - "harrystech/data-platform"
     schedule:
       interval: "weekly"
 
-  - assignees:
-      - "thomas-vogels"
-    directory: "/"
+  - directory: "/"
     package-ecosystem: "github-actions"
     reviewers:
-      - "harrystech/data-eng"
+      - "harrystech/data-platform"
     schedule:
       interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,6 @@ repos:
           - "types-tabulate==0.9.0.1"
           - "types-termcolor==1.1.6.1"
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.7.2.1
+    rev: v0.9.0.5
     hooks:
       - id: shellcheck


### PR DESCRIPTION
## Description

This drops my personal account as an assignee for PRs from dependabot.
This also fixes the team name to data-platform.

And since `pre-commit` would fail otherwise, there's a version upgrade for `shellcheck`.

### User-visible Changes

None.

### Internal Changes

None.
(This affects the repo, not Arthur).

